### PR TITLE
Add ImageMagick as a software requirement in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Sufia has the following features:
 1. Fedora Commons
 1. A SQL RDBMS (MySQL, SQLite)
 1. [Redis](http://redis.io/) key-value store
+1. [ImageMagick](http://www.imagemagick.org/)
 1. Ruby
 
 #### !! Ensure that you have all of the above components installed before you continue. !!


### PR DESCRIPTION
It is not possible to install Sufia without ImageMagick installed since HydraDerivatives requires the ImageMagick command line tools.

Closes #202.
