### PR TITLE
Modifying how zclip works when a flash player is not present, since the ...

### DIFF
--- a/app/assets/javascripts/sufia/single_use_link.js
+++ b/app/assets/javascripts/sufia/single_use_link.js
@@ -12,7 +12,7 @@ function getSingleUse(id) {
 // short hand for $(document).ready();
 $(function() {
     ZeroClipboard.setDefaults({ moviePath: "/assets/ZeroClipboard.swf" });
-    $.each($(".copypaste"), function() {
+    $.each($(".copypaste"), function(idx, item) {
         var clip = new ZeroClipboard();
         clip.on("dataRequested", function(client, args) {
             clip.setText(getSingleUse(this.id));
@@ -21,10 +21,14 @@ $(function() {
             alert("A single use link to " + args.text + " was copied to your clipboard.")
         })
         clip.on("noflash", function(client, args) {
-            alert("Your single-use link: " + getSingleUse(this.id))
+            $(item).bind('click', function(e) {
+                alert("Your single-use link (please copy): " + getSingleUse(item.id));
+            } );
         })
         clip.on("wrongflash", function(client, args) {
-            alert("Your single-use link: " + getSingleUse(this.id))
+            $(item).bind('click', function(e) {
+                alert("Your single-use link (please copy): " + getSingleUse(item.id));
+            } );
         })
         clip.glue($("#" + this.id))
     })


### PR DESCRIPTION
...event fires on page load not click as previously assumed.  Allow the user to see the link on click in an alert without it being added to the clipboard by zclip.
