### PR TITLE
Don't convert avatar images, fixes #527

### DIFF
--- a/sufia-models/app/models/sufia/avatar_uploader.rb
+++ b/sufia-models/app/models/sufia/avatar_uploader.rb
@@ -1,16 +1,9 @@
 class Sufia::AvatarUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
   include CarrierWave::Compatibility::Paperclip
-
-  attr_accessor :original_size
-
-  before :cache, :get_original_file_size
-  
-  process convert: 'png'
   
   version :medium do
     process resize_to_limit: [300, 300]
-    
   end
 
   version :thumb do
@@ -24,9 +17,5 @@ class Sufia::AvatarUploader < CarrierWave::Uploader::Base
   def extension_white_list
     %w(jpg jpeg png gif bmp tif tiff)
   end
-
-  def get_original_file_size file
-    @original_size = file.size
-  end
-
+  
 end

--- a/sufia-models/app/models/sufia/avatar_validator.rb
+++ b/sufia-models/app/models/sufia/avatar_validator.rb
@@ -2,9 +2,7 @@ module Sufia
   class AvatarValidator < ActiveModel::Validator
     def validate(record)
       return unless record.avatar?
-      unless record.avatar.original_size.nil?
-        record.errors.add(:avatar_file_size, 'must be less than 2MB') if record.avatar.original_size > 2.megabytes.to_i
-      end
+      record.errors.add(:avatar_file_size, 'must be less than 2MB') if record.avatar.size > 2.megabytes.to_i
     end
   end
 end


### PR DESCRIPTION
This is a better solution to #356.  After discussion in #525, we decided it's better to just not convert any of the uploaded Avatar images to png files.
