### PR TITLE
ModelMethods#apply_depositor_metadata should accept a user or a string

### DIFF
--- a/spec/controllers/batch_controller_spec.rb
+++ b/spec/controllers/batch_controller_spec.rb
@@ -16,7 +16,7 @@ describe BatchController do
       @batch = Batch.new
       @batch.save
       @file = GenericFile.new(:batch=>@batch)
-      @file.apply_depositor_metadata(@user.user_key)
+      @file.apply_depositor_metadata(@user)
       @file.save
       @file2 = GenericFile.new(:batch=>@batch)
       @file2.apply_depositor_metadata('otherUser')
@@ -118,10 +118,10 @@ describe BatchController do
       @b1 = Batch.new
       @b1.save
       @file = GenericFile.new(:batch=>@b1, :label=>'f1')
-      @file.apply_depositor_metadata(@user.user_key)
+      @file.apply_depositor_metadata(@user)
       @file.save
       @file2 = GenericFile.new(:batch=>@b1, :label=>'f2')
-      @file2.apply_depositor_metadata(@user.user_key)
+      @file2.apply_depositor_metadata(@user)
       @file2.save
     end
     after do

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -54,7 +54,7 @@ describe DashboardController do
           files_count = assigns(:document_list).count
           until files_count == 3
             gf = GenericFile.new()
-            gf.apply_depositor_metadata(@user.user_key)
+            gf.apply_depositor_metadata(@user)
             gf.save
             files_count += 1
           end

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -290,7 +290,7 @@ describe GenericFilesController do
   describe "destroy" do
     before(:each) do
       @generic_file = GenericFile.new
-      @generic_file.apply_depositor_metadata(@user.user_key)
+      @generic_file.apply_depositor_metadata(@user)
       @generic_file.save
       @user = FactoryGirl.find_or_create(:user)
       sign_in @user
@@ -315,7 +315,7 @@ describe GenericFilesController do
     before do
       #controller.should_receive(:virus_check).and_return(0)      
       @generic_file = GenericFile.new
-      @generic_file.apply_depositor_metadata(@user.user_key)
+      @generic_file.apply_depositor_metadata(@user)
       @generic_file.save
     end
     after do

--- a/spec/controllers/single_use_link_controller_spec.rb
+++ b/spec/controllers/single_use_link_controller_spec.rb
@@ -5,7 +5,7 @@ describe SingleUseLinkController do
     @user = FactoryGirl.find_or_create(:user)
     @file = GenericFile.new
     @file.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
-    @file.apply_depositor_metadata(@user.user_key)
+    @file.apply_depositor_metadata(@user)
     @file.save
     @file2 = GenericFile.new
     @file2.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -127,7 +127,7 @@ describe UsersController do
     end
     it "should remove a trophy" do
       f = GenericFile.create(title:"myFile")
-      f.apply_depositor_metadata(@user.user_key)
+      f.apply_depositor_metadata(@user)
       f.save
       file_id = f.pid.split(":").last
       Trophy.create(:generic_file_id => file_id, :user_id => @user.id)
@@ -197,7 +197,7 @@ describe UsersController do
   describe "#toggle_trophy" do
      before do
        @file = GenericFile.new()
-       @file.apply_depositor_metadata(@user.user_key)
+       @file.apply_depositor_metadata(@user)
        @file.save
        @file_id = @file.pid.split(":").last
      end

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -4,7 +4,7 @@ describe IngestLocalFileJob do
   let(:user) { FactoryGirl.find_or_create(:user) }
 
   let (:generic_file) do 
-    GenericFile.new.tap { |f| f.apply_depositor_metadata(user.user_key); f.save } 
+    GenericFile.new.tap { |f| f.apply_depositor_metadata(user); f.save } 
   end 
 
   before do

--- a/spec/models/audit_job_spec.rb
+++ b/spec/models/audit_job_spec.rb
@@ -7,7 +7,7 @@ describe AuditJob do
     GenericFile.any_instance.should_receive(:characterize_if_changed).and_yield
     GenericFile.any_instance.stub(:terms_of_service).and_return('1')
     @file = GenericFile.new
-    @file.apply_depositor_metadata(@user.user_key)
+    @file.apply_depositor_metadata(@user)
     @file.save
     @ds = @file.datastreams.first
   end

--- a/spec/models/batch_update_job_spec.rb
+++ b/spec/models/batch_update_job_spec.rb
@@ -6,7 +6,7 @@ describe BatchUpdateJob do
     @batch = Batch.new
     @batch.save
     @file = GenericFile.new(:batch=>@batch)
-    @file.apply_depositor_metadata(@user.user_key)
+    @file.apply_depositor_metadata(@user)
     @file.save
     @file2 = GenericFile.new(:batch=>@batch)
     @file2.apply_depositor_metadata('otherUser')

--- a/spec/models/event_jobs_spec.rb
+++ b/spec/models/event_jobs_spec.rb
@@ -7,7 +7,7 @@ describe 'event jobs' do
     @third_user = FactoryGirl.find_or_create(:curator)
     GenericFile.any_instance.stub(:terms_of_service).and_return('1')
     @gf = GenericFile.new(pid: 'test:123')
-    @gf.apply_depositor_metadata(@user.user_key)
+    @gf.apply_depositor_metadata(@user)
     @gf.title = 'Hamlet'
     @gf.save
   end

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -321,17 +321,14 @@ describe GenericFile do
     end
   end
   describe "trophies" do
-    before(:all) do
-      @u = FactoryGirl.create(:user)
+    before do
+      u = FactoryGirl.create(:user)
       @f = GenericFile.new.tap do |gf|
-        gf.apply_depositor_metadata(@u.user_key)
+        gf.apply_depositor_metadata(u)
         gf.stub(:characterize_if_changed).and_yield #don't run characterization
         gf.save!
       end
-      @t = Trophy.create(user_id: @u.id, generic_file_id: @f.pid)
-    end
-    after(:all) do
-      @u.destroy
+      @t = Trophy.create(user_id: u.id, generic_file_id: @f.pid)
     end
     it "should have a trophy" do
       Trophy.where(generic_file_id: @f.pid).count.should == 1
@@ -347,7 +344,7 @@ describe GenericFile do
       u = FactoryGirl.create(:user)
       f = GenericFile.new
       f.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
-      f.apply_depositor_metadata(u.user_key)
+      f.apply_depositor_metadata(u)
       f.stub(:characterize_if_changed).and_yield #don't run characterization
       f.save!
       @f = f.reload

--- a/sufia-models/lib/sufia/models/generic_file/actions.rb
+++ b/sufia-models/lib/sufia/models/generic_file/actions.rb
@@ -3,7 +3,7 @@ module Sufia::GenericFile
   module Actions
     def self.create_metadata(generic_file, user, batch_id)
 
-      generic_file.apply_depositor_metadata(user.user_key)
+      generic_file.apply_depositor_metadata(user)
       generic_file.date_uploaded = Date.today
       generic_file.date_modified = Date.today
       generic_file.creator = user.name

--- a/sufia-models/lib/sufia/models/model_methods.rb
+++ b/sufia-models/lib/sufia/models/model_methods.rb
@@ -1,18 +1,3 @@
-# Copyright © 2012 The Pennsylvania State University
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-require 'hydra/model_methods'
 module Sufia
   module ModelMethods
     extend ActiveSupport::Concern
@@ -26,9 +11,10 @@ module Sufia
     # Adds metadata about the depositor to the asset
     # Most important behavior: if the asset has a rightsMetadata datastream, this method will add +depositor_id+ to its individual edit permissions.
 
-    def apply_depositor_metadata(depositor_id)
+    def apply_depositor_metadata(depositor)
       rights_ds = self.datastreams["rightsMetadata"]
       prop_ds = self.datastreams["properties"]
+      depositor_id = depositor.respond_to?(:user_key) ? depositor.user_key : depositor
 
       rights_ds.update_indexed_attributes([:edit_access, :person]=>depositor_id) unless rights_ds.nil?
       prop_ds.depositor = depositor_id unless prop_ds.nil?


### PR DESCRIPTION
like the method it overrides in HydraHead.  See:
https://github.com/projecthydra/hydra-head/blob/9a5b2728be2046125d09376a6d78ad06d26548c3/hydra-core/lib/hydra/model_methods.rb#L12
