### PR TITLE
New versions throw an error in the UI on GF edit

### DIFF
--- a/lib/sufia/files_controller_behavior.rb
+++ b/lib/sufia/files_controller_behavior.rb
@@ -164,7 +164,12 @@ module Sufia
         Sufia.queue.push(ContentNewVersionEventJob.new(@generic_file.pid, current_user.user_key))
       end
 
-      update_metadata
+      # only update metadata if there is a generic_file object which is not the case for version updates
+      update_metadata if params[:generic_file]
+
+      #always save the file so the new version or metadata gets recorded
+      @generic_file.save!
+      
 
       # do not trigger an update event if a version event has already been triggered
       Sufia.queue.push(ContentUpdateEventJob.new(@generic_file.pid, current_user.user_key)) unless version_event
@@ -186,7 +191,6 @@ module Sufia
       @generic_file.attributes = valid_attributes
       @generic_file.set_visibility(params[:visibility])
       @generic_file.date_modified = DateTime.now
-      @generic_file.save!
     end
 
 

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -286,7 +286,7 @@ describe GenericFilesController do
       CharacterizeJob.should_receive(:new).with(@generic_file.pid).and_return(s2)
       Sufia.queue.should_receive(:push).with(s2).once
       file = fixture_file_upload('/image.jp2','image/jp2')
-      post :update, :id=>@generic_file.pid, :filedata=>file, :Filename=>"The world", :generic_file=>{:tag=>[''] }
+      post :update, :id=>@generic_file.pid, :filedata=>file, :Filename=>"The world"
 
       edited_file = GenericFile.find(@generic_file.pid)
       version2 = edited_file.content.latest_version
@@ -304,7 +304,7 @@ describe GenericFilesController do
       s2 = stub('one')
       CharacterizeJob.should_receive(:new).with(@generic_file.pid).and_return(s2)
       Sufia.queue.should_receive(:push).with(s2).once
-      post :update, :id=>@generic_file.pid, :revision=>'content.0', :generic_file=>{:tag=>['']}
+      post :update, :id=>@generic_file.pid, :revision=>'content.0'
 
       restored_file = GenericFile.find(@generic_file.pid)
       version3 = restored_file.content.latest_version


### PR DESCRIPTION
Fixing the version tests so they work more simmilar to the UI.  Fixing the code to work with the UI and not throw an error when updating versions.
