### PR TITLE
Adding a partial to allow for overriding batch_edit menu actions

### DIFF
--- a/app/views/batch_edits/_batch_edits_actions.html.erb
+++ b/app/views/batch_edits/_batch_edits_actions.html.erb
@@ -1,0 +1,1 @@
+<li data-behavior="batch-edit-select-abc" data-state="on"><a href="#"><i class="icon-ok"></i> Select ABC</a></li>

--- a/app/views/batch_edits/_check_all.html.erb
+++ b/app/views/batch_edits/_check_all.html.erb
@@ -3,8 +3,7 @@
       <%= check_box_tag 'check_all', 'yes', @all_checked, :disabled => ((@batch_size_on_other_page + @document_list.count) > @max_batch_size) %>
       <a class="dropdown-toggle"  data-toggle="dropdown" href="#"><span class="icon-cog" title="click for selection options"></span></a>
       <ul class="dropdown-menu">
-        <li data-behavior="batch-edit-select-none" data-state="on"><a href="#"><i class="icon-ok"></i> Select None</a></li>
-        <li data-behavior="batch-edit-select-page" data-state="off"><a href="#"><i class=""></i> Select Current Page</a></li>
+        <%= render partial:'batch_edits_actions' %>
       </ul>
     </div>
   <% end %>

--- a/app/views/dashboard/_batch_edits_actions.html.erb
+++ b/app/views/dashboard/_batch_edits_actions.html.erb
@@ -1,0 +1,2 @@
+<li data-behavior="batch-edit-select-none" data-state="on"><a href="#"><i class="icon-ok"></i> Select None</a></li>
+<li data-behavior="batch-edit-select-page" data-state="off"><a href="#"><i class=""></i> Select Current Page</a></li>

--- a/spec/views/batch_edits/check_all_spec.rb
+++ b/spec/views/batch_edits/check_all_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'Check All' do
+  before (:all) do
+    @document_list = ['a','b','c']
+    @batch_size_on_other_page = 0
+    @max_batch_size = 100
+  end
+
+  it 'should render batch edits actions' do
+    controller.prepend_view_path "app/views/batch_edits"
+    html = render :partial=>'/batch_edits/check_all'
+    html.should have_selector("li[data-behavior='batch-edit-select-abc']")
+  end
+
+  it 'should render dashboard actions' do
+    controller.prepend_view_path "app/views/dashboard"
+    html = render :partial=>'/batch_edits/check_all'
+    html.should have_selector("li[data-behavior='batch-edit-select-none']")
+    html.should have_selector("li[data-behavior='batch-edit-select-page']")
+  end
+end


### PR DESCRIPTION
Adding this partial allows each view location to include their own actions for the Batch Edit items.
