### PR TITLE
Updated the download controller to use load_instance_from_solr for speed

### DIFF
--- a/lib/sufia/downloads_controller_behavior.rb
+++ b/lib/sufia/downloads_controller_behavior.rb
@@ -26,7 +26,7 @@ module Sufia
     
     def show
       if can? :read, params["id"]
-        asset = ActiveFedora::Base.find(params[:id], :cast=>true)
+        asset = ActiveFedora::Base.load_instance_from_solr(params[:id])
         # we can now examine @asset and determine if we should send_content, or some other action.
         send_content (asset)
       else 


### PR DESCRIPTION
Squashed commit of https://github.com/projecthydra/sufia/pull/85

We recently implemented a similar downloads controller that we used for thumbnails (similar to you folks), and found that we got the same functionality at a significantly quicker pace (2-4x) if we hit up solr rather than ActiveFedora::Find. Thought I'd share. Seems to pass all your tests, but you'd know best if this'd affect you in any undue way.
