### PR TITLE
Extracting noid template to configurable

### DIFF
--- a/lib/generators/sufia/templates/config/sufia.rb
+++ b/lib/generators/sufia/templates/config/sufia.rb
@@ -6,6 +6,9 @@ Sufia.config do |config|
       :file_author => :creator
     }
 
+  # Specify a different template for your repositories unique identifiers
+  # config.noid_template = ".reeddeeddk"
+
   config.max_days_between_audits = 7
 
       config.cc_licenses = {

--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -29,6 +29,7 @@ module Sufia
     # Set some configuration defaults
     config.queue = Sufia::Resque::Queue
     config.enable_ffmpeg = false
+    config.noid_template = '.reeddeeddk'
     config.ffmpeg_path = 'ffmpeg'
     config.fits_message_length = 5
     config.temp_file_base = nil

--- a/lib/sufia/id_service.rb
+++ b/lib/sufia/id_service.rb
@@ -16,7 +16,12 @@ require 'noid'
 
 module Sufia
   module IdService
-    @minter = ::Noid::Minter.new(:template => '.reeddeeddk')
+
+    def self.noid_template
+      Sufia.config.noid_template
+    end
+
+    @minter = ::Noid::Minter.new(:template => noid_template)
     @pid = $$
     @namespace = Sufia::Engine.config.id_namespace
     @semaphore = Mutex.new
@@ -41,7 +46,7 @@ module Sufia
       File.open(Sufia::Engine.config.minter_statefile, File::RDWR|File::CREAT, 0644) do |f|
         f.flock(File::LOCK_EX)
         yaml = YAML::load(f.read)
-        yaml = {:template => '.reeddeeddk'} unless yaml
+        yaml = {:template => noid_template} unless yaml
         minter = ::Noid::Minter.new(yaml)
         pid = "#{@namespace}:#{minter.mint}"
         f.rewind


### PR DESCRIPTION
Prior to this commit, the template for NOID creation was hard-coded in
IdService. By extracting the template to a configuration option - with a
default - institutions can further customize what will very likely be
the a portion of the URL for their repository objects.
