### PR TITLE
Noid.namespaceize should not append a second namespace onto a pid.

### DIFF
--- a/spec/services/noid_spec.rb
+++ b/spec/services/noid_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Sufia::Noid do
+  describe "#namespaceize" do
+    subject { Sufia::Noid.namespaceize(id) }
+
+    context "when the passed in pid doesn't have a namespace" do
+      let(:id) { 'abc123' }
+      it { should eq 'sufia:abc123' }
+    end
+    context "when the passed in pid has a namespace" do
+      let(:id) { 'ksl:abc123' }
+      it { should eq 'ksl:abc123' }
+    end
+  end
+end

--- a/sufia-models/app/services/sufia/noid.rb
+++ b/sufia-models/app/services/sufia/noid.rb
@@ -16,11 +16,8 @@ module Sufia
       end
 
       def namespaceize(identifier)
-        if identifier.start_with?(namespace)
-          identifier
-        else
-          "#{namespace}:#{identifier}"
-        end
+        return identifier if identifier.include?(':')
+        "#{namespace}:#{identifier}"
       end
 
       protected


### PR DESCRIPTION
Previously if the passed in identifier had a namespace that was not the
same as the configure namespace it would append a second namespace to
the identifier.  This would create an invalid pid.
