### PR TITLE
Use Sufia.config rather than Sufia::Engine.config.

### DIFF
--- a/sufia-models/lib/sufia/models/id_service.rb
+++ b/sufia-models/lib/sufia/models/id_service.rb
@@ -43,7 +43,7 @@ module Sufia
 
     def self.next_id
       pid = ''
-      File.open(Sufia::Engine.config.minter_statefile, File::RDWR|File::CREAT, 0644) do |f|
+      File.open(Sufia.config.minter_statefile, File::RDWR|File::CREAT, 0644) do |f|
         f.flock(File::LOCK_EX)
         yaml = YAML::load(f.read)
         yaml = {:template => noid_template} unless yaml


### PR DESCRIPTION
Users of sufia-models may not have Sufia::Engine defined.

This is a partial fix for #121
