### PR TITLE
Change date format in fixture stub file

### DIFF
--- a/spec/fixtures/sufia_generic_stub.descMeta.txt
+++ b/spec/fixtures/sufia_generic_stub.descMeta.txt
@@ -1,6 +1,6 @@
 <info:fedora/sufia:<%= @id %>> <http://purl.org/dc/terms/publisher> "<%= @user %>" .
 <info:fedora/sufia:<%= @id %>> <http://purl.org/dc/terms/description> "<%= @title %> Description" .
-<info:fedora/sufia:<%= @id %>> <http://purl.org/dc/terms/created> "<%= Time.now.strftime("%m/%d/%Y") %>" .
+<info:fedora/sufia:<%= @id %>> <http://purl.org/dc/terms/created> "<%= Time.now.ctime %>" .
 <info:fedora/sufia:<%= @id %>> <http://purl.org/dc/terms/contributor> "<%= @user %>" .
 <info:fedora/sufia:<%= @id %>> <http://purl.org/dc/terms/title> "<%= @title %>" .
 <info:fedora/sufia:<%= @id %>> <http://purl.org/dc/terms/relation> "test" .


### PR DESCRIPTION
The old format was giving parse errors when running `rake fixtures` because my computer thought the date format was dd/mm/yyyy instead of mm/dd/yyyy. This way fixes the problem but using the c time format.
