### PR TITLE
Allowing for values that are not arrays while showing metadata

### DIFF
--- a/app/views/single_use_link/show.html.erb
+++ b/app/views/single_use_link/show.html.erb
@@ -10,7 +10,7 @@
       <table class="table table-striped"><!-- class="verticalheadings"> -->
       <tbody>
       <% @terms.each do |term| %>
-        <% vals =  @generic_file.send(term) %>
+        <% vals =  Array( @generic_file.send(term)) %>
             <tr id='row_<%=term.to_s%>' class="expandable">
               <th width="20%">
                 <%=get_label(term)%>


### PR DESCRIPTION
The sigle use link show page is not displaying due to values that are not arrays.
