### PR TITLE
Reindex everything scopes to sufia's namespace

### DIFF
--- a/sufia-models/lib/sufia/models/jobs/resolrize_job.rb
+++ b/sufia-models/lib/sufia/models/jobs/resolrize_job.rb
@@ -18,6 +18,13 @@ class ResolrizeJob
   end
 
   def run
-    ActiveFedora::Base.reindex_everything
+    require 'active_fedora/version'
+    active_fedora_version = Gem::Version.new(ActiveFedora::VERSION)
+    minimum_feature_version = Gem::Version.new('6.4.4')
+    if active_fedora_version >= minimum_feature_version
+      ActiveFedora::Base.reindex_everything("pid~#{Sufia.config.id_namespace}:*")
+    else
+      ActiveFedora::Base.reindex_everything
+    end
   end
 end


### PR DESCRIPTION
ActiveFedora::Base.reindex_everything certainly does that. It will
search out all objects from Fedora and attempt to load them into an
ActiveFedora::Base model. If you ran this from an application that has
only a subset of the models in Fedora you could be in for some really
weird surprises.

This patch allows you to pass a Fedora query string to the underlying
Rubydora search method.

In the case of our application, I only want to reindex items that are in
the namespace "und", so my method call looked like the following:

```
ActiveFedora::Base.reindex_everything("pid~und:*")
```

Closes #153
Dependent on https://github.com/projecthydra/active_fedora/pull/161
