### PR TITLE
sufia should use HH 5.4 and Rails 3.2.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 # Please see sufia.gemspec for dependency information.
 gemspec
 
-gem 'hydra-head', github: 'projecthydra/hydra-head'
+gem 'hydra-head'
 #gem 'mail_form', :git => 'git://github.com/psu-stewardship/mail_form.git', :ref => '50c00f0'
 group :development, :test do
   gem 'sqlite3'

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Sufia::VERSION
 
-  gem.add_dependency 'rails', '~> 3.2.8'
+  gem.add_dependency 'rails', '~> 3.2.11'
   gem.add_dependency 'blacklight', '~> 4.0.0'
   gem.add_dependency 'blacklight_advanced_search'
-  gem.add_dependency "hydra-head", ">= 5.3"
+  gem.add_dependency "hydra-head", ">= 5.4"
   gem.add_dependency "active-fedora", ">= 5.5"
 
   gem.add_dependency 'noid', '0.5.5'


### PR DESCRIPTION
HH 5.4 brings a patch that makes authZ work again, and Rails 3.2.11 contains multiple security patches over 3.2.8 as a baseline.
