### PR TITLE
Trophy ids coming from the profile page no longer have the suffix 

### DIFF
--- a/app/controllers/concerns/sufia/users_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/users_controller_behavior.rb
@@ -55,7 +55,7 @@ module Sufia::UsersControllerBehavior
     delete_trophy = params.keys.reject{|k,v|k.slice(0,'remove_trophy'.length)!='remove_trophy'}
     delete_trophy = delete_trophy.map{|v| v.slice('remove_trophy_'.length..-1)}
     delete_trophy.each do | smash_trophy |
-      Trophy.where(user_id: current_user.id, generic_file_id: smash_trophy.slice("#{Sufia::Engine.config.id_namespace}:".length..-1)).each.map(&:delete)
+      Trophy.where(user_id: current_user.id, generic_file_id: smash_trophy).each.map(&:delete)
     end
     Sufia.queue.push(UserEditProfileEventJob.new(@user.user_key))
     redirect_to sufia.profile_path(URI.escape(@user.to_s,'@.')), notice: "Your profile has been updated"

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -139,6 +139,19 @@ describe UsersController do
       u.facebook_handle.should == 'face'
       u.googleplus_handle.should == 'goo'
     end
+    it "should remove a trophy" do
+      f = GenericFile.create(title:"myFile")
+      f.apply_depositor_metadata(@user.user_key)
+      f.save
+      file_id = f.pid.split(":").last
+      Trophy.create(:generic_file_id => file_id, :user_id => @user.id)
+      @user.trophy_ids.length.should == 1
+      post :update, uid: @user.user_key,  'remove_trophy_'+file_id=> 'yes' 
+      response.should redirect_to(@routes.url_helpers.profile_path(URI.escape(@user.user_key,'@.')))
+      flash[:notice].should include("Your profile has been updated")
+      @user.trophy_ids.length.should == 0
+      f.destroy 
+    end
   end
   describe "#follow" do
     after(:all) do


### PR DESCRIPTION
trying to remove it breaks the remove trophy action and does not remove the trophy.
