### PR TITLE
Updated to use the new after hook in hydra-batch-edit 

### DIFF
--- a/app/assets/javascripts/sufia/batch_select_all.js
+++ b/app/assets/javascripts/sufia/batch_select_all.js
@@ -167,10 +167,13 @@ $(document).ready(function() {
       }
     });
   
-    // hide or show the batch update buttons file selections
-    $(".batch_toggle").bind('click', function(e) {
+});
+
+  // hide or show the batch update buttons file selections
+  function setup_buttontoggle(checkbox) {
+    checkbox.bind('click', function(e) {
          e.preventDefault();
          toggleButtons();
-     });
-});
+     });  
+  }
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -73,8 +73,8 @@ limitations under the License.
   window.document_list_count = <%= @document_list.count %>;
   toggleButtons(<%= !@empty_batch %>);
       
-
-  $('#documents').batchEdit();
+  // initialize hydra batch edit and set up select all button toggle after checkboxes have been created 
+  $('#documents').batchEdit({afterCheckboxUpdate: setup_buttontoggle});
 
 
  <% end %>

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "hydra-head", "~> 6.0"
 
   gem.add_dependency 'noid', '~> 0.6.6'
-  gem.add_dependency 'hydra-batch-edit', '~> 0.1'
+  gem.add_dependency 'hydra-batch-edit', '~> 0.3'
 
   gem.add_dependency 'resque', '~> 1.23.0'#, :require => 'resque/server'
   gem.add_dependency 'resque-pool', '0.3.0'


### PR DESCRIPTION
This removes the raise condition where the bind is being done before the check boxes exist so that button toggles can be done on checkbox click
