### PR TITLE
Pinning to versions that work with hydra 5.4 

### DIFF
--- a/spec/support/Gemfile
+++ b/spec/support/Gemfile
@@ -6,7 +6,8 @@ gem 'sqlite3'
 
 gem 'devise' #BL adds this later, so check to see if we can remove this
 gem 'blacklight'
-gem "hydra-head"
+gem "hydra-head", "5.4.0"
+gem "solrizer", "2.1.0"
 
 gem 'sufia', :path=>'../../'
 gem 'rspec-rails', :group=>:test

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "hydra-head", ">= 5.4"
   gem.add_dependency "active-fedora", ">= 5.5"
 
-  gem.add_dependency 'noid', '0.5.5'
+  gem.add_dependency 'noid', '~> 0.6.6'
   gem.add_dependency 'hydra-batch-edit', '~> 0.1.0'
 
 # Other components


### PR DESCRIPTION
When we run rake clean  & rake spec  we do not want a mingling of HH6 and HH5, but since hydra-head and solorizer are not pinned to a version they are getting the latest, which casues the spec tests to fail.
