### PR TITLE
correct typo in page; closes #336

### DIFF
--- a/app/views/static/help.html.erb
+++ b/app/views/static/help.html.erb
@@ -17,6 +17,6 @@ limitations under the License.
 <h1>User Support</h1>
  <h2>Service Inquiries and Requests</h2>
  <p>
-   Use app/views/static/about.html.erb to override this file.
+   Use app/views/static/help.html.erb to override this file.
  </p>
 


### PR DESCRIPTION
Minor typo but it has the effect of making About and Help look like they use the same page, which they don't.
