### PR TITLE
Mock and work around FITS when running specs in travis-ci

### DIFF
--- a/spec/models/characterize_job_spec.rb
+++ b/spec/models/characterize_job_spec.rb
@@ -21,6 +21,10 @@ describe CharacterizeJob do
     end
     it "should create a transcode job" do
       job = stub("stub video job")
+      if $in_travis
+        @generic_file.stub(:video?).and_return(true)
+        GenericFile.should_receive(:find).with(@generic_file.id).and_return(@generic_file)
+      end
       TranscodeVideoJob.should_receive(:new).with(@generic_file.id, 'content').and_return(job)
       Sufia.queue.should_receive(:push).with(job)
       subject.run
@@ -39,6 +43,10 @@ describe CharacterizeJob do
     end
     it "should create a transcode job" do
       job = stub("stub audio job")
+      if $in_travis
+        @generic_file.stub(:audio?).and_return(true)
+        GenericFile.should_receive(:find).with(@generic_file.id).and_return(@generic_file)
+      end
       TranscodeAudioJob.should_receive(:new).with(@generic_file.id, 'content').and_return(job)
       Sufia.queue.should_receive(:push).with(job)
       subject.run
@@ -54,6 +62,10 @@ describe CharacterizeJob do
     it "should create a transcode job. (we'd like ogg too)" do
       # TODO just copy the 'content' datastream to the mp3 datastream if it's an mp3, and then transcode to ogg
       job = stub("stub audio job")
+      if $in_travis
+        @generic_file.stub(:audio?).and_return(true)
+        GenericFile.should_receive(:find).with(@generic_file.id).and_return(@generic_file)
+      end
       TranscodeAudioJob.should_receive(:new).with(@generic_file.id, 'content').and_return(job)
       Sufia.queue.should_receive(:push).with(job)
       subject.run

--- a/spec/models/file_content_datastream_spec.rb
+++ b/spec/models/file_content_datastream_spec.rb
@@ -71,7 +71,7 @@ describe FileContentDatastream do
     it "should have the path" do
       @subject.send(:fits_path).should be_present
     end
-    it "should return an xml document" do
+    it "should return an xml document", :unless => $in_travis do
       repo = mock("repo")
       repo.stub(:config=>{})
       f = File.new(fixture_path + '/world.png')
@@ -83,7 +83,7 @@ describe FileContentDatastream do
       doc = Nokogiri::XML.parse(xml)
       doc.root.xpath('//ns:imageWidth/text()', {'ns'=>'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}).inner_text.should == '50'
     end
-    it "should return expected results when invoked via HTTP" do
+    it "should return expected results when invoked via HTTP", :unless => $in_travis do
       repo = mock("repo")
       repo.stub(:config=>{})
       f = ActionDispatch::Http::UploadedFile.new(:tempfile => File.new(fixture_path + '/world.png'),

--- a/spec/models/fits_datastream_spec.rb
+++ b/spec/models/fits_datastream_spec.rb
@@ -14,7 +14,7 @@
 
 require 'spec_helper'
 
-describe FitsDatastream do
+describe FitsDatastream, :unless => $in_travis do
   before(:all) do
     @file = GenericFile.new
     @file.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content')

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -533,7 +533,7 @@ describe GenericFile do
     end
   end
   describe "characterize" do
-    it "should return expected results when called" do
+    it "should return expected results when called", :unless => $in_travis do
       @file.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content')
       @file.characterize
       doc = Nokogiri::XML.parse(@file.characterization.content)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,21 @@ if ENV['COVERAGE']
   SimpleCov.command_name "spec"
 end
 
+$in_travis = !ENV['TRAVIS'].nil? && ENV['TRAVIS'] == 'true'
+
+if $in_travis
+  # Monkey-patches the FITS runner to return the PDF FITS fixture
+  module Sufia
+    module FileContent
+      module ExtractMetadata
+        def run_fits!(path)
+          File.open(File.join(File.expand_path('../fixtures', __FILE__), 'pdf_fits.xml')).read
+        end
+      end
+    end
+  end
+end
+
 Resque.inline = Rails.env.test?
 
 FactoryGirl.definition_file_paths = [File.expand_path("../factories", __FILE__)]


### PR DESCRIPTION
Three different strategies in place here:
1. First, in `spec_helper.rb`, if we're running in the travis-ci environment then set the `$in_travis` global variable to true;
2. Then, if `$in_travis` is true, monkey-patch the `Sufia::FileContent::ExtractMetadata.run_fits!` method to return a FITS XML fixture for the bits of code that depend upon this method doing something FITS-like;
3. Next, use the `:unless => $in_travis` conditional to completely skip specs that are just for testing FITS;
4. Finally, in specs where the dummy FITS XML above causes problems, do some creative stubbing to work around that.

Is this too evil?
