### PR TITLE
Rendering itemprop for custom show fields

### DIFF
--- a/app/views/records/show_fields/_default.html.erb
+++ b/app/views/records/show_fields/_default.html.erb
@@ -1,5 +1,5 @@
-<% Array(generic_file[key]).each do |v| %>
-  <span itemprop="#{key}" itemscope itemtype="http://schema.org/Thing">
+<% Array(record[key]).each do |v| %>
+  <span itemprop="<%= key %>" itemscope itemtype="http://schema.org/Thing">
     <%= v %>
   </span>
   <br />

--- a/spec/views/collections/_show_descriptions.html.erb_spec.rb
+++ b/spec/views/collections/_show_descriptions.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'collections/_show_descriptions.html.erb' do
+  context 'displaying a custom collection' do
+    before do
+      @collection = mock_model(Collection)
+      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+      allow(@collection).to receive(:date_modified).and_return(["today"])
+      allow(@collection).to receive(:terms_for_display).and_return([:date_modified])
+    end
+
+    it "should draw the metadata fields for collection" do
+      render
+      expect(rendered).to have_content 'Date modified'
+      expect(rendered).to include('itemprop="date_modified"')
+    end
+  end
+
+end


### PR DESCRIPTION
I discovered this yesterday with getting SS up with the latest Sufia.  I think it should be fairly self-explanatory, but when you try to use a field that isn't defined by one of Sufia's models, it uses the default, which wasn't working correctly.
@mjgiarlo does that sound right?
