### PR TITLE
Including on sufia-models subdir in gemspec

### DIFF
--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |spec|
 
   # This is a temporary homepage until we've had a chance to review the
   # process
-  spec.homepage      = "https://github.com/jeremyf/sufia"
+  spec.homepage      = "https://github.com/projecthydra/sufia"
   spec.license       = "Apache"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($/).grep(%r{\Asufia-models})
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Prior to this commit, the sufia-models was including all of sufia
instead of including only those files in sufia-models

Closes #198
