### PR TITLE
Resque should use the redis instance configured in redis.yml

### DIFF
--- a/lib/generators/sufia/templates/config/redis_config.rb
+++ b/lib/generators/sufia/templates/config/redis_config.rb
@@ -1,17 +1,3 @@
-# Copyright © 2012 The Pennsylvania State University
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 if defined?(PhusionPassenger)
   PhusionPassenger.on_event(:starting_worker_process) do |forked|
     # We're in smart spawning mode.
@@ -23,6 +9,7 @@ if defined?(PhusionPassenger)
       # The important two lines
       $redis.client.disconnect if $redis 
       $redis = Redis.new(host: config[:host], port: config[:port], thread_safe: true) rescue nil
+      Resque.redis = $redis
       Resque.redis.client.reconnect if Resque.redis
     end
   end


### PR DESCRIPTION
Before this patch it used the default port, because Resque is unaware of
`$redis`.
