### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Sufia has the following features:
 1. A SQL RDBMS (MySQL, SQLite)
 1. [Redis](http://redis.io/) key-value store
 1. Ruby
-l## !! Ensure that you have all of the above components installled before you continue. !!
+
+#### !! Ensure that you have all of the above components installed before you continue. !!
 
 ## Creating an application
-### Generate base Rails installl
+### Generate base Rails install
 ```rails new my_app```
 ### Add gems to Gemfile
 ```
@@ -45,7 +46,7 @@ gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'  # re
 gem 'jettywrapper'
 gem 'font-awesome-sass-rails'
 ```
-Then `bundle installl`
+Then `bundle install`
 
 Note the line with kaminari listed as a dependency.  This is a temporary fix to address a problem in the current release of kaminari.  Technically you should not have to list kaminari, which is a dependency of blacklight and sufia. 
 
@@ -53,7 +54,7 @@ Note the line with kaminari listed as a dependency.  This is a temporary fix to 
 ```
 rails g blacklight --devise
 rails g hydra:head -f
-bundle installl 
+bundle install
 rails g sufia -f
 rm public/index.html
 ```
@@ -90,7 +91,7 @@ Add this line:
 //= require sufia
 ```
 
-### Installl Fits.sh
+### Install Fits.sh
 1. Go to http://code.google.com/p/fits/downloads/list and download a copy of fits & unpack it somewhere on your Machine.
 1. Give your system access to fits
     1. By adding the path to fits.sh to your excutable PATH. (ex. in your .bashrc)
@@ -101,7 +102,7 @@ Add this line:
 1. You should be able to run "fits.sh" from the command line and see a help message
 
 ### Start background workers
-**Note:** Resque relies on the [redis](http://redis.io/) key-value store.  You must installl [redis](http://redis.io/) on your system and *have redis running* in order for this command to work.
+**Note:** Resque relies on the [redis](http://redis.io/) key-value store.  You must install [redis](http://redis.io/) on your system and *have redis running* in order for this command to work.
 To start redis, you usually want to call the `redis-server` command.
 
 ```


### PR DESCRIPTION
Fixed a few instances of installl (with 3 "L"s).

Fixed a heading so it wouldn't appear to be part of the bulleted list above it.
