### PR TITLE
Removing username in mobile view

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,8 +1,10 @@
 <% if user_signed_in? %>
     <div class="btn-group" id="user_utility_links">
       <%= render partial: 'users/notify_link' %>
-      <a href="<%= sufia.profile_path(current_user) %>" class="btn btn-default " id="profile_link" title="click for User Profile"><span class="glyphicon glyphicon-user">&nbsp;</span><%= current_user.name %>
-      </a>
+      <%= link_to sufia.profile_path(current_user), class: "btn btn-default", id: "profile_link", title: "click for User Profile" do %>
+        <span class="glyphicon glyphicon-user"></span>
+        <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
+      <% end %>
       <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#"><span class="caret" title="click for additional menu options"></span></a>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li><%= link_to raw('<span class="glyphicon glyphicon-dashboard"></span> my dashboard'), sufia.dashboard_index_path, id: 'dashboard_nav_link' %></li>


### PR DESCRIPTION
When re-sizing the page to its smallest, the user_utility_links button group will break.  The problem is that the text of the username is too long to fit in the space.  I've opted to simply hide the text altogether, since this isn't something can really control, other than perhaps trying to make the text really small, truncating and using an ellipsis, using different text, or some combination of the above.

What say you: @jcoyne @mtribone @mjgiarlo @cam156 
