### PR TITLE
Alerts when editing permissions, fixes #498

### DIFF
--- a/app/assets/javascripts/sufia/permissions.js
+++ b/app/assets/javascripts/sufia/permissions.js
@@ -44,9 +44,9 @@ Blacklight.onLoad(function() {
         return false;
       }
 
-      if ($('#new_user_name_skel').val() == $('#file_owner').html()) {
-        $('#permissions_error_text').html("Cannot change owner permissions.");
-        $('#permissions_error').show();
+      if ( ($('#new_user_name_skel').val()+$('.add-on').text()) == $('#file_owner').data('depositor') ) {
+        $('#permissions_error_text').html("Cannot change depositor permissions.");
+        $('#permissions_error').removeClass('hidden');
         $('#new_user_name_skel').val('');
         $('#new_user_name_skel').focus();
         return false;
@@ -54,12 +54,12 @@ Blacklight.onLoad(function() {
 
       if (!is_permission_duplicate($('#new_user_name_skel').val())) {
         $('#permissions_error_text').html("This user already has a permission.");
-        $('#permissions_error').show();
+        $('#permissions_error').removeClass('hidden');
         $('#new_user_name_skel').focus();
         return false;
       }
       $('#permissions_error').html();
-      $('#permissions_error').hide();
+      $('#permissions_error').addClass('hidden');
 
       var un = $('#new_user_name_skel').val();
       var perm_form = $('#new_user_permission_skel').val();
@@ -84,12 +84,12 @@ Blacklight.onLoad(function() {
 
       if (!is_permission_duplicate($('#new_group_name_skel').val())) {
         $('#permissions_error_text').html("This group already has a permission.");
-        $('#permissions_error').show();
+        $('#permissions_error').removeClass('hidden');
         $('#new_group_name_skel').focus();
         return false;
       }
       $('#permissions_error').html();
-      $('#permissions_error').hide();
+      $('#permissions_error').addClass('hidden');
       // clear out the elements to add more
       $('#new_group_name_skel').val('');
       $('#new_group_permission_skel').val('none');
@@ -118,7 +118,7 @@ Blacklight.onLoad(function() {
       var td2 = $(document.createElement('td'));
       var remove = $('<button class="btn close">X</button>');
 
-      $('#save_perm_note').show();
+      $('#save_perm_note').removeClass('hidden');
 
       $('#new_perms').append(td1);
       $('#new_perms').append(td2);
@@ -143,8 +143,9 @@ Blacklight.onLoad(function() {
 
   $('.remove_perm').on('click', function() {
      var top = $(this).parent().parent();
-     top.hide(); // do not show the block
+     top.addClass('hidden'); // do not show the block
      top.find('.select_perm')[0].options[0].selected= true; // select the first otion which is none
+     $('#save_perm_note').removeClass('hidden');
      return false;
 
   });

--- a/app/views/generic_files/_permission_form.html.erb
+++ b/app/views/generic_files/_permission_form.html.erb
@@ -7,8 +7,8 @@
 <input type="hidden" name="generic_file[permissions][group][public]" value="1" />
 <input type="hidden" name="generic_file[permissions][group][registered]" value="2" />
 <h2><% if params[:controller] == 'batch' %>Bulk <% end %>Permissions <% if params[:controller] == 'batch' %><small>(applied to all files just uploaded)</small><% end %></h2>
-<div class="alert hide" id="save_perm_note">Permissions are <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
-<div class="alert alert-error hide" id="permissions_error"><a class="close" data-dismiss="alert" href="#">×</a><span id="permissions_error_text"></span></div>
+<div class="alert alert-info hidden" id="save_perm_note">Permissions are <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
+<div class="alert alert-warning hidden" id="permissions_error"><a class="close" data-dismiss="alert" href="#">×</a><span id="permissions_error_text"></span></div>
 <div class="well">
   <div class="row">
     <p class="pull-right">
@@ -105,7 +105,11 @@
     <th width="40%">Access Level</th>
   </tr>
   <tr id="file_permissions">
-    <td><%= label_tag :owner_access, "Depositor (<span id=\"file_owner\">#{link_to_profile depositor}</span>)".html_safe, class: "control-label" %></td>
+    <td>
+      <%= label_tag :owner_access, class: "control-label" do %>
+        Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>) 
+      <% end %>
+    </td>
     <td>
     <%= Sufia.config.owner_permission_levels.keys[0] %>
     </td>


### PR DESCRIPTION
This uses Bootstrap 3's `hidden` class and the jQuery `removeClass()` and `addClass()` methods instead of `show()` and `hide()`.
