### PR TITLE
Replacing #run_fits! with #extract_metadata

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,11 +19,17 @@ $in_travis = !ENV['TRAVIS'].nil? && ENV['TRAVIS'] == 'true'
 
 if $in_travis
   # Monkey-patches the FITS runner to return the PDF FITS fixture
-  module Hydra 
+  module Hydra
     module Derivatives
       module ExtractMetadata
-        def run_fits!(path)
-          File.open(File.join(File.expand_path('../fixtures', __FILE__), 'pdf_fits.xml')).read
+        def extract_metadata
+          return unless has_content?
+          Hydra::FileCharacterization.characterize(content, filename_for_characterization, :fits) do |config|
+            config[:fits] = lambda { |filename|
+              filename = File.expand_path("../fixtures/pdf_fits.xml", __FILE__)
+              File.read(filename)
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
Hydra::Derivatives removed the private method :run_fits!
