### PR TITLE
In order to create single-use links you need edit permissions, not read permissions

### DIFF
--- a/app/controllers/single_use_links_controller.rb
+++ b/app/controllers/single_use_links_controller.rb
@@ -28,9 +28,19 @@ class SingleUseLinksController < ApplicationController
     end
   end
 
+  # Catch permission errors
+  rescue_from Hydra::AccessDenied, CanCan::AccessDenied do |exception|
+    if current_user and current_user.persisted?
+      redirect_to root_url, :alert => "You do not have sufficient privileges to create links to this document"
+    else
+      session["user_return_to"] = request.url
+      redirect_to new_user_session_url, :alert => exception.message
+    end
+  end
+
   protected
   def authorize_user!
-    authorize! :read, @asset
+    authorize! :edit, @asset
   end
 
   def load_asset

--- a/spec/controllers/single_use_links_controller_spec.rb
+++ b/spec/controllers/single_use_links_controller_spec.rb
@@ -21,9 +21,8 @@ describe SingleUseLinksController do
     controller.stub(:has_access?).and_return(true)
     controller.stub(:clear_session_user) ## Don't clear out the authenticated session
   end
-  describe "logged in user" do
+  describe "logged in user with edit permission" do
     before do
-      @user = FactoryGirl.find_or_create(:user)
       sign_in @user
       @now = DateTime.now
       DateTime.stub(:now).and_return(@now)
@@ -48,6 +47,31 @@ describe SingleUseLinksController do
       end
 
     end   
+  end
+
+  describe "logged in user without edit permission" do
+    before do
+      @other_user = FactoryGirl.find_or_create(:archivist)
+      @file.read_users << @other_user
+      @file.save
+      sign_in @other_user
+    end
+
+    describe "GET 'download'" do
+      it "and_return http success" do
+        get 'new_download', id:@file.pid
+        response.should_not be_success
+      end
+
+    end
+
+    describe "GET 'show'" do
+      it "and_return http success" do
+        get 'new_show', id:@file.pid
+        response.should_not be_success
+      end
+
+    end
   end
 
   describe "unkown user" do

--- a/sufia-models/app/models/concerns/sufia/user.rb
+++ b/sufia-models/app/models/concerns/sufia/user.rb
@@ -70,7 +70,7 @@ module Sufia::User
   end
 
   def ability
-    @ability ||= Ability.new(self)
+    @ability ||= ::Ability.new(self)
   end
 
   module ClassMethods


### PR DESCRIPTION
The proper way to address this would have been to implement a Sufia::Ability module and add an ability for SingleUseLink objects, but that proved pretty complicated and would potentially impact everyone who is using Sufia in annoying ways, so I just went with the simple route - changing the hard-coded :read to :edit.  If someone has suggestions, I'm listening. :ear: 
