### PR TITLE
Replacing Helper#display_title with Model#to_s

### DIFF
--- a/app/helpers/generic_file_helper.rb
+++ b/app/helpers/generic_file_helper.rb
@@ -15,10 +15,7 @@
 
 module GenericFileHelper
   def display_title(gf)
-    title =  gf.title.join(' | ')
-    title = gf.label if title.blank?
-    title = 'No Title' if title.blank?
-    title
+    gf.to_s
   end
 
   def add_field (key)

--- a/app/views/generic_files/_asset_permissions_denial_flash.html.erb
+++ b/app/views/generic_files/_asset_permissions_denial_flash.html.erb
@@ -16,7 +16,7 @@ limitations under the License.
 
 The file(s)
 <% generic_files.first(20).each  do |gf|%>
-<%= link_to(display_title(gf), generic_file_url(gf.noid)) %><%= ',' unless gf == generic_files.last %>
+<%= link_to(gf, generic_file_url(gf.noid)) %><%= ',' unless gf == generic_files.last %>
 <% end %>
 <%= '...' if generic_files.length > 20 %>
  could not be updated.  You do not have sufficient privileges to edit it.

--- a/app/views/generic_files/_asset_saved_flash.html.erb
+++ b/app/views/generic_files/_asset_saved_flash.html.erb
@@ -16,7 +16,7 @@ limitations under the License.
 
 The file(s)
 <% generic_files.first(20).each do |gf|%>
-<%= link_to(display_title(gf), generic_file_url(gf.noid)) %><%= ',' unless gf == generic_files.last %>
+<%= link_to(gf, generic_file_url(gf.noid)) %><%= ',' unless gf == generic_files.last %>
 <% end %>
 <%= '...' if generic_files.length > 20 %>
 have been saved.

--- a/app/views/generic_files/_asset_updated_flash.html.erb
+++ b/app/views/generic_files/_asset_updated_flash.html.erb
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 %>
 
-The file <%= link_to(display_title(generic_file), sufia.generic_file_url(generic_file.noid)) %> has been updated.
+The file <%= link_to(generic_file, sufia.generic_file_url(generic_file.noid)) %> has been updated.

--- a/app/views/generic_files/edit.html.erb
+++ b/app/views/generic_files/edit.html.erb
@@ -43,7 +43,7 @@ $("a[rel=popover]").popover({ html: true });
 
 <%= render :partial => 'breadcrumbs' %>
 
-<h1 class="lower">Edit <%= display_title(@generic_file) %></h1>
+<h1 class="lower">Edit <%= @generic_file %></h1>
 
 <div class="row">
   <div class="span40">

--- a/app/views/generic_files/show.html.erb
+++ b/app/views/generic_files/show.html.erb
@@ -28,7 +28,7 @@ limitations under the License.
 
 <%= render :partial => 'generic_files/breadcrumbs' %>
 
-<h1 class="lower"><%= display_title(@generic_file) %></h1>
+<h1 class="lower"><%= @generic_file %></h1>
 
 <div class="row">
   <div class="span40">

--- a/app/views/single_use_link/generate_download.html.erb
+++ b/app/views/single_use_link/generate_download.html.erb
@@ -1,3 +1,3 @@
 <h1>Single Use Link</h1>
 <p>Anyone can use the following link once to download the file</p>
-<%= link_to display_title(@generic_file), @link %> <%= link_to raw('<i class="icon-link icon-large"></i>'), '#', :class => 'copypaste itemicon itemcode', :title => 'Copy File URL', :id => "copy_link_#{@generic_file.pid}" %>
+<%= link_to @generic_file, @link %> <%= link_to raw('<i class="icon-link icon-large"></i>'), '#', :class => 'copypaste itemicon itemcode', :title => 'Copy File URL', :id => "copy_link_#{@generic_file.pid}" %>

--- a/app/views/single_use_link/generate_show.html.erb
+++ b/app/views/single_use_link/generate_show.html.erb
@@ -1,3 +1,3 @@
 <h1>Single Use Link</h1>
 <p>Anyone can use the following link once to view the file metadata</p>
-<%= link_to display_title(@generic_file), @link %>
+<%= link_to @generic_file, @link %>

--- a/app/views/single_use_link/show.html.erb
+++ b/app/views/single_use_link/show.html.erb
@@ -1,5 +1,5 @@
 <div >
-  <h1 class="lower"><%= display_title(@generic_file) %></h1>
+  <h1 class="lower"><%= @generic_file %></h1>
     <h2 class="non lower">Actions</h2>
     <p>
       <%= link_to "Download (can only be used once)", @download_link %>

--- a/app/views/users/_trophy_edit.html.erb
+++ b/app/views/users/_trophy_edit.html.erb
@@ -7,7 +7,7 @@
     <% trophies.each do |t| %>
       <dd>
         <div class="controls">
-          <%= link_to display_title(t), sufia.generic_file_path(t) %>
+          <%= link_to t, sufia.generic_file_path(t) %>
           <label class="checkbox fleft">
             <%= check_box_tag "remove_trophy_#{t.id}" %> Yes &nbsp;
           </label>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -40,7 +40,7 @@ limitations under the License.
       <dd><%= link_to_field('depositor', @user.to_s, GenericFile.where(:depositor => @user.to_s).count) %></dd>
       <dt><i class="icon-trophy trophy-on" ></i> Highlighted Files</dt>
       <% @trophies.each do |t| %>
-        <dd> <%= link_to display_title(t), sufia.generic_file_path(t) %></dd>
+        <dd> <%= link_to t, sufia.generic_file_path(t) %></dd>
       <% end %>
     </dl>
 

--- a/lib/sufia/batch_edits_controller_behavior.rb
+++ b/lib/sufia/batch_edits_controller_behavior.rb
@@ -22,7 +22,7 @@ module Sufia
             h[key] ||= []
             h[key] = (h[key] + gf.send(key)).uniq
           end
-          @names << display_title(gf)
+          @names << gf.to_s
           permissions = (permissions + gf.permissions).uniq
        end
 

--- a/lib/sufia/jobs/batch_update_job.rb
+++ b/lib/sufia/jobs/batch_update_job.rb
@@ -14,7 +14,6 @@
 
 class BatchUpdateJob
   include Hydra::PermissionsQuery
-  include GenericFileHelper
   include Rails.application.routes.url_helpers 
 
   def queue_name
@@ -79,7 +78,7 @@ class BatchUpdateJob
   end
   
   def file_list ( files)
-    return files.map {|gf| '<a href="'+Sufia::Engine.routes.url_helpers.generic_files_path+'/'+gf.noid+'">'+display_title(gf)+'</a>'}.join(', ')
+    return files.map {|gf| '<a href="'+Sufia::Engine.routes.url_helpers.generic_files_path+'/'+gf.noid+'">'+gf.to_s+'</a>'}.join(', ')
     
   end
   

--- a/lib/sufia/model_methods.rb
+++ b/lib/sufia/model_methods.rb
@@ -35,5 +35,11 @@ module Sufia
 
       return true
     end
+
+    def to_s
+      return Array(title).join(" | ") if title.present?
+      label || "No Title"
+    end
+
   end
 end

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -20,6 +20,25 @@ describe GenericFile do
     @file = subject #TODO remove this line someday (use subject instead)
   end
 
+  describe '#to_s' do
+    it 'uses the provided titles' do
+      subject.title = ["Hello", "World"]
+      expect(subject.to_s).to eq("Hello | World")
+    end
+
+    it 'falls back on label if no titles are given' do
+      subject.title = []
+      subject.label = 'Spam'
+      expect(subject.to_s).to eq("Spam")
+    end
+
+    it 'with no label or titles it is "No Title"' do
+      subject.title = []
+      subject.label = nil
+      expect(subject.to_s).to eq("No Title")
+    end
+  end
+
   describe "terms_for_editing" do
     it "should return a list" do
       @file.terms_for_editing.should == [ :contributor, :creator, :title, :description, :publisher,


### PR DESCRIPTION
By using #to_s we can consistently render an object in any context,
instead of sending it through a transformation function. This also means
that the "display_title" for an object can be accessed in any context.
