### PR TITLE
better responsive header and search form

### DIFF
--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -98,5 +98,5 @@ $gray-lighter: #eee;
   margin-top: 7px;
 }
 #search-submit-header {
-  margin-left: -15px;
+  border: none;
 }

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -3,7 +3,7 @@
     <div class="col-xs-6 col-sm-7">
       <%= render partial: '/logo' %>
     </div><!-- /.col-xs-5 -->
-    <div class="col-xs-6 col-sm-5">
+    <div class="col-xs-6 col-sm-5 text-right">
         <%= render partial: '/user_util_links' %>
     </div><!-- /.col-xs-7 -->
   </div><!-- /.row -->

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,9 +1,8 @@
 <%= form_tag search_form_action, method: :get, id: "search-form-header", role: "search" do %>
   <%= render_hash_as_hidden_fields(params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
-  <div class="container-fluid">
-    <div class="row">
 
-      <div class="col-xs-10">
+    <div class="row">
+      <div class="col-xs-12">
         <div class="input-group">
           <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", 
               placeholder: t("sufia.search.form.q.placeholder") %>
@@ -12,6 +11,9 @@
           <label class="sr-only" for="search-field-header"><%= t("sufia.search.form.q.label") %></label>
 
           <div class="input-group-btn">
+            <button type="submit" class="btn btn-primary" id="search-submit-header">
+              <%= t('sufia.search.button.html') %>
+            </button>
             <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
               <span data-search-element="label"><%= t("sufia.search.form.option.all.label_long") %></span>
               <span class="caret"></span>
@@ -44,16 +46,9 @@
 
             </ul>
           </div><!-- /.input-group-btn -->
-        
+
         </div><!-- /.input-group -->
       </div><!-- /text field dropdown -->
-      
-      <div class="col-xs-2">
-        <button type="submit" class="btn btn-primary" id="search-submit-header">
-          <span class="glyphicon glyphicon-search"></span> Go
-        </button>
-      </div><!-- /.go -->
-    
     </div><!-- /.row -->
-  </div><!-- /.container-fluid -->
+
 <% end %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -29,6 +29,9 @@ en:
           my_shares:
             label_short:  "My Shares"
             label_long:   "My Shares"
+      button:
+        html: '<span class="glyphicon glyphicon-search"></span> Go'
+        text: "Search"
     upload:
       my_computer:
         tab_label: "My Computer"


### PR DESCRIPTION
This is purely cosmetic...  This aligns the recently-refactored user_util_links partial with the search form in the header.  Simplifying things a bit, I used Bootstrap's input-group class to put the search form into one row.  That way, the margins are consistent across various display sizes.  The only visual change is that the submit button comes before the dropdown... this is meet Bootstrap's defaults, which could probably be overridden somehow.

The text of the button remains with the icon, but if you change it to just "Search" the form would be semantically correct, i.e. "Search all of Sufia", "Search My Collections", etc.

@mtribone care to weigh-in?  What would users' reactions be?
