### PR TITLE
Extracting @groups to #groups method

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# This is an RVM Project .rvmrc file, used to automatically load the ruby
+# development environment upon cd'ing into the directory
+
+# First we specify our desired <ruby>[@<gemset>], the @gemset name is optional.
+environment_id="ruby-1.9.3-p194@sufia"
+
+#
+# Uncomment following line if you want options to be set only for given project.
+#
+# PROJECT_JRUBY_OPTS=( --1.9 )
+
+#
+# First we attempt to load the desired environment directly from the environment
+# file. This is very fast and efficient compared to running through the entire
+# CLI and selector. If you want feedback on which environment was used then
+# insert the word 'use' after --create as this triggers verbose mode.
+#
+if [[ -d "${rvm_path:-$HOME/.rvm}/environments" \
+  && -s "${rvm_path:-$HOME/.rvm}/environments/$environment_id" ]]
+then
+  \. "${rvm_path:-$HOME/.rvm}/environments/$environment_id"
+
+  if [[ -s "${rvm_path:-$HOME/.rvm}/hooks/after_use" ]]
+  then
+    . "${rvm_path:-$HOME/.rvm}/hooks/after_use"
+  fi
+else
+  # If the environment file has not yet been created, use the RVM CLI to select.
+  if ! rvm --create use  "$environment_id"
+  then
+    echo "Failed to create RVM environment '${environment_id}'."
+    exit 1
+  fi
+fi
+
+#
+# If you use an RVM gemset file to install a list of gems (*.gems), you can have
+# it be automatically loaded. Uncomment the following and adjust the filename if
+# necessary.
+#
+# filename=".gems"
+# if [[ -s "$filename" ]]
+# then
+#   rvm gemset import "$filename" | grep -v already | grep -v listed | grep -v complete | sed '/^$/d'
+# fi
+
+# If you use bundler, this might be useful to you:
+if command -v bundle && [[ -s Gemfile ]]
+then
+  bundle
+fi
+
+

--- a/app/controllers/batch_controller.rb
+++ b/app/controllers/batch_controller.rb
@@ -25,11 +25,6 @@ class BatchController < ApplicationController
     @generic_file = GenericFile.new
     @generic_file.creator = current_user.name
     @generic_file.title =  @batch.generic_files.map(&:label)
-    begin
-      @groups = current_user.groups
-    rescue
-      logger.warn "Can not get to LDAP for user groups"
-    end
   end
 
   def update

--- a/app/controllers/batch_edits_controller.rb
+++ b/app/controllers/batch_edits_controller.rb
@@ -6,7 +6,6 @@ class BatchEditsController < ApplicationController
        super 
        @generic_file = GenericFile.new
        @generic_file.depositor = current_user.user_key
-       @groups = current_user.groups       
        @terms = @generic_file.editable_terms - [:title] # +:format, :resource_type 
 
        # do we want to show the original values for anything...

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,7 +44,6 @@ class UsersController < ApplicationController
   # Display form for users to edit their profile information
   def edit
     @user = current_user
-    @groups = @user.groups
     @trophies = @user.trophy_ids
   end
 

--- a/app/views/generic_files/_permission.html.erb
+++ b/app/views/generic_files/_permission.html.erb
@@ -104,8 +104,7 @@ limitations under the License.
   <div class="row control-group">
     <div id="new-group" >
       <div class="input-append">
-        <% @groups.unshift('Select a group') %>
-        <%= select_tag 'new_group_name_skel', options_for_select(@groups), :class => 'span38' %>
+        <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + groups), :class => 'span38' %>
         <%= select_tag 'new_group_permission_skel', options_for_select(Sufia::Engine.config.permission_levels), :class => 'span17' %>
         <button class="btn btn-mini btn-inverse" id="add_new_group_skel" ><i class="icon-plus-sign"></i> Add</button>
         <br /><span id="directory_group_result"></span>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -90,10 +90,8 @@ $("a[rel=popover]").popover();
   <hr />
 
   <h3><i class="icon-group"></i> User Managed Groups Info (UMG) <%= link_to 'Manage UMG', 'http://umg.its.psu.edu/', :class => 'btn btn-mini btn-primary' %> </h3>
-  <% if @groups %>
-    <% @groups.each do |g| %>
-      <i class="icon-caret-right"></i> <%= g %><br />
-    <% end %>
+  <% groups.each do |g| %>
+    <i class="icon-caret-right"></i> <%= g %><br />
   <% end %>
 </div>
 

--- a/lib/sufia/controller.rb
+++ b/lib/sufia/controller.rb
@@ -20,11 +20,16 @@ module Sufia::Controller
     include Hydra::Controller::ControllerBehavior
 
     before_filter :notifications_number
+    helper_method :groups
 
   end
 
   def current_ability
     current_user ? current_user.ability : super
+  end
+
+  def groups
+    @groups ||= current_user ? current_user.groups : []
   end
 
   def render_404(exception)

--- a/spec/fixtures/sufia/sufia_sufia1.descMeta.txt
+++ b/spec/fixtures/sufia/sufia_sufia1.descMeta.txt
@@ -1,0 +1,12 @@
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/publisher> "archivist1" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/description> "sufia test Description" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/created> "01/18/2013" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/contributor> "archivist1" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/title> "sufia test" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/relation> "test" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/subject> "sufia test Test" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/language> "En" .
+<info:fedora/sufia:sufia1> <http://xmlns.com/foaf/0.1/based_near> "State College" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/rights> "archivist1" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/creator> "archivist1" .
+<info:fedora/sufia:sufia1> <http://purl.org/dc/terms/identifier> "Test" .

--- a/spec/fixtures/sufia/sufia_sufia1.foxml.erb
+++ b/spec/fixtures/sufia/sufia_sufia1.foxml.erb
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foxml:digitalObject PID="sufia:sufia1" VERSION="1.1" xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+  <foxml:objectProperties>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="sufia test"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="fedoraAdmin"/>
+  </foxml:objectProperties>
+  <foxml:datastream CONTROL_GROUP="X" ID="DC" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      ID="DC1.0" LABEL="Dublin Core Record for this object" MIMETYPE="text/xml">
+      <foxml:xmlContent>
+        <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+          xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+          <dc:title>sufia test</dc:title>
+          <dc:identifier>sufia:sufia1</dc:identifier>
+        </oai_dc:dc>
+      </foxml:xmlContent>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="M" ID="descMetadata" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="descMetadata.0" LABEL="" MIMETYPE="text/plain">
+      <foxml:contentLocation REF="file:<%=@localDir%>/sufia/sufia_sufia1.descMeta.txt" TYPE="URL"/>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="X" ID="RELS-EXT" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="RELS-EXT.0"
+      LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml">
+      <foxml:xmlContent>
+        <rdf:RDF xmlns:ns0="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+          <rdf:Description rdf:about="info:fedora/sufia:sufia1">
+            <ns0:hasModel rdf:resource="info:fedora/afmodel:GenericFile"/>
+          </rdf:Description>
+        </rdf:RDF>
+      </foxml:xmlContent>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="M" ID="content" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="content.0" LABEL="Test Data 1"
+      MIMETYPE="text/plain" >
+      <foxml:contentLocation REF="file:<%=@localDir%>/sufia/sufia_sufia1.txt" TYPE="URL"/>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="X" ID="rightsMetadata" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion CREATED="2012-04-06T13:41:37.093Z" ID="rightsMetadata.0" LABEL="" MIMETYPE="text/xml">
+      <foxml:xmlContent>
+        <rightsMetadata version="0.1" xmlns="http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1">
+          <copyright>
+            <human/>
+            <machine>
+              <uvalicense>no</uvalicense>
+            </machine>
+          </copyright>
+          <access type="discover">
+            <human/>
+            <machine>
+                <group>public</group>
+            </machine>
+          </access>
+          <access type="read">
+            <human/>
+            <machine/>
+          </access>
+          <access type="edit">
+            <human/>
+            <machine>
+              <person>archivist1@example.com</person>
+            </machine>
+          </access>
+          <embargo>
+            <human/>
+            <machine/>
+          </embargo>
+        </rightsMetadata>
+      </foxml:xmlContent>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+</foxml:digitalObject>

--- a/spec/fixtures/sufia/sufia_sufia1.foxml.xml
+++ b/spec/fixtures/sufia/sufia_sufia1.foxml.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foxml:digitalObject PID="sufia:sufia1" VERSION="1.1" xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+  <foxml:objectProperties>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="sufia test"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="fedoraAdmin"/>
+  </foxml:objectProperties>
+  <foxml:datastream CONTROL_GROUP="X" ID="DC" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      ID="DC1.0" LABEL="Dublin Core Record for this object" MIMETYPE="text/xml">
+      <foxml:xmlContent>
+        <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+          xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+          <dc:title>sufia test</dc:title>
+          <dc:identifier>sufia:sufia1</dc:identifier>
+        </oai_dc:dc>
+      </foxml:xmlContent>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="M" ID="descMetadata" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="descMetadata.0" LABEL="" MIMETYPE="text/plain">
+      <foxml:contentLocation REF="file:/Users/jfriesen/Repositories/sufia/spec/fixtures/sufia/sufia_sufia1.descMeta.txt" TYPE="URL"/>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="X" ID="RELS-EXT" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="RELS-EXT.0"
+      LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml">
+      <foxml:xmlContent>
+        <rdf:RDF xmlns:ns0="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+          <rdf:Description rdf:about="info:fedora/sufia:sufia1">
+            <ns0:hasModel rdf:resource="info:fedora/afmodel:GenericFile"/>
+          </rdf:Description>
+        </rdf:RDF>
+      </foxml:xmlContent>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="M" ID="content" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="content.0" LABEL="Test Data 1"
+      MIMETYPE="text/plain" >
+      <foxml:contentLocation REF="file:/Users/jfriesen/Repositories/sufia/spec/fixtures/sufia/sufia_sufia1.txt" TYPE="URL"/>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="X" ID="rightsMetadata" STATE="A" VERSIONABLE="true">
+    <foxml:datastreamVersion CREATED="2012-04-06T13:41:37.093Z" ID="rightsMetadata.0" LABEL="" MIMETYPE="text/xml">
+      <foxml:xmlContent>
+        <rightsMetadata version="0.1" xmlns="http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1">
+          <copyright>
+            <human/>
+            <machine>
+              <uvalicense>no</uvalicense>
+            </machine>
+          </copyright>
+          <access type="discover">
+            <human/>
+            <machine>
+                <group>public</group>
+            </machine>
+          </access>
+          <access type="read">
+            <human/>
+            <machine/>
+          </access>
+          <access type="edit">
+            <human/>
+            <machine>
+              <person>archivist1@example.com</person>
+            </machine>
+          </access>
+          <embargo>
+            <human/>
+            <machine/>
+          </embargo>
+        </rightsMetadata>
+      </foxml:xmlContent>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+</foxml:digitalObject>

--- a/spec/fixtures/sufia/sufia_sufia1.txt
+++ b/spec/fixtures/sufia/sufia_sufia1.txt
@@ -1,0 +1,1 @@
+This is a test fixture for sufia: sufia1.


### PR DESCRIPTION
Using instance variables in views creates strong coupling with
corresponding controllers. Ideally all instance variables in the view
would be replaced with corresponding helper methods.

In doing so, we would be dramatically improving our ability to modify
views and controllers.

At present we are looking to modify the batch_edits controller to prompt
users for different forms based on a selected object type (i.e. law
journal or senior thesis or ETD). There is a larger refactoring that
would need to occur, but this is my initial attempt to fix one of the
issues that we will be having.
