### PR TITLE
Restrict rails to ~> 4.0.  4.1.0 causes errors with mailboxer

### DIFF
--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency 'rails', '> 4.0.0', '< 5.0'
+  spec.add_dependency 'rails', '~> 4.0.0'
   spec.add_dependency 'activeresource', "~>4.0.0" # No longer a dependency of rails 4.0
 
   spec.add_dependency "hydra-head", "~> 7.0.1"


### PR DESCRIPTION
```
ActiveRecord::StatementInvalid:
       SQLite3::SQLException: near "*": syntax error: SELECT
       COUNT(DISTINCT conversations.*, DISTINCT conversations.*) FROM
       "conversations" INNER JOIN "notifications" ON
       "notifications"."conversation_id" = "conversations"."id" AND
       "notifications"."type" IN ('Message') INNER JOIN "receipts" ON
       "receipts"."notification_id" = "notifications"."id" WHERE
       "notifications"."type" = 'Message' AND "receipts"."mailbox_type"
       = 'inbox' AND "receipts"."trashed" = 'f' AND "receipts"."deleted"
       = 'f' AND "receipts"."receiver_id" = 1 AND
       "receipts"."receiver_type" = 'User' AND "receipts"."is_read" =
       'f'
```
