### PR TITLE
Use hydra-head's before_add_file hook to perform virus checks...

### DIFF
--- a/lib/sufia/virus_found_error.rb
+++ b/lib/sufia/virus_found_error.rb
@@ -1,0 +1,4 @@
+module Sufia
+  class VirusFoundError < StandardError; end
+end
+

--- a/spec/models/generic_file/actions_spec.rb
+++ b/spec/models/generic_file/actions_spec.rb
@@ -1,10 +1,19 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+require 'sufia/virus_found_error'
 
 describe GenericFile do
-
   describe "#virus_check" do
+    let(:f) { File.new(fixture_path + '/world.png') }
+    let(:generic_file) do
+      GenericFile.new.tap do |gf|
+        gf.apply_depositor_metadata('mjg')
+        gf.save
+      end
+    end
     before do
-      unless defined? ClamAV
+      if defined? ClamAV
+        ClamAV.instance.loaddb
+      else
         class ClamAV
           def self.instance
             new
@@ -15,11 +24,12 @@ describe GenericFile do
     end
     after do
       Object.send(:remove_const, :ClamAV) if @stubbed_clamav
+      generic_file.destroy
     end
     it "should return the results of running ClamAV scanfile method" do
-      # subject.stub(:to_solr).and_return({})
-      ClamAV.any_instance.should_receive(:scanfile).and_return(1)    
-      Sufia::GenericFile::Actions.virus_check(File.new(fixture_path + '/world.png')).should == 1
+      ClamAV.any_instance.should_receive(:scanfile).and_return(1)
+      expect { Sufia::GenericFile::Actions.virus_check(f) }.to raise_error(Sufia::VirusFoundError, /virus was found/)
+      generic_file.add_file(f, 'content', 'world.png')
     end
   end
 end

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -1,6 +1,23 @@
 require 'spec_helper'
 
 describe GenericFile do
+  before(:all) do
+    if defined? ClamAV
+      ClamAV.instance.loaddb
+    else
+      class ClamAV
+        def self.instance
+          new
+        end
+      end
+      @stubbed_clamav = true
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :ClamAV) if @stubbed_clamav
+  end
+
   before do
     subject.apply_depositor_metadata('jcoyne')
     @file = subject #TODO remove this line someday (use subject instead)
@@ -154,6 +171,10 @@ describe GenericFile do
     end
     it "should have a dc desc metadata" do
       @file.descMetadata.should be_kind_of GenericFileRdfDatastream
+    end
+    it "should call the before hook on add_file" do
+      @file.should_receive(:before_add_file)
+      @file.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
     end
     it "should have content datastream" do
       @file.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')

--- a/sufia-models/lib/sufia/models/generic_file.rb
+++ b/sufia-models/lib/sufia/models/generic_file.rb
@@ -38,6 +38,9 @@ module Sufia
       attr_accessible *(ds_specs['descMetadata'][:type].fields + [:permissions])
     end
 
+    def before_add_file(file, dsid, filename)
+      Actions.virus_check(file)
+    end
 
     def record_version_committer(user)
       version = content.latest_version

--- a/tasks/sufia-dev.rake
+++ b/tasks/sufia-dev.rake
@@ -51,6 +51,7 @@ task :generate do
     `echo "gem 'sufia', :path=>'../../../sufia'
 gem 'capybara'
 gem 'factory_girl_rails'
+gem 'clamav'
 gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'" >> spec/internal/Gemfile`
     puts "Copying generator"
     `cp -r spec/support/lib/generators spec/internal/lib`


### PR DESCRIPTION
...automatically when content datastreams are attached to objects via `add_file`, which is what we use in Sufia. Do this in a way that is overrideable by downstream adopters.

NOTE: this depends upon the following hydra-head PR: https://github.com/projecthydra/hydra-head/pull/77 (so the CI builds will fail)
