### PR TITLE
Add delete route to mailbox#delete matched route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Sufia::Engine.routes.draw do
   # Messages
   get 'notifications' => 'mailbox#index', :as => :mailbox
   match 'notifications/delete_all' => 'mailbox#delete_all', as: :mailbox_delete_all, via: [:get, :post]
-  match 'notifications/:uid/delete' => 'mailbox#delete', as: :mailbox_delete, via: [:get, :post]
+  match 'notifications/:uid/delete' => 'mailbox#delete', as: :mailbox_delete, via: [:delete, :get, :post]
 
   # User profile & follows
   resources :users, only: [:index, :show, :edit, :update], as: :profiles


### PR DESCRIPTION
Previously this route did not exist so the User Interface returned a route error.  After this change, an individual notification can be deleted in the User's mailbox.
