### PR TITLE
Refactor Trophies javascript.

### DIFF
--- a/app/assets/javascripts/sufia/trophy.js
+++ b/app/assets/javascripts/sufia/trophy.js
@@ -1,32 +1,47 @@
-// short hand for $(document).ready();
-$(function() {
+function toggleTrophy(url, anchor) {
+  $.ajax({
+     url: url,
+     type: "post",
+     success: function(data) {
+       gid = data.generic_file_id;
+       if (anchor.hasClass("trophy-on")){
+         // we've just removed the trophy
+         trophyOff(anchor);
+       } else {
+         trophyOn(anchor);
+       }
 
-   $('.trophy-class').click(function(){
-      var uid=$("#current_user").html();
-      $.ajax({
-         url:"/users/"+uid+"/trophy",
-         type:"post",
-         data: "file_id="+this.id,
-         success:function(data) {
-           gid = data.generic_file_id;
-           var oldclass = $('#'+gid).find('i').attr("class");
-           if (oldclass.indexOf("trophy-on") != -1){
-             $('#'+gid).find('i').attr("title", "Highlight work");
-           } else {
-             $('#'+gid).find('i').attr("title", "Unhighlight work");
-           }
-
-           $('#'+gid).find('i').toggleClass("trophy-on");
-           $('#'+gid).find('i').toggleClass("trophy-off");
-           if ($('#'+gid).data('removerow')) {
-             $('#trophyrow_'+gid).fadeOut(1000, function() {
-              $('#trophyrow_'+gid).remove();
-              });
-           }
-         }
-      })
+       anchor.toggleClass("trophy-on");
+       anchor.toggleClass("trophy-off");
+     }
+  });
+}
+// Trophy will be removed
+function trophyOff(anchor) {
+  if (anchor.data('removerow')) {
+    $('#trophyrow_'+gid).fadeOut(1000, function() {
+      $('#trophyrow_'+gid).remove();
     });
+  } else {
+    anchor.attr("title", "Highlight work");
+    $nodes = anchor.contents()
+    $nodes[$nodes.length - 1].nodeValue = anchor.data('add-text')
+  }
+}
 
-}); //closing function at the top of the page
+function trophyOn(anchor) {
+  anchor.attr("title", "Unhighlight work");
+  $nodes = anchor.contents()
+  $nodes[$nodes.length - 1].nodeValue = anchor.data('remove-text')
+}
+
+Blacklight.onLoad( function() {
+  // #this method depends on a "current_user" global variable having been set.
+  $('.trophy-class').click(function(evt){
+    evt.preventDefault();
+    anchor = $(this);
+    toggleTrophy(anchor.data('url'), anchor);
+  });
+});
 
 

--- a/app/helpers/trophy_helper.rb
+++ b/app/helpers/trophy_helper.rb
@@ -1,12 +1,20 @@
 # -*- coding: utf-8 -*-
 module TrophyHelper
- def display_trophy_link(user, noid)
-   trophyclass = "trophy-off"
-   trophytitle= "Highlight File on Profile"
-   if user.trophies.map(&:generic_file_id).include? noid
-     trophyclass = "trophy-on"
-   end
+ def display_trophy_link(user, noid, args={}, &block)
+   trophy = user.trophies.where(generic_file_id: noid).first
+   trophyclass = trophy ? "trophy-on" : "trophy-off"
 
-   link_to raw("<i class='#{trophyclass} glyphicon glyphicon-star'></i> #{trophytitle}"),"", :class=> 'trophy-class', :title => trophytitle, :id => noid,  :remote=>true # link to trophy
+   args[:add_text] ||= "Highlight File on Profile"
+   args[:remove_text] ||= "Unhighlight File"
+   text = trophy ? args[:remove_text] : args[:add_text]
+   args[:class] = [args[:class], "trophy-class #{trophyclass}"].compact.join(' ')
+   args[:data] ||= {}
+   args[:data]['add-text'] = args[:add_text]
+   args[:data]['remove-text'] = args[:remove_text]
+
+   args[:data][:url] = sufia.trophy_profile_path(user, file_id: noid)
+   link_to '#', class: args[:class], data: args[:data] do
+     yield(text)
+   end
  end
 end

--- a/app/views/dashboard/_index_partials/_list_files.html.erb
+++ b/app/views/dashboard/_index_partials/_list_files.html.erb
@@ -47,7 +47,9 @@
           <%= link_to raw('<i class="glyphicon glyphicon-trash"></i> Delete File'), sufia.generic_file_path(noid), :class => 'itemicon itemtrash', :title => 'Delete File', :method => :delete, :data => {:confirm => "Deleting a file from #{t('sufia.product_name')} is permanent. Click OK to delete this file from #{t('sufia.product_name')}, or Cancel to cancel this operation"} %>
         </li>
         <li>
-          <%= display_trophy_link(@user, noid) %>
+          <%= display_trophy_link(@user, noid) do |text| %>
+            <i class='glyphicon glyphicon-star'></i> <%= text %>
+          <% end %>
         </li>
       </ul>
     </div>

--- a/app/views/layouts/sufia-dashboard.html.erb
+++ b/app/views/layouts/sufia-dashboard.html.erb
@@ -16,7 +16,6 @@
             <%= link_to '<i class="glyphicon glyphicon-upload"></i> Upload File(s)'.html_safe, sufia.new_generic_file_path, {:class => "btn btn-primary"}  %><br />
           </div>
           <div class="col-xs-12 col-sm-9">
-            <div class="sr-only" id="current_user"><%=@user.user_key%></div>
             <div class="row">
               <%= render :partial => 'heading' %>
               <%= render :partial => 'search_form' %>

--- a/app/views/users/_contributions.html.erb
+++ b/app/views/users/_contributions.html.erb
@@ -3,13 +3,17 @@
   <% if @trophies.count > 0 %>
     <table>
       <% @trophies.each do |t| %>
-        <tr id="trophyrow_<%= Sufia::Noid.noidify(t.pid) %>">
+        <tr id="trophyrow_<%= t.noid %>">
           <td>
             <%= render partial: "dashboard/_index_partials/thumbnail_display", locals: {document: t, width: 90} %>
           </td>
           <td>
             <%= link_to display_title(t), sufia.generic_file_path(t) %>
-            <%= link_to raw("<i class='trophy-on icon-remove'></i>"), "", class: 'glyphicon glyphicon-trophy trophy-on', title: "Click to remove from Highlighted files.", id: Sufia::Noid.noidify(t.pid), remote: true, data: {removerow: "true"} if current_user == @user%>
+            <% if current_user == @user %>
+              <%= display_trophy_link current_user, t.noid, class: 'glyphicon glyphicon-trophy', data: {removerow: true} do %>
+                <i class='trophy-on icon-remove'></i>
+              <% end %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/users/_trophy_edit.html.erb
+++ b/app/views/users/_trophy_edit.html.erb
@@ -9,7 +9,7 @@
         <div class="controls">
           <%= link_to t, sufia.generic_file_path(t) %>
           <label class="checkbox fleft">
-            <%= check_box_tag "remove_trophy_#{t.id}" %> Yes &nbsp;
+            <%= check_box_tag "remove_trophy_#{t.noid}" %> Yes &nbsp;
           </label>
         </div>
       </dd>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,21 +6,19 @@ $('#myTab a').click(function (e) {
 })
 
 <% end %>
-  <div class="sr-only" id="current_user"><%=@user.user_key%></div>
   <div class="col-xs-12">
     <div class="pull-right">
       <%= render 'profile_actions' %>
     </div>
     <span class="col-xs-3">
       <%= render 'left_sidebar' %>
-    </span> <!-- /close span20 -->
+    </span>
 
-<!-- right col -->
+    <!-- right col -->
     <span class="col-xs-9">
-
       <%= render 'profile_tabs' %>
-    </span> <!-- /close span50 -->
-  </div><!-- /close span110 -->
+    </span>
+  </div>
 
 
 

--- a/spec/helpers/trophy_helper_spec.rb
+++ b/spec/helpers/trophy_helper_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe TrophyHelper do
+  describe "#display_trophy_link" do
+    let(:user) { FactoryGirl.create(:normal_user) }
+    let(:noid) { '9999' }
+
+    let(:text_attributes) { '[data-add-text="Highlight File on Profile"][data-remove-text="Unhighlight File"]' }
+    let(:url_attribute) { "[data-url=\"/users/#{user.to_param}/trophy?file_id=9999\"]" }
+
+    context "when there is no trophy" do
+      it "should have a link for highlighting" do
+        out = helper.display_trophy_link(user, noid) { |text| "foo #{text} bar" } 
+        node = Capybara::Node::Simple.new(out)
+        expect(node).to have_selector("a.trophy-class.trophy-off#{text_attributes}#{url_attribute}")
+        expect(node).to have_link 'foo Highlight File on Profile bar', href: '#'
+      end
+    end
+
+    context "when there is a trophy" do
+      before do
+        user.trophies.create(generic_file_id: noid)
+      end
+
+      it "should have a link for highlighting" do
+        out = helper.display_trophy_link(user, noid) { |text| "foo #{text} bar" } 
+        node = Capybara::Node::Simple.new(out)
+        expect(node).to have_selector("a.trophy-class.trophy-on#{text_attributes}#{url_attribute}")
+        expect(node).to have_link 'foo Unhighlight File bar', href: '#'
+      end
+
+      it "should allow removerow to be passed" do
+        out = helper.display_trophy_link(user, noid, data: {removerow: true}) { |text| "foo #{text} bar" } 
+        node = Capybara::Node::Simple.new(out)
+        expect(node).to have_selector("a.trophy-class.trophy-on[data-removerow=\"true\"]#{text_attributes}#{url_attribute}")
+      end
+    end
+  end
+end

--- a/sufia-models/app/models/concerns/sufia/user.rb
+++ b/sufia-models/app/models/concerns/sufia/user.rb
@@ -45,7 +45,7 @@ module Sufia::User
 
   def trophy_files
     trophies.map do |t|
-      GenericFile.load_instance_from_solr(Sufia::Noid.namespaceize(t.generic_file_id))
+      ::GenericFile.load_instance_from_solr(Sufia::Noid.namespaceize(t.generic_file_id))
     end
   end
 


### PR DESCRIPTION
All trophy scripts should use the TrophyHelper#display_trophy_link
Add the `trophy-class` back to the user's profile page.
The script now updates the link text depending on the current state of
the trophy.
Trophies should work with Turbolinks now.
