### PR TITLE
Create collection and upload buttons

### DIFF
--- a/app/views/my/index.html.erb
+++ b/app/views/my/index.html.erb
@@ -37,7 +37,9 @@
 <%= render partial: 'document_list' %>
 
 <% content_for :sidebar do %>
-    <%= render partial: 'facets' %>
+  <%= link_to t("sufia.dashboard.upload"), sufia.new_generic_file_path, class: "btn btn-primary" %>
+  <%= link_to t("sufia.dashboard.create_collection"), collections.new_collection_path, id: "hydra-collection-add", class: "btn btn-primary" %>
+  <%= render partial: 'facets' %>
 <% end %>
 
 <%= render 'results_pagination' %>

--- a/spec/features/browse_dashboard_files_spec.rb
+++ b/spec/features/browse_dashboard_files_spec.rb
@@ -61,6 +61,14 @@ describe "Browse Dashboard" do
       expect(page).to have_content('3 files')
     end
 
+    it "should display a button for uploading files" do
+      click_link('Upload')
+    end
+
+    it "should display a button for creating collections" do
+      click_link('Create Collection')
+    end
+
   end
 
   context "within my collections page" do


### PR DESCRIPTION
Display links for creating collections and uploading files in each of the dashboard sub-pages, ex. files, collections, highlights and shares.  Fixes #535 
