### PR TITLE
Extracting @groups to #groups helper method

### DIFF
--- a/app/controllers/batch_controller.rb
+++ b/app/controllers/batch_controller.rb
@@ -25,11 +25,6 @@ class BatchController < ApplicationController
     @generic_file = GenericFile.new
     @generic_file.creator = current_user.name
     @generic_file.title =  @batch.generic_files.map(&:label)
-    begin
-      @groups = current_user.groups
-    rescue
-      logger.warn "Can not get to LDAP for user groups"
-    end
   end
 
   def update

--- a/app/controllers/batch_edits_controller.rb
+++ b/app/controllers/batch_edits_controller.rb
@@ -6,7 +6,6 @@ class BatchEditsController < ApplicationController
        super 
        @generic_file = GenericFile.new
        @generic_file.depositor = current_user.user_key
-       @groups = current_user.groups       
        @terms = @generic_file.editable_terms - [:title] # +:format, :resource_type 
 
        # do we want to show the original values for anything...

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,7 +44,6 @@ class UsersController < ApplicationController
   # Display form for users to edit their profile information
   def edit
     @user = current_user
-    @groups = @user.groups
     @trophies = @user.trophy_ids
   end
 

--- a/app/views/generic_files/_permission.html.erb
+++ b/app/views/generic_files/_permission.html.erb
@@ -104,8 +104,7 @@ limitations under the License.
   <div class="row control-group">
     <div id="new-group" >
       <div class="input-append">
-        <% @groups.unshift('Select a group') %>
-        <%= select_tag 'new_group_name_skel', options_for_select(@groups), :class => 'span38' %>
+        <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + groups), :class => 'span38' %>
         <%= select_tag 'new_group_permission_skel', options_for_select(Sufia::Engine.config.permission_levels), :class => 'span17' %>
         <button class="btn btn-mini btn-inverse" id="add_new_group_skel" ><i class="icon-plus-sign"></i> Add</button>
         <br /><span id="directory_group_result"></span>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -90,10 +90,8 @@ $("a[rel=popover]").popover();
   <hr />
 
   <h3><i class="icon-group"></i> User Managed Groups Info (UMG) <%= link_to 'Manage UMG', 'http://umg.its.psu.edu/', :class => 'btn btn-mini btn-primary' %> </h3>
-  <% if @groups %>
-    <% @groups.each do |g| %>
-      <i class="icon-caret-right"></i> <%= g %><br />
-    <% end %>
+  <% groups.each do |g| %>
+    <i class="icon-caret-right"></i> <%= g %><br />
   <% end %>
 </div>
 

--- a/lib/sufia/controller.rb
+++ b/lib/sufia/controller.rb
@@ -20,11 +20,16 @@ module Sufia::Controller
     include Hydra::Controller::ControllerBehavior
 
     before_filter :notifications_number
+    helper_method :groups
 
   end
 
   def current_ability
     current_user ? current_user.ability : super
+  end
+
+  def groups
+    @groups ||= current_user ? current_user.groups : []
   end
 
   def render_404(exception)


### PR DESCRIPTION
Using instance variables in views creates strong coupling with
corresponding controllers. Ideally all instance variables in the view
would be replaced with corresponding helper methods.

In doing so, we would be dramatically improving our ability to modify
views and controllers.

At present we are looking to modify the batch_edits controller to prompt
users for different forms based on a selected object type (i.e. law
journal or senior thesis or ETD). There is a larger refactoring that
would need to occur, but this is my initial attempt to fix one of the
issues that we will be having.
