### PR TITLE
Upgrading ActiveFedora to latest 6.5 version

### DIFF
--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 3.2.13', '< 5.0'
   spec.add_dependency 'activeresource' # No longer a dependency of rails 4.0
   spec.add_dependency "hydra-head", "~> 6.3.0"
-  spec.add_dependency 'active-fedora', "~> 6.4.0"
+  spec.add_dependency 'active-fedora', "~> 6.5.0"
 
   spec.add_dependency 'nest', '~> 1.1.1'
   spec.add_dependency 'resque', '~> 1.23.0'#, :require => 'resque/server'


### PR DESCRIPTION
This should update Sufia to use the latest ActiveFedora version.  I haven't seen any Travis messages, so I don't know what the status is on the build, but when I tested it locally, there weren't any errors.
