### PR TITLE
Indicating attr_accessible is deprecated

### DIFF
--- a/sufia-models/app/models/checksum_audit_log.rb
+++ b/sufia-models/app/models/checksum_audit_log.rb
@@ -1,5 +1,5 @@
 class ChecksumAuditLog < ActiveRecord::Base
-  attr_accessible :pass, :pid, :dsid, :version, :created_at if Rails::VERSION::MAJOR == 3
+  deprecated_attr_accessible :pass, :pid, :dsid, :version, :created_at
 
   def ChecksumAuditLog.get_audit_log(version)
     ChecksumAuditLog.find_or_create_by_pid_and_dsid_and_version(:pid => version.pid,

--- a/sufia-models/app/models/domain_term.rb
+++ b/sufia-models/app/models/domain_term.rb
@@ -1,5 +1,5 @@
 class DomainTerm < ActiveRecord::Base
-  attr_accessible :model, :term if Rails::VERSION::MAJOR == 3
+  deprecated_attr_accessible  :model, :term
 
   # TODO we should add an index on this join table and remove the uniq query
   has_and_belongs_to_many :local_authorities, :uniq=> true 

--- a/sufia-models/app/models/local_authority.rb
+++ b/sufia-models/app/models/local_authority.rb
@@ -2,7 +2,7 @@ require 'rdf'
 require 'rdf/rdfxml'
 
 class LocalAuthority < ActiveRecord::Base
-  attr_accessible :name if Rails::VERSION::MAJOR == 3
+  deprecated_attr_accessible  :name
   # TODO we should add an index on this join table and remove the uniq query
   has_and_belongs_to_many :domain_terms, :uniq=> true 
   has_many :local_authority_entries

--- a/sufia-models/app/models/local_authority_entry.rb
+++ b/sufia-models/app/models/local_authority_entry.rb
@@ -1,4 +1,4 @@
 class LocalAuthorityEntry < ActiveRecord::Base
   belongs_to :local_authority
-  attr_accessible :local_authority, :label, :uri if Rails::VERSION::MAJOR == 3
+  deprecated_attr_accessible  :local_authority, :label, :uri
 end

--- a/sufia-models/app/models/single_use_link.rb
+++ b/sufia-models/app/models/single_use_link.rb
@@ -1,6 +1,6 @@
 class SingleUseLink < ActiveRecord::Base
 
-  attr_accessible :downloadKey, :expires, :itemId, :path if Rails::VERSION::MAJOR == 3
+  deprecated_attr_accessible  :downloadKey, :expires, :itemId, :path
     
   
   def self.create_show(item_id)

--- a/sufia-models/app/models/trophy.rb
+++ b/sufia-models/app/models/trophy.rb
@@ -1,5 +1,5 @@
 class Trophy < ActiveRecord::Base
-  attr_accessible :generic_file_id, :user_id if Rails::VERSION::MAJOR == 3
+  deprecated_attr_accessible  :generic_file_id, :user_id
 
   validate :count_within_limit, :on => :create
 

--- a/sufia-models/app/models/version_committer.rb
+++ b/sufia-models/app/models/version_committer.rb
@@ -1,3 +1,3 @@
 class VersionCommitter < ActiveRecord::Base
-  attr_accessible :obj_id, :datastream_id, :version_id, :committer_login if Rails::VERSION::MAJOR == 3
+  deprecated_attr_accessible  :obj_id, :datastream_id, :version_id, :committer_login
 end

--- a/sufia-models/lib/sufia/models/active_record/deprecated_attr_accessible.rb
+++ b/sufia-models/lib/sufia/models/active_record/deprecated_attr_accessible.rb
@@ -1,0 +1,16 @@
+module ActiveRecord
+  module DeprecatedAttrAccessible
+    extend ActiveSupport::Concern
+    module ClassMethods
+      def deprecated_attr_accessible(*args)
+        if Rails::VERSION::MAJOR < 4 || defined?(ProtectedAttributes)
+          ActiveSupport::Deprecation.warn("deprecated_attr_accessible  is, wait for it, deprecated. It will be removed when Sufia stops support Rails 3.")
+          attr_accessible(*args)
+        end
+      end
+    end
+  end
+end
+ActiveRecord::Base.class_eval do
+  include ActiveRecord::DeprecatedAttrAccessible
+end

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -37,6 +37,7 @@ module Sufia
       initializer "patches" do
         require 'sufia/models/active_fedora/redis'
         require 'sufia/models/active_record/redis'
+        require 'sufia/models/active_record/deprecated_attr_accessible'
         require 'sufia/models/active_support/core_ext/marshal' unless Rails::VERSION::MAJOR == 4
       end
 

--- a/sufia-models/lib/sufia/models/user.rb
+++ b/sufia-models/lib/sufia/models/user.rb
@@ -19,7 +19,7 @@ module Sufia::User
     acts_as_followable
 
     # Setup accessible (or protected) attributes for your model
-    attr_accessible *permitted_attributes if Rails::VERSION::MAJOR == 3
+    deprecated_attr_accessible  *permitted_attributes
 
     # Add user avatar (via paperclip library)
     has_attached_file :avatar, :styles => { medium: "300x300>", thumb: "100x100>" }, :default_url => '/assets/missing_:style.png'


### PR DESCRIPTION
Given the existence of the ProtectedAttributes gem
it is feasible that attr_accessible will be enabled for applications
that upgrade from Rails 3 to Rails 4. This is to be a convenience
method indicating the behavior.
