### PR TITLE
Pegging hooks version

### DIFF
--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'resque', '~> 1.23.0'#, :require => 'resque/server'
   gem.add_dependency 'resque-pool', '0.3.0'
   gem.add_dependency 'rmagick'
+  gem.add_dependency 'hooks', '~> 0.2.2'
   gem.add_dependency 'devise'
   gem.add_dependency 'paperclip', '3.3.0'
   gem.add_dependency 'daemons', '1.1.9'


### PR DESCRIPTION
Tests were breaking against newest version of hooks.

Is this something we should be doing here?
