### PR TITLE
Injecting Sufia::User after Hydra::User

### DIFF
--- a/sufia-models/lib/generators/sufia/models/install_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/install_generator.rb
@@ -55,7 +55,7 @@ This generator makes the following changes to your application:
   def inject_sufia_user_behavior
     file_path = "app/models/#{model_name.underscore}.rb"
     if File.exists?(file_path)
-      inject_into_class file_path, model_name.classify do
+      inject_into_file file_path, after: /include Hydra\:\:User.*$/ do
         "# Connects this user object to Sufia behaviors. " +
           "\n include Sufia::User\n"
       end


### PR DESCRIPTION
Given that Hydra is a dependency of Sufia the expected behavior for
the user file is:

```
class User
  include Hydra::User
  include Sufia::User
end
```

That way, any methods defined in Hydra::User can be overridden and
execute super in the expected order (i.e. User would lookup super in
Sufia::User and then Hydra::User)
