### PR TITLE
Replacing jQuery.live() with jQuery.on()

### DIFF
--- a/app/assets/javascripts/sufia.js
+++ b/app/assets/javascripts/sufia.js
@@ -68,7 +68,7 @@ $(function() {
   setInterval(notify_update_link, 30*1000);
 
   // bootstrap alerts are closed this function
-  $('.alert .close').live('click',function(){
+  $(document).on('click', '.alert .close' , function(){
     $(this).parent().hide();
   });
 

--- a/vendor/assets/javascripts/fileupload/application.js
+++ b/vendor/assets/javascripts/fileupload/application.js
@@ -176,7 +176,7 @@ $(function () {
 
     // Open download dialogs via iframes,
     // to prevent aborting current uploads:
-    $('#fileupload .files a:not([target^=_blank])').live('click', function (e) {
+    $(document).on('click', '#fileupload .files a:not([target^=_blank])', function (e) {
         e.preventDefault();
         $('<iframe style="display:none;"></iframe>')
             .prop('src', this.href)


### PR DESCRIPTION
As per http://api.jquery.com/live/, .live() has been removed as of 1.9,
below is the relevant code from the above link.

```
Rewriting the .live() method in terms of its successors is
straightforward; these are templates for equivalent calls for all three
event attachment methods:

$(selector).live(events, data, handler);                // jQuery 1.3+
$(document).delegate(selector, events, data, handler);  // jQuery 1.4.3+
$(document).on(events, selector, data, handler);        // jQuery 1.7+
```
