### PR TITLE
Return only GenericFile objects in the dashboard

### DIFF
--- a/lib/sufia/dashboard_controller_behavior.rb
+++ b/lib/sufia/dashboard_controller_behavior.rb
@@ -96,9 +96,9 @@ module Sufia
       ["edit"]
     end
 
-    # return only GenericFile objects from our search results
+    # calls Blacklight's get_search_results, but can be overridden if needed
     def get_dashboard_results
-      get_search_results(params, {:fq => 'has_model_ssim:"info:fedora/afmodel:GenericFile"'})
+      get_search_results params
     end
   end
 end


### PR DESCRIPTION
The list view in the dashboard assumes that all the solr documents in the current array are generic files:

https://github.com/projecthydra/sufia/blob/master/app/views/dashboard/_index_partials/_list_files.html.erb#L19

If you're trying to add Sufia into your existing Hydra application, this won't be the case and you'll have some of your
own custom models in there as well.  The change makes the dashboard's view explicit, returning only GenericFile objects to the view.

I came across this problem when I was adding Sufia into my existing application.  There may be other better ways of solving this, so feel free to comment.
