### PR TITLE
Adding more verbose logging to specs

### DIFF
--- a/tasks/sufia-dev.rake
+++ b/tasks/sufia-dev.rake
@@ -26,7 +26,7 @@ end
 desc "Run specs"
 RSpec::Core::RakeTask.new(:rspec) do |t|
   t.pattern = '../**/*_spec.rb'
-  t.rspec_opts = "--colour -I ../"
+  t.rspec_opts = ["--colour -I ../", '--backtrace']
 end
 
 desc "Load fixtures"


### PR DESCRIPTION
This could be very helpful for Travis builds
And I need to test if the RDF gem is the culprit of a modify frozen
string error. Or the ActiveFedora gem. Or if it is isolated to Curate.
