### PR TITLE
Redirect to dashboard upon login

### DIFF
--- a/app/controllers/concerns/sufia/controller.rb
+++ b/app/controllers/concerns/sufia/controller.rb
@@ -41,6 +41,11 @@ module Sufia::Controller
     end
   end
 
+  # Override Devise method to redirect to dashboard after signing in
+  def after_sign_in_path_for(resource)
+    sufia.dashboard_index_path
+  end
+
   protected
 
   ### Hook which is overridden in Sufia::Ldap::Controller

--- a/spec/features/display_dashboard_spec.rb
+++ b/spec/features/display_dashboard_spec.rb
@@ -1,35 +1,38 @@
 require 'spec_helper'
 
-describe "Display User Dashboard" do
+describe "The Dashboard" do
 
   before do
     sign_in :user_with_fixtures
-    visit "/dashboard"
   end
 
-  it "should show the user's information" do
-    page.should have_content "My Dashboard"
-    page.should have_content "User Activity"
-    page.should have_content "User Notifications"
-    page.should have_content "Your Statistics"
-  end
+  context "upon sign-in" do
 
-  it "should let the user upload files" do
-    click_link "Upload"
-    page.should have_content "Upload"
-  end
+    it "should show the user's information" do
+      page.should have_content "My Dashboard"
+      page.should have_content "User Activity"
+      page.should have_content "User Notifications"
+      page.should have_content "Your Statistics"
+    end
 
-  it "should let the user create collections" do
-    click_link "Create Collection"
-    page.should have_content "Create New Collection"
-  end
+    it "should let the user upload files" do
+      click_link "Upload"
+      page.should have_content "Upload"
+    end
 
-  it "should let the user view files" do
-    click_link "View Files"
-    page.should have_content "My Files"
-    page.should have_content "My Collections"
-    page.should have_content "My Highlights"
-    page.should have_content "Files Shared with Me"
+    it "should let the user create collections" do
+      click_link "Create Collection"
+      page.should have_content "Create New Collection"
+    end
+
+    it "should let the user view files" do
+      click_link "View Files"
+      page.should have_content "My Files"
+      page.should have_content "My Collections"
+      page.should have_content "My Highlights"
+      page.should have_content "Files Shared with Me"
+    end
+
   end
 
 end


### PR DESCRIPTION
This overrides a method in Devise to redirect the user to the dashboard after they've logged in.  It's somewhat implementation-specific, so it could be argued that it doesn't belong in Sufia proper.  We at Penn State would implement locally instead.  Thoughts?
