### PR TITLE
Extracting CharacterizationService

### DIFF
--- a/spec/models/file_content_datastream_spec.rb
+++ b/spec/models/file_content_datastream_spec.rb
@@ -54,9 +54,6 @@ describe FileContentDatastream do
       @subject.stub(:pid=>'my_pid')
       @subject.stub(:dsVersionID=>'content.7')
     end
-    it "should have the path" do
-      @subject.send(:fits_path).should be_present
-    end
     it "should return an xml document", :unless => $in_travis do
       repo = double("repo")
       repo.stub(:config=>{})

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -560,43 +560,6 @@ describe GenericFile do
       @file.save
       @file.delete
     end
-    describe "after job runs" do
-      before(:all) do
-        myfile = GenericFile.new
-        myfile.add_file(File.open(fixture_path + '/sufia/sufia_test4.pdf'), 'content', 'sufia_test4.pdf')
-        myfile.label = 'label123'
-        myfile.apply_depositor_metadata('mjg36')
-        myfile.save
-        @myfile = myfile.reload
-      end
-      after(:all) do
-        @myfile.delete
-      end
-      it "should return expected results after a save" do
-        @myfile.file_size.should == ['218882']
-        @myfile.original_checksum.should == ['5a2d761cab7c15b2b3bb3465ce64586d']
-      end
-      it "should return a hash of all populated values from the characterization terminology" do
-        @myfile.characterization_terms[:format_label].should == ["Portable Document Format"]
-        @myfile.characterization_terms[:mime_type].should == "application/pdf"
-        @myfile.characterization_terms[:file_size].should == ["218882"]
-        @myfile.characterization_terms[:original_checksum].should == ["5a2d761cab7c15b2b3bb3465ce64586d"]
-        @myfile.characterization_terms.keys.should include(:last_modified)
-        @myfile.characterization_terms.keys.should include(:filename)
-      end
-      it "should append metadata from the characterization" do
-        @myfile.title.should include("Microsoft Word - sample.pdf.docx")
-        @myfile.filename[0].should == @myfile.label
-      end
-      it "should include thumbnail generation in characterization job" do
-        @myfile.thumbnail.size.should_not be_nil
-      end
-      it "should append each term only once" do
-        @myfile.append_metadata
-        @myfile.format_label.should == ["Portable Document Format"]
-        @myfile.title.should include("Microsoft Word - sample.pdf.docx")
-      end
-    end
   end
   describe "label" do
     it "should set the inner label" do

--- a/spec/services/characterization_service_spec.rb
+++ b/spec/services/characterization_service_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe CharacterizationService do
+  describe "after job runs" do
+    subject { CharacterizationService.new(generic_file) }
+    let(:generic_file) {
+      GenericFile.new.tap {|file|
+        file.add_file(File.open(fixture_path + '/sufia/sufia_test4.pdf'), 'content', 'sufia_test4.pdf')
+        file.label
+      }
+    }
+
+    it "should return expected results after a save" do
+      subject.call
+      generic_file.file_size.should == ['218882']
+      generic_file.original_checksum.should == ['5a2d761cab7c15b2b3bb3465ce64586d']
+
+      expect(generic_file.format_label).to eq ["Portable Document Format"]
+      expect(generic_file.mime_type).to eq "application/pdf"
+      expect(generic_file.file_size).to eq ["218882"]
+      expect(generic_file.original_checksum).to eq ["5a2d761cab7c15b2b3bb3465ce64586d"]
+
+      generic_file.title.should include("Microsoft Word - sample.pdf.docx")
+      generic_file.filename[0].should == generic_file.label
+      generic_file.format_label.should == ["Portable Document Format"]
+      generic_file.title.should include("Microsoft Word - sample.pdf.docx")
+    end
+  end
+end

--- a/sufia-models/app/services/characterization_service.rb
+++ b/sufia-models/app/services/characterization_service.rb
@@ -1,0 +1,43 @@
+# Responsible for extracting characterization metadata
+# from the given object.
+#
+# This is not in a complete state, but instead reflects a step towards
+# extraction.
+class CharacterizationService
+  attr_reader :object, :terminology, :fits_to_desc_mapping
+  def initialize(object, config = {})
+    @object = object
+    @fits_to_desc_mapping = config.fetch(:fits_to_desc_mapping, Sufia.config.fits_to_desc_mapping)
+    @terminology = config.fetch(:terminology, object.characterization.class.terminology)
+  end
+
+  def call
+    object.characterization.ng_xml = object.content.extract_metadata
+    append_metadata
+    object.filename = object.label
+    object.save
+  end
+
+  protected
+
+  # Populate descMetadata with fields from FITS (e.g. Author from pdfs)
+  def append_metadata
+    terms = object.characterization_terms
+    fits_to_desc_mapping.each_pair do |k, v|
+      if terms.has_key?(k)
+        # coerce to array to remove a conditional
+        terms[k] = [terms[k]] unless terms[k].is_a? Array
+        terms[k].each do |term_value|
+          proxy_term = object.send(v)
+          if proxy_term.kind_of?(Array)
+            proxy_term << term_value unless proxy_term.include?(term_value)
+          else
+            # these are single-valued terms which cannot be appended to
+            object.send("#{v}=", term_value)
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -26,6 +26,7 @@ module Sufia
       config.queue = Sufia::Resque::Queue
 
       config.autoload_paths += %W(
+        #{config.root}/app/services
         #{config.root}/lib/sufia/models/jobs
         #{config.root}/app/models/datastreams
       )

--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_follower', '>= 0.1.1', '< 0.3'
   spec.add_dependency 'paperclip', '~> 3.4.0'
   spec.add_dependency 'zipruby', '0.3.6'
-  spec.add_dependency 'hydra-derivatives', '~> 0.0.5'
+  spec.add_dependency 'hydra-derivatives', '~> 0.0.7'
   # https://github.com/zdennis/activerecord-import/pull/79
   #spec.add_dependency 'activerecord-import', '0.3.0' # 0.3.1 caused a bug in testing: "SQLite3::SQLException: near ",": syntax error: INSERT INTO..."
 end


### PR DESCRIPTION
By creating a Service class, I'm shifting the responsibility from
GenericFile, which should not worry about the characterization
process.

_Make sure specs pass on Travis as I can't get my instance to run
clean tests._
