### PR TITLE
This change makes it possible to have both sufia and hydra-editor installed

### DIFF
--- a/app/views/generic_files/_field_form.html.erb
+++ b/app/views/generic_files/_field_form.html.erb
@@ -9,6 +9,6 @@
   <% end %>
 
   <% vals.to_ary.each_with_index do |v, index| %>
-    <%= render_edit_field_partial(key, f:f,  v: v, index: index, render_req: render_req) %>
+    <%= render_edit_field_partial(key, record: generic_file, f:f,  v: v, index: index, render_req: render_req) %>
   <% end %>
  </div><!-- /control-group -->


### PR DESCRIPTION
This change makes it possible to have both sufia and hydra-editor installed in the same host app. (They both have view helpers named render_edit_field_partial, but they behave slightly differently.)
