### PR TITLE
Classes in app/jobs should be available to the application

### DIFF
--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -17,6 +17,7 @@ module Sufia
     engine_name 'sufia'
  
     config.autoload_paths += %W(
+      #{config.root}/app/jobs
       #{config.root}/app/controllers/concerns
       #{config.root}/app/models/concerns
       #{config.root}/app/models/datastreams


### PR DESCRIPTION
Prior to this my application would receive: `uninitialized constant IngestLocalFileJob`
