### PR TITLE
Resolrize job should not depend on solrizer-fedora

### DIFF
--- a/lib/sufia/jobs/resolrize_job.rb
+++ b/lib/sufia/jobs/resolrize_job.rb
@@ -18,6 +18,6 @@ class ResolrizeJob
   end
 
   def run
-    Solrizer::Fedora::Solrizer.new.solrize_objects(:suppress_errors => false)
+    ActiveFedora::Base.reindex_everything
   end
 end

--- a/tasks/sufia.rake
+++ b/tasks/sufia.rake
@@ -103,7 +103,7 @@ namespace :sufia do
 
   desc "Re-solrize all objects"
   task :resolrize => :environment do
-    Resque.enqueue(ResolrizeJob)
+    Sufia.queue.push(ResolrizeJob.new)
   end
 
   namespace :export do


### PR DESCRIPTION
And invocation was using old `Resque.enqueue` form rather than the new `Sufia.queue.push` form.
