### PR TITLE
Adding database_cleaner

### DIFF
--- a/spec/controllers/mailbox_controller_spec.rb
+++ b/spec/controllers/mailbox_controller_spec.rb
@@ -11,10 +11,6 @@ describe MailboxController do
     MailboxController.any_instance.stub(:authenticate_user!).and_return(true)
     sign_in @user
   end
-  after(:each) do
-    @rec1.delete
-    @rec2.delete
-  end
   describe "#index" do
     it "should show message" do
       User.any_instance.should_receive(:mark_as_read)

--- a/spec/models/event_jobs_spec.rb
+++ b/spec/models/event_jobs_spec.rb
@@ -13,9 +13,6 @@ describe 'event jobs' do
   end
   after(:each) do
     @gf.delete
-    @user.delete
-    @another_user.delete
-    @third_user.delete
     $redis.keys('events:*').each { |key| $redis.del key }
     $redis.keys('User:*').each { |key| $redis.del key }
     $redis.keys('GenericFile:*').each { |key| $redis.del key }

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -10,15 +10,6 @@ describe LocalAuthority do
     LocalAuthority.count.should == 0
     LocalAuthorityEntry.count.should == 0
   end
-  after(:each) do
-    LocalAuthorityEntry.all.each(&:destroy)
-    DomainTerm.all.each do |term|
-      term.local_authorities.each do |auth|
-        auth.destroy
-      end
-      term.destroy
-    end
-  end
   it "should harvest an ntriples RDF vocab" do
     LocalAuthority.harvest_rdf("genres", @nt)
     LocalAuthority.count.should == 1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'rspec/rails'
 require 'rspec/autorun'
 require 'capybara/rspec'
 require 'capybara/rails'
+require 'database_cleaner'
 
 require File.expand_path('../support/features', __FILE__)
 
@@ -57,6 +58,19 @@ RSpec.configure do |config|
 
   config.include Devise::TestHelpers, :type => :controller
   config.include EngineRoutes, :type => :controller
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end
 
 

--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "database_cleaner"
 
   spec.add_dependency 'rails', '>= 3.2.13', '< 5.0'
   spec.add_dependency 'activeresource' # No longer a dependency of rails 4.0

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'yaml_db', '0.2.3'
   gem.add_dependency 'rainbow', '1.1.4'
   gem.add_dependency 'font-awesome-sass-rails', '~>3.0'
+
+  gem.add_development_dependency "database_cleaner"
 end

--- a/tasks/sufia-dev.rake
+++ b/tasks/sufia-dev.rake
@@ -49,6 +49,7 @@ task :generate do
 
     `echo "gem 'sufia', :path=>'../../../sufia'
 gem 'capybara'
+gem 'database_cleaner'
 gem 'factory_girl_rails'
 gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'" >> spec/internal/Gemfile`
     puts "Copying generator"


### PR DESCRIPTION
Instead of relying on transactions to keep the database clean, this
gem provides the necessary cleaning scripts to ensure that the
database is in a pristine state before each spec.
