### PR TITLE
Restoring the exception catching for migrations

### DIFF
--- a/sufia-models/lib/generators/sufia/models/install_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/install_generator.rb
@@ -92,7 +92,11 @@ This generator makes the following changes to your application:
   private
 
   def better_migration_template(file)
-    migration_template "migrations/#{file}", "db/migrate/#{file}"
+    begin
+      migration_template "migrations/#{file}", "db/migrate/#{file}"
+    rescue Rails::Generators::Error => e
+      say_status("warning", e.message, :yellow)
+    end
   end
 
 end


### PR DESCRIPTION
When sufia installs, it should handle a duplicate migration by
skipping that migration and offering a message for recovery.
