### PR TITLE
Configure dashboard notification limits

### DIFF
--- a/app/helpers/sufia/dashboard_helper_behavior.rb
+++ b/app/helpers/sufia/dashboard_helper_behavior.rb
@@ -13,7 +13,7 @@ module Sufia
       if @notifications.empty?
         t('sufia.dashboard.no_notifications')
       else
-        render partial: "mailbox/notifications", locals: { messages: @notifications }
+        render partial: "mailbox/notifications", locals: { messages: notifications_for_dashboard }
       end
     end
 
@@ -27,6 +27,16 @@ module Sufia
 
     def number_of_collections user=current_user
       Collection.where(Solrizer.solr_name('depositor', :stored_searchable) => user.user_key).count
+    end
+
+    def notifications_for_dashboard
+      @notifications.limit(Sufia.config.max_notifications_for_dashboard)
+    end
+
+    def link_to_additional_notifications
+      if @notifications.count > Sufia.config.max_notifications_for_dashboard
+        link_to t('sufia.dashboard.additional_notifications'), sufia.notifications_path
+      end
     end
 
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -49,5 +49,6 @@
   <div class="portal">
     <h3><%= t("sufia.dashboard.user_notifications") %></h3>
     <%= render_recent_notifications %>
+    <%= link_to_additional_notifications %>
   </div>
 </div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -47,15 +47,16 @@ en:
     homepage:
       featured_works:       'Featured Works'
     dashboard:
-      title:                "My Dashboard"
-      greeting:             "Hello, "
-      upload:               "Upload"
-      create_collection:    "Create Collection"
-      view_files:           "View Files"
-      user_activity:        "User Activity"
-      no_activity:          "User has no recent activity"
-      user_notifications:   "User Notifications"
-      no_notifications:     "User has no notifications"
+      title:                    "My Dashboard"
+      greeting:                 "Hello, "
+      upload:                   "Upload"
+      create_collection:        "Create Collection"
+      view_files:               "View Files"
+      user_activity:            "User Activity"
+      no_activity:              "User has no recent activity"
+      user_notiticiations:      "User Notifications"
+      no_notifications:         "User has no notifications"
+      additional_notifications: "See all notifications"
       stats:
         heading:            "Your Statistics"
         files:              "Files you've deposited"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,7 +14,9 @@ FactoryGirl.define do
     factory :user_with_mail do
       after(:create) do |user|
         message = '<span class="batchid ui-helper-hidden">fake_batch_noid</span>You\'ve got mail.'
-        User.batchuser().send_message(user, message, "Sample notification.")
+        (1..6).each do |number|
+          User.batchuser().send_message(user, message, "Sample notification #{number.to_s}.")
+        end
       end
     end
 

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -12,7 +12,7 @@ describe "Notifications page" do
     page.find(:xpath, '//thead/tr').should have_content "Date"
     page.find(:xpath, '//thead/tr').should have_content "Subject"
     page.find(:xpath, '//thead/tr').should have_content "Message"
-    page.should have_content "Sample notification."
+    page.should have_content "Sample notification 1."
     page.should have_content "less than a minute ago"
     page.should have_content "You've got mail."
   end

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -74,16 +74,39 @@ describe "dashboard/index.html.erb" do
           { action: 'so and so edited their profile', timestamp: @now },
           { action: 'so and so uploaded a file', timestamp: (@now - 360 ) }
         ])
-        assign(:notifications, FactoryGirl.create(:user_with_mail).mailbox.inbox)
       end
 
       it "should include recent activities and notifications" do
         render
         expect(rendered).to include "so and so edited their profile"
         expect(rendered).to include "6 minutes ago"
-        expect(rendered).to include "You've got mail"
-        expect(rendered).to include "Sample notification"
       end
+
+    end
+
+    context "with notifications" do
+
+      before do
+        assign(:notifications, FactoryGirl.create(:user_with_mail).mailbox.inbox)
+      end
+
+      it "shows a link to all notifications" do
+        render
+        expect(rendered).to include "See all notifications"
+      end
+
+      it "defaults to a limited number of notifications" do
+        render
+        expect(rendered).to include "Sample notification 2."
+        expect(rendered).to_not include "Sample notification 1."
+      end
+
+      it "allows showing more notifications" do
+        Sufia.config.max_notifications_for_dashboard = 6
+        render
+        expect(rendered).to include "Sample notification 1."
+      end
+
 
     end
 

--- a/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
@@ -11,6 +11,8 @@ Sufia.config do |config|
 
   config.max_days_between_audits = 7
 
+  config.max_notifications_for_dashboard = 5
+
   config.cc_licenses = {
     'Attribution 3.0 United States' => 'http://creativecommons.org/licenses/by/3.0/us/',
     'Attribution-ShareAlike 3.0 United States' => 'http://creativecommons.org/licenses/by-sa/3.0/us/',

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -25,6 +25,7 @@ module Sufia
       config.enable_local_ingest = nil
       config.analytics = false
       config.queue = Sufia::Resque::Queue
+      config.max_notifications_for_dashboard = 5
 
       config.autoload_paths += %W(
         #{config.root}/lib/sufia/models/jobs


### PR DESCRIPTION
Provides a configurable way to limit the number of notifications displayed on the dashboard, with a link to all notifications if that number is exceeded.  Fixes #537 
