### PR TITLE
Changes to create a new error message for single-use-link errors 

### DIFF
--- a/app/controllers/single_use_link_controller.rb
+++ b/app/controllers/single_use_link_controller.rb
@@ -1,7 +1,10 @@
+require 'sufia/single_use_error'
+
 class SingleUseLinkController < DownloadsController
   before_filter :authenticate_user!, :except => [:show, :download]
   skip_filter :normalize_identifier
   prepend_before_filter :normalize_identifier, :except => [:download, :show]
+  rescue_from Sufia::SingleUseError, :with => :render_single_use_error
   
   def generate_download
     @generic_file = GenericFile.find(params[:id])
@@ -76,11 +79,12 @@ class SingleUseLinkController < DownloadsController
     
     return link
   end
-  
-  def not_found 
-    raise ActionController::RoutingError.new('Not Found') 
-  end 
-  def expired 
-    raise ActionController::RoutingError.new('expired') 
-  end 
+ 
+  def not_found
+    raise Sufia::SingleUseError.new('Single Use Link Not Found')
+  end
+  def expired
+    raise Sufia::SingleUseError.new('Single Use Link Expired')
+  end
+ 
 end

--- a/app/views/error/single_use_error.html.erb
+++ b/app/views/error/single_use_error.html.erb
@@ -1,0 +1,35 @@
+<%#
+Copyright © 2012 The Pennsylvania State University
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+%>
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Single use link Not Found</title>
+  </head>
+  <body>
+    <div class="columns two-a">
+      <div class="column second">
+        <h1>Single Use Link Expired or Not Found</h1>
+        <p>
+          <%= t('sufia.product_name') %> could not locate the single use link.            
+          This link either expired or had been used previously.  We apologize
+          for the inconvenience. You might be interested in using
+          <a href="/help/">the help page</a> for looking up
+          solutions.
+        </p>
+      </div>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,10 @@ Sufia::Engine.routes.draw do
   # Static page routes (workaround)
   match ':action' => 'static#:action', :constraints => { :action => /about|help|terms|zotero|mendeley|agreement|subject_libraries|versions/ }, :as => :static
 
+  #Single use link errors
+  match 'single_use_link/not_found' => 'errors#single_use_error'
+  match 'single_use_link/expired' => 'errors#single_use_error'
+
   # Catch-all (for routing errors)
   match '*error' => 'errors#routing'
   

--- a/lib/sufia/controller.rb
+++ b/lib/sufia/controller.rb
@@ -42,6 +42,10 @@ module Sufia::Controller
     render :template => '/error/500', :layout => "error", :formats => [:html], :status => 500
   end
 
+  def render_single_use_error(exception)
+    logger.error("Rendering PAGE due to exception: #{exception.inspect} - #{exception.backtrace if exception.respond_to? :backtrace}")
+    render :template => '/error/single_use_error', :layout => "error", :formats => [:html], :status => 404
+  end
 
   def notifications_number
     @notify_number=0

--- a/lib/sufia/single_use_error.rb
+++ b/lib/sufia/single_use_error.rb
@@ -1,0 +1,4 @@
+module Sufia 
+  class SingleUseError < StandardError; end
+end
+


### PR DESCRIPTION
Previously, this resulted in a 404 error.  It now has a more descriptive error message specific to single use link errors.
