### PR TITLE
Notifications page includes date info in list of messages.

### DIFF
--- a/app/views/mailbox/index.html.erb
+++ b/app/views/mailbox/index.html.erb
@@ -5,14 +5,16 @@
 <div id="Data">
     <table class="table table-striped"> 
         <thead> 
-            <tr> 
-                <th>Subject</th> 
+            <tr>
+                <th>Date</th>
+                <th>Subject</th>
                 <th>Message</th> 
             </tr> 
         </thead> 
         <tbody> 
             <% @messages.each do |msg| %> 
-                <tr class="<%= cycle("","zebra") %>"> 
+                <tr class="<%= cycle("","zebra") %>">
+                   <td><%= time_ago_in_words(msg.last_message.created_at) %> ago </td>
                    <td><%= msg.last_message.subject.html_safe  %></td> 
                    <td><%= msg.last_message.body.html_safe  %></td> 
                    <td><%= link_to raw('<i class="icon-trash icon-large"></i>'),

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,6 +12,10 @@ FactoryGirl.define do
   factory :user_with_fixtures, :class => User do |u|
     email 'archivist2@example.com'
     password 'password'
+    after(:create) do |user|
+      message = '<span class="batchid ui-helper-hidden">fake_batch_noid</span>You\'ve got mail.'
+      User.batchuser().send_message(user, message, "Sample notification.")
+    end
   end
 
   factory :curator, :class => User do |u|

--- a/spec/features/notifications.rb
+++ b/spec/features/notifications.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe "Uploading files via web form" do
+
+  before do
+    sign_in :user_with_fixtures
+  end
+
+  it "should have an ingest screen" do
+    visit "/notifications"
+    page.should have_content "User Notifications"
+    page.find(:xpath, '//thead/tr').should have_content "Date"
+    page.find(:xpath, '//thead/tr').should have_content "Subject"
+    page.find(:xpath, '//thead/tr').should have_content "Message"
+    page.should have_content "Sample notification."
+    page.should have_content "less than a minute ago"
+    page.should have_content "You've got mail."
+  end
+
+end


### PR DESCRIPTION
refs a Scholarsphere ticket #3941 - "Notifications should include a date and time"
