### PR TITLE
Renaming intializers to be more descriptive

### DIFF
--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -3,7 +3,7 @@ require 'blacklight'
 require 'blacklight_advanced_search'
 require 'hydra/head'
 require 'hydra-batch-edit'
-require 'sufia/models'
+
 
 require 'rails_autolink'
 
@@ -19,6 +19,10 @@ module Sufia
       #{config.root}/app/models/datastreams
       #{Hydra::Engine.root}/app/models/concerns
     )
+
+    initializer 'sufia.initializer' do
+      require 'sufia/models'
+    end
   end
 
   autoload :Controller

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -35,12 +35,12 @@ module Sufia
         load File.expand_path('../../../tasks/sufia-models_tasks.rake', __FILE__)
       end
 
-      initializer "patches" do
+      initializer "sufia-models.patches" do
         require 'sufia/models/active_fedora/redis'
         require 'sufia/models/active_record/redis'
       end
 
-      initializer 'requires' do
+      initializer 'sufia-models.initializer', after: 'sufia-models.patches' do
         require 'activerecord-import'
         require 'hydra/derivatives'
         require 'sufia/models/model_methods'
@@ -59,7 +59,7 @@ module Sufia
         require 'sufia/models/solr_document_behavior'
       end
 
-      initializer 'configure' do
+      initializer 'sufia-models.configure', after: 'sufia-models.initialize' do
         Hydra::Derivatives.ffmpeg_path    = Sufia.config.ffmpeg_path
         Hydra::Derivatives.temp_file_base = Sufia.config.temp_file_base
         Hydra::Derivatives.fits_path      = Sufia.config.fits_path


### PR DESCRIPTION
By adding a name prefix we can more readily layer engines together.

I'm using an engine (curate) that wants to ensure the sufia-models are
initialized before curate is initialized.

I'm cribbing the information from Ryan Bigg's work on the Spree engine.
He is the person that wrote the Rails Engine guides.
