### PR TITLE
Adding an operride path where to redirect for when a file gets destroyed

### DIFF
--- a/lib/sufia/files_controller/upload_complete_behavior.rb
+++ b/lib/sufia/files_controller/upload_complete_behavior.rb
@@ -3,5 +3,10 @@ module Sufia
     def upload_complete_path(batch_id)
       Sufia::Engine.routes.url_helpers.batch_edit_path(batch_id)
     end
+
+    def destroy_complete_path(params)
+      Sufia::Engine.routes.url_helpers.dashboard_index_path
+    end
+
   end # /FilesController::UploadCompleteBehavior
 end # /Sufia

--- a/lib/sufia/files_controller_behavior.rb
+++ b/lib/sufia/files_controller_behavior.rb
@@ -72,7 +72,7 @@ module Sufia
       pid = @generic_file.noid
       @generic_file.destroy
       Sufia.queue.push(ContentDeleteEventJob.new(pid, current_user.user_key))
-      redirect_to sufia.dashboard_index_path, :notice => render_to_string(:partial=>'generic_files/asset_deleted_flash', :locals => { :generic_file => @generic_file })
+      redirect_to self.class.destroy_complete_path(params), :notice => render_to_string(:partial=>'generic_files/asset_deleted_flash', :locals => { :generic_file => @generic_file })
     end
 
     # routed to /files (POST)
@@ -181,6 +181,7 @@ module Sufia
     end
 
     protected
+
 
     def json_error(error, name=nil, additional_arguments={})
       args = {:error => error}

--- a/spec/lib/sufia/upload_complete_behavior_spec.rb
+++ b/spec/lib/sufia/upload_complete_behavior_spec.rb
@@ -9,6 +9,10 @@ class UploadThingRedefine
     return "example.com"
   end
 
+  def self.destroy_complete_path(id)
+    return "destroy.com"
+  end
+
 end
 
 describe Sufia::FilesController::UploadCompleteBehavior do
@@ -17,10 +21,16 @@ describe Sufia::FilesController::UploadCompleteBehavior do
     it "respond with the batch edit path" do
       UploadThing.upload_complete_path(test_id).should == Sufia::Engine.routes.url_helpers.batch_edit_path(test_id)
     end
+    it "respond with the dashboard path" do
+      UploadThing.destroy_complete_path({}).should ==   Sufia::Engine.routes.url_helpers.dashboard_index_path
+    end
   end
   context "overriden path" do
     it "respond with the batch edit path" do
       UploadThingRedefine.upload_complete_path(test_id).should == "example.com"
+    end
+    it "respond with the batch edit path" do
+      UploadThingRedefine.destroy_complete_path(test_id).should == "destroy.com"
     end
   end
 end


### PR DESCRIPTION
Not sure if the Behavior should be renamed since I want to add another path to get overridden.  Went with the least changes, but I am willing to rename the class to a more generic FileActionCompleteBehavior or something of the sort.  What say the group?
