### PR TITLE
Updating file extraction for files#create action

### DIFF
--- a/lib/sufia/files_controller_behavior.rb
+++ b/lib/sufia/files_controller_behavior.rb
@@ -78,7 +78,12 @@ module Sufia
         # check error condition No files
         return render(:json => [{:error => "Error! No file to save"}].to_json) if !params.has_key?(:files)
 
-        file = params[:files].first
+        file = params[:files].detect {|f| f.respond_to?(:original_filename) }
+        if !file
+          render :json => [{:name => 'unknown file', :error => "Error! No file for upload"}], :status => :unprocessable_entity
+          return false
+        end
+
         # check error condition empty file
         if ((file.respond_to?(:tempfile)) && (file.tempfile.size == 0))
            retval = render :json => [{ :name => file.original_filename, :error => "Error! Zero Length File!"}].to_json

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -37,6 +37,13 @@ describe GenericFilesController do
       @mock.delete unless @mock.inner_object.class == ActiveFedora::UnsavedDigitalObject 
     end
 
+    it "should render error the file wasn't actually a file" do
+      file = 'hello'
+      xhr :post, :create, :files=>[file], :Filename=>"The World", :batch_id=>'sample:batch_id', :permission=>{"group"=>{"public"=>"read"} }, :terms_of_service => '1'
+      response.status.should == 422
+      JSON.parse(response.body).first['error'].should match(/no file for upload/i)
+    end
+
     it "should spawn a content deposit event job" do
       file = fixture_file_upload('/world.png','image/png')
       s1 = stub('one')


### PR DESCRIPTION
When updating to Hydra 5.3 for Sufia, I noticed our installation was
sending the following params:

```
  {:files => ["","", <Actual File Object>]}
```

instead of the expected:

```
  {:files => [<Actual File Object>]}
```

I've updated how the file is extracted from the params[:file]. I have
also added the :unprocessable_entity status as that is a more customary
HTTP status on failure (for javascript requests sending 200 status when
there is an error may confuse the javascript client listening to the
request)

What I have been able to determine is that the `input[name="files[]"]`
element of `./app/views/generic_files/_multiple_upload.html.erb` are
being captured as part of the form serialization and posting.

I was working in Chrome, and the "Select Folder..." option was visible.
When I would click upload, I would get:

```
{:files => ["","", <Actual File Object>]}
```

If I removed the conditional logic for Chrome, and didn't render the
second `input[name="files[]"]` for directories, I ended up POSTing the
following:

```
{:files => ["", <Actual File Object>]}
```

I tried simply renaming those elements to my_files[], but then the
uploader failed, as it was using the name property to build the form
for submission.
