### PR TITLE
Allow minter statefile to be configured by the application

### DIFF
--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -32,6 +32,7 @@ module Sufia
     config.ffmpeg_path = 'ffmpeg'
     config.fits_message_length = 5
     config.temp_file_base = nil
+    config.minter_statefile = '/tmp/minter-state'
     config.id_namespace = "sufia"
     config.fits_path = "fits.sh"
     config.enable_contact_form_delivery = false

--- a/lib/sufia/id_service.rb
+++ b/lib/sufia/id_service.rb
@@ -38,20 +38,19 @@ module Sufia
 
     def self.next_id
       pid = ''
-      File.open("tmp/minter-state", File::RDWR|File::CREAT, 0644) {|f|
+      File.open(Sufia::Engine.config.minter_statefile, File::RDWR|File::CREAT, 0644) do |f|
         f.flock(File::LOCK_EX)
         yaml = YAML::load(f.read)
         yaml = {:template => '.reeddeeddk'} unless yaml
         minter = ::Noid::Minter.new(yaml)
-        pid =  "#{@namespace}:#{minter.mint}"
+        pid = "#{@namespace}:#{minter.mint}"
         f.rewind
         yaml = YAML::dump(minter.dump)
         f.write yaml
         f.flush
         f.truncate(f.pos)
-      }
+      end
       return pid
     end
-    
   end
 end


### PR DESCRIPTION
Don't hard-code the location of the id minter's state file.  Set a reasonable default in /tmp.
