### PR TITLE
Until we have a new release of HH, this gets sufia's specs passing

### DIFF
--- a/spec/support/Gemfile
+++ b/spec/support/Gemfile
@@ -6,7 +6,7 @@ gem 'sqlite3'
 
 gem 'devise' #BL adds this later, so check to see if we can remove this
 gem 'blacklight'
-gem "hydra-head"
+gem 'hydra-head', github: 'projecthydra/hydra-head'
 
 gem 'sufia', :path=>'../../'
 gem 'rspec-rails', :group=>:test


### PR DESCRIPTION
Currently we get two authZ-related failures in the batch controller spec because can? edit is always coming back true.

I suspect this is because we need this patch:

https://github.com/projecthydra/hydra-head/commit/8227e986ec004ac1c0282979b58267c0ff68162e
