### PR TITLE
Adding header metadata so the page reduces to a small size on the phone.

### DIFF
--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -2,6 +2,9 @@
 <link href='https://fonts.googleapis.com/css?family=Lato:300,400' rel='stylesheet' type='text/css'>
 <meta charset="utf-8" />
 
+<!-- added for use on small devices like phones" -->
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+
 <title><%= h(@page_title || application_name) %></title>
 <!-- application css -->
 <%= stylesheet_link_tag 'application' %>


### PR DESCRIPTION
This fixes the issue when you bring up sufia on a small device it just shows a really small version of the page instead of the compressed column view of the page.
