### PR TITLE
Moved Sufia.config into sufia-models.

### DIFF
--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -15,18 +15,6 @@ module Sufia
 
   class Engine < ::Rails::Engine
     engine_name 'sufia'
-
-    # Set some configuration defaults
-    config.queue = Sufia::Resque::Queue
-    config.enable_ffmpeg = false
-    config.noid_template = '.reeddeeddk'
-    config.ffmpeg_path = 'ffmpeg'
-    config.fits_message_length = 5
-    config.temp_file_base = nil
-    config.minter_statefile = '/tmp/minter-state'
-    config.id_namespace = "sufia"
-    config.fits_path = "fits.sh"
-    config.enable_contact_form_delivery = false
  
     config.autoload_paths += %W(
       #{config.root}/app/controllers/concerns
@@ -34,14 +22,6 @@ module Sufia
       #{config.root}/app/models/datastreams
     )
 
-  end
-
-  def self.config(&block)
-    @@config ||= Sufia::Engine::Configuration.new
-
-    yield @@config if block
-
-    return @@config
   end
 
   autoload :Controller

--- a/sufia-models/lib/sufia/models.rb
+++ b/sufia-models/lib/sufia/models.rb
@@ -14,14 +14,8 @@ module Sufia
   extend ActiveSupport::Autoload
 
   module Models
-
-    extend ActiveSupport::Autoload
-
-    autoload :Resque, 'sufia/models/queue/resque'
-    autoload :User, 'sufia/models/user'
   end
 
-  autoload :Resque, 'sufia/models/resque'
   autoload :Utils, 'sufia/models/utils'
 
   attr_writer :queue

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -1,3 +1,4 @@
+require 'sufia/models/resque'
 module Sufia
   module Models
     def self.config(&block)
@@ -9,6 +10,19 @@ module Sufia
     end
 
     class Engine < ::Rails::Engine
+
+      # Set some configuration defaults
+      config.enable_ffmpeg = false
+      config.noid_template = '.reeddeeddk'
+      config.ffmpeg_path = 'ffmpeg'
+      config.fits_message_length = 5
+      config.temp_file_base = nil
+      config.minter_statefile = '/tmp/minter-state'
+      config.id_namespace = "sufia"
+      config.fits_path = "fits.sh"
+      config.enable_contact_form_delivery = false
+      config.queue = Sufia::Resque::Queue
+
       config.autoload_paths += %W(
         #{config.root}/lib/sufia/models/jobs
         #{config.root}/app/models/datastreams

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Sufia::VERSION
 
   gem.add_dependency 'rails', '~> 3.2.13'
-  gem.add_dependency 'sufia-models'
+  gem.add_dependency 'sufia-models', '~> 0.1.2'
   gem.add_dependency 'blacklight', '~> 4.0'
   gem.add_dependency 'blacklight_advanced_search'
   gem.add_dependency "hydra-head", "~> 6.0"


### PR DESCRIPTION
This ensures that users of sufia-models will be able to access
Sufia.config

Fixes #122
