### PR TITLE
Use add_file() rather than add_file_datastream() to ensure object label is set

### DIFF
--- a/lib/sufia/files_controller_behavior.rb
+++ b/lib/sufia/files_controller_behavior.rb
@@ -146,7 +146,7 @@ module Sufia
 
       if params.has_key?(:revision) and params[:revision] !=  @generic_file.content.latest_version.versionID
         revision = @generic_file.content.get_version(params[:revision])
-        @generic_file.add_file_datastream(revision.content, :dsid => 'content', :mimeType => revision.mimeType)
+        @generic_file.add_file(revision.content, datastream_id, revision.label)
         version_event = true
         Sufia.queue.push(ContentRestoredVersionEventJob.new(@generic_file.pid, current_user.user_key, params[:revision]))
       end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -1,3 +1,4 @@
+
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe DownloadsController do
@@ -6,8 +7,7 @@ describe DownloadsController do
     before do
       @f = GenericFile.new(:pid => 'sufia:test1')
       @f.apply_depositor_metadata('archivist1@example.com')
-      @f.set_title_and_label('world.png')
-      @f.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content', :mimeType => 'image/png')
+      @f.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
       @f.should_receive(:characterize_if_changed).and_yield
       @f.save!
     end

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -271,7 +271,7 @@ describe GenericFilesController do
     before do
       #GenericFile.any_instance.stub(:to_solr).and_return({})
       @generic_file = GenericFile.new
-      @generic_file.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content')
+      @generic_file.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
       @generic_file.apply_depositor_metadata('mjg36')
       @generic_file.save
     end
@@ -477,8 +477,7 @@ describe GenericFilesController do
     before do
       f = GenericFile.new(:pid => 'sufia:test5')
       f.apply_depositor_metadata('archivist1@example.com')
-      f.set_title_and_label('world.png')
-      f.add_file_datastream(File.new(fixture_path +  '/world.png'))
+      f.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
       # grant public read access explicitly
       f.read_groups = ['public']
       f.should_receive(:characterize_if_changed).and_yield

--- a/spec/controllers/single_use_link_controller_spec.rb
+++ b/spec/controllers/single_use_link_controller_spec.rb
@@ -4,12 +4,11 @@ describe SingleUseLinkController do
   before(:all) do
     @user = FactoryGirl.find_or_create(:user)
     @file = GenericFile.new
-    @file.set_title_and_label('world.png')
-    @file.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content', :mimeType => 'image/png')
+    @file.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
     @file.apply_depositor_metadata(@user.user_key)
     @file.save
     @file2 = GenericFile.new
-    @file2.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content', :mimeType => 'image/png')
+    @file2.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
     @file2.apply_depositor_metadata('mjg36')
     @file2.save
   end

--- a/spec/models/characterize_job_spec.rb
+++ b/spec/models/characterize_job_spec.rb
@@ -15,7 +15,7 @@ describe CharacterizeJob do
 
   describe "with a AVI (video) file" do
     before do
-      @generic_file.add_file_datastream(File.new(fixture_path + '/countdown.avi'), :dsid=>'content', :mime_type=>'video/avi')
+      @generic_file.add_file(File.open(fixture_path + '/countdown.avi'), 'content', 'countdown.avi')
       @generic_file.stub(:characterize_if_changed).and_yield
       @generic_file.save!
     end
@@ -38,7 +38,7 @@ describe CharacterizeJob do
 
   describe "with a WAV (audio) file" do
     before do
-      @generic_file.add_file_datastream(File.new(fixture_path + '/piano_note.wav'), :dsid=>'content', :mime_type=>'audio/wav')
+      @generic_file.add_file(File.open(fixture_path + '/piano_note.wav'), 'content', 'piano_note.wav')
       @generic_file.stub(:characterize_if_changed).and_yield
       @generic_file.save!
     end
@@ -57,7 +57,7 @@ describe CharacterizeJob do
 
   describe "with an mp3 (audio) file" do
     before do
-      @generic_file.add_file_datastream(File.new(fixture_path + '/sufia/sufia_test5.mp3'), :dsid=>'content', :mime_type=>'audio/mp3')
+      @generic_file.add_file(File.open(fixture_path + '/sufia/sufia_test5.mp3'), 'content', 'sufia_test5.mp3')
       @generic_file.stub(:characterize_if_changed).and_yield
       @generic_file.save!
     end
@@ -77,7 +77,7 @@ describe CharacterizeJob do
 
   describe "with an jpeg2000 (image) file" do
     before do
-      @generic_file.add_file_datastream(File.new(fixture_path + '/image.jp2'), :dsid=>'content', :mime_type=>'image/jp2')
+      @generic_file.add_file(File.open(fixture_path + '/image.jp2'), 'content', 'image.jp2')
       @generic_file.stub(:characterize_if_changed).and_yield
       @generic_file.save!
     end

--- a/spec/models/checksum_audit_log_spec.rb
+++ b/spec/models/checksum_audit_log_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe ChecksumAuditLog do
   before(:all) do
     @f = GenericFile.new
-    @f.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content')
+    @f.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
     @f.apply_depositor_metadata('mjg36')
     @f.stub(:characterize_if_changed).and_yield #don't run characterization
     @f.save!

--- a/spec/models/file_content_datastream_spec.rb
+++ b/spec/models/file_content_datastream_spec.rb
@@ -7,7 +7,7 @@ describe FileContentDatastream do
   describe "version control" do
     before do
       f = GenericFile.new
-      f.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content')
+      f.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
       f.apply_depositor_metadata('mjg36')
       f.stub(:characterize_if_changed).and_yield #don't run characterization
       f.save
@@ -33,7 +33,7 @@ describe FileContentDatastream do
     end
     describe "add a version" do
       before do
-        @file.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content')
+        @file.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
         @file.stub(:characterize_if_changed).and_yield #don't run characterization
         @file.save
       end
@@ -93,13 +93,13 @@ describe FileContentDatastream do
       @generic_file.delete
     end
     it "should only return true when the datastream has actually changed" do
-      @generic_file.add_file_datastream(File.new(fixture_path + '/world.png', 'rb'), :dsid=>'content')
+      @generic_file.add_file(File.open(fixture_path + '/world.png', 'rb'), 'content', 'world.png')
       @generic_file.content.changed?.should be_true
       @generic_file.save!
       @generic_file.content.changed?.should be_false
 
       # Add a thumbnail ds
-      @generic_file.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'thumbnail')
+      @generic_file.add_file(File.open(fixture_path + '/world.png'), 'thumbnail', 'world.png')
       @generic_file.thumbnail.changed?.should be_true
       @generic_file.content.changed?.should be_false
 

--- a/spec/models/fits_datastream_spec.rb
+++ b/spec/models/fits_datastream_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe FitsDatastream, :unless => $in_travis do
   before(:all) do
     @file = GenericFile.new
-    @file.add_file_datastream(File.new(fixture_path + '/world.png'), :dsid=>'content')
+    @file.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
     @file.characterize
   end
   it "should have a format label" do

--- a/spec/models/transcode_audio_job_spec.rb
+++ b/spec/models/transcode_audio_job_spec.rb
@@ -12,8 +12,7 @@ describe TranscodeAudioJob, :if => Sufia.config.enable_ffmpeg do
 
   describe "with a wav file" do
     before do
-      @generic_file.add_file_datastream(File.new(fixture_path + '/piano_note.wav'), :dsid=>'content')
-      @generic_file.mime_type = 'audio/wav'
+      @generic_file.add_file(File.open(fixture_path + '/piano_note.wav'), 'content', 'piano_note.wav')
       @generic_file.save!
     end
     after do
@@ -39,7 +38,7 @@ describe TranscodeAudioJob, :if => Sufia.config.enable_ffmpeg do
   describe "with an mp3 file" do
     # Uncomment when this is nolonger pending
     # before do
-    #   @generic_file.add_file_datastream(File.new(fixture_path + '/sufia/sufia_test5.mp3'), :dsid=>'content')
+    #   @generic_file.add_file(File.open(fixture_path + '/sufia/sufia_test5.mp3'), 'content', 'sufia_test5.mp3')
     #   @generic_file.characterize # so that the mime_type is set
     #   @generic_file.save!
     # end
@@ -62,7 +61,7 @@ describe TranscodeAudioJob, :if => Sufia.config.enable_ffmpeg do
   describe "with an ogg file" do
     # Uncomment when this is nolonger pending
     # before do
-    #   @generic_file.add_file_datastream(File.new(fixture_path + '/Example.ogg'), :dsid=>'content')
+    #   @generic_file.add_file(File.open(fixture_path + '/Example.ogg'), 'content', 'Example.ogg')
     #   @generic_file.characterize # so that the mime_type is set
     #   @generic_file.save!
     # end

--- a/spec/models/transcode_video_job_spec.rb
+++ b/spec/models/transcode_video_job_spec.rb
@@ -4,7 +4,7 @@ describe TranscodeVideoJob, :if => Sufia.config.enable_ffmpeg do
   before do
     @generic_file = GenericFile.new
     @generic_file.apply_depositor_metadata('jcoyne@example.com')
-    @generic_file.add_file_datastream(File.new(fixture_path + '/countdown.avi'), :dsid=>'content')
+    @generic_file.add_file(File.open(fixture_path + '/countdown.avi'), 'content', 'countdown.avi')
     @generic_file.stub(:characterize_if_changed).and_yield
     @generic_file.mime_type = 'video/avi'
     @generic_file.save!

--- a/spec/models/unzip_job_spec.rb
+++ b/spec/models/unzip_job_spec.rb
@@ -4,7 +4,7 @@ describe UnzipJob do
   before do
     @batch = Batch.create
     @generic_file = GenericFile.new(:batch=>@batch)
-    @generic_file.add_file_datastream(File.new(fixture_path + '/icons.zip'), :dsid=>'content')
+    @generic_file.add_file(File.open(fixture_path + '/icons.zip'), 'content', 'icons.zip')
     @generic_file.apply_depositor_metadata('mjg36')
     @generic_file.stub(:characterize_if_changed).and_yield #don't run characterization
     @generic_file.save

--- a/sufia-models/lib/sufia/models/jobs/unzip_job.rb
+++ b/sufia-models/lib/sufia/models/jobs/unzip_job.rb
@@ -42,12 +42,7 @@ class UnzipJob
   def create_file(file)
     @generic_file = GenericFile.new
     @generic_file.batch_id = zip_file.batch.pid
-    file_name = file.name
-    mime_types = MIME::Types.of(file_name)
-    mime_type = mime_types.empty? ? "application/octet-stream" : mime_types.first.content_type
-    options = {:label=>file_name, :dsid=>'content', :mimeType=>mime_type}
-    @generic_file.add_file_datastream(file.read, options)
-    @generic_file.set_title_and_label( file_name, :only_if_blank=>true )
+    @generic_file.add_file(file.read, 'content', file.name)
     @generic_file.apply_depositor_metadata(zip_file.edit_users.first)
     @generic_file.date_uploaded = Time.now.ctime
     @generic_file.date_modified = Time.now.ctime


### PR DESCRIPTION
This solves the FITS datastream spec error resulting from the missing `<filename>` element
