### PR TITLE
Replaced orphan "What's This" button with two individual tooltips for... 

### DIFF
--- a/app/helpers/sufia/records_helper_behavior.rb
+++ b/app/helpers/sufia/records_helper_behavior.rb
@@ -8,11 +8,13 @@ module Sufia
      more_or_less_button(key, 'remover', '-')
     end
 
-    def help_icon(key)
-      link_to '#', id: "generic_file_#{key.to_s}_help", rel: 'popover', 
-        'data-content' => metadata_help(key),
-        'data-original-title' => get_label(key) do
-          content_tag 'i', '', class: "glyphicon glyphicon-question-sign large-icon"
+    def help_icon(key, content = nil, title = nil)
+      content = content || metadata_help(key)
+      title = title || get_label(key)
+      link_to '#', id: "generic_file_#{key.to_s}_help", rel: 'popover',
+              'data-content' => content,
+              'data-original-title' => title do
+        content_tag 'i', '', class: "glyphicon glyphicon-question-sign large-icon"
       end
     end
 

--- a/app/views/generic_files/_groups_description.html.erb
+++ b/app/views/generic_files/_groups_description.html.erb
@@ -1,5 +1,6 @@
-    <p>
-    The list of groups in the drop-down marked &quot;Select a group&quot; is a list of User Managed Groups that you are a member of, and are managed by <%=t('sufia.institution_name') %>'s ITS department.  You may select a specific group and assign an access
-    level for a file within <%=t('sufia.product_name') %>, similarly to adding user access levels.  However, management of these groups and their membership is handled centrally at <a href="http://umg.its.psu.edu" target="_blank">umg.its.psu.edu</a>.  
-    </p>
+<p>The list of groups in the drop-down marked &quot;Select a group&quot; is a list of User Managed Groups that
+  you are a member of, and are managed by <%=t('sufia.institution_name') %>'s ITS department.  You may select
+  a specific group and assign an access level for a file within <%=t('sufia.product_name') %>, similarly to
+  adding user access levels.  However, management of these groups and their membership is handled centrally
+  at <a href='http://umg.its.psu.edu' target='_blank'>umg.its.psu.edu</a>.</p>
 

--- a/app/views/generic_files/_permission_form.html.erb
+++ b/app/views/generic_files/_permission_form.html.erb
@@ -6,61 +6,23 @@
 
 <input type="hidden" name="generic_file[permissions][group][public]" value="1" />
 <input type="hidden" name="generic_file[permissions][group][registered]" value="2" />
-<h2><% if params[:controller] == 'batch' %>Bulk <% end %>Permissions <% if params[:controller] == 'batch' %><small>(applied to all files just uploaded)</small><% end %></h2>
+
+<h2><% if params[:controller] == 'batch' %>Bulk <% end %>Permissions <% if params[:controller] == 'batch' %>
+      <small>(applied to all files just uploaded)</small><% end %>
+</h2>
+
 <div class="alert alert-info hidden" id="save_perm_note">Permissions are <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
 <div class="alert alert-warning hidden" id="permissions_error"><a class="close" data-dismiss="alert" href="#">×</a><span id="permissions_error_text"></span></div>
+
 <div class="well">
-  <div class="row">
-    <p class="pull-right">
-    <!-- Button to trigger modal -->
-    <a href="#myModal" role="button" class="btn btn-warning" data-toggle="modal">What's this <i class="glyphicon glyphicon-question-sign large-icon"></i></a>
-<!-- Modal -->
-<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"></button>
-        <h2 id="myModalLabel"><%=t('sufia.product_name') %> Permissions</h2>
-      </div>
-      <div class="modal-body">
-        <h3>Visibility</h3>
-        <p>This setting will determine who can view your file, and the associated metadata. Setting
-        the visibility to <span class="label label-success">Open Access</span> will allow your content to be discovered in Google and viewed by anyone.
-        The visibility setting <span class="label label-info"><%=t('sufia.institution_name') %></span> will only allow users who are logged into <%=t('sufia.product_name') %>
-        (via WebAccess) to view the content.  Files that are marked <span class="label label-danger">Private</span> are only able to be viewed
-        by users and/or groups that have been given specific access in the &quot;Share With&quot; section.
-        </p>
 
-        <p>
-        Permissions in <%=t('sufia.product_name') %> are hierarchical.  This means that you cannot set the visibility of a file to <span class="label label-success">Open Access</span> or
-        <span class="label label-info"><%=t('sufia.institution_name') %></span> and simultaneously try to restrict the access of a single user. However, you may mark the visibility of
-        a file as <span class="label label-danger">Private</span> and then grant access to particular users and/or groups for that file in the &quot;Share With&quot;
-        section.
-        </p>
-
-        <h3>Share With</h3>
-        <p>You may grant &quot;View/Download&quot; or &quot;Edit&quot;  access for specific users and/or groups to files. Enter
-        a valid <%=t('sufia.account_name') %>, one at a time, select the access level for that user and click
-        <button class="btn btn-xs btn-inverse" onclick="return false;"><i class="glyphicon glyphicon-plus" ></i>Add</button>.
-        </p>
-
-        <%= render partial: 'generic_files/groups_description' %>
-
-        <h3>Permission Definitions</h3>
-        <p>
-        <strong>View/Download:</strong> this file (both contents and metadata) is accessible from within <%=t('sufia.product_name') %>.<br />
-        <strong>Edit:</strong> this file (both contents and metadata) can be edited.  You may only grant this permission to <%=t('sufia.institution_name') %> users and/or groups.
-        </p>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-primary" data-dismiss="modal">Close</button>
-      </div>
-    </div>
-  </div>
-</div>
-    </p>
-  </div>
-  <h3>Visibility - <small>who should have the ability to read and download</small></h3>
+  <!-- Visibility -->
+  <% visibility_text = capture do %>
+    <%= render partial: 'generic_files/visibility' %>
+  <% end %>
+  <h3>Visibility - <small>who should have the ability to read and download</small>
+    <span id="visibility_tooltip" class="h5"><%= help_icon('visibility', visibility_text) %></span>
+  </h3>
   <div class="radio">
     <label>
       <input type="radio" id="visibility_open" name="visibility" value="<%=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if !public_perm.blank? %> checked="true"<% end %>/> <span class="label label-success">Open Access</span> Visible to the world.
@@ -72,8 +34,15 @@
       <input type="radio" id="visibility_restricted" name="visibility" value="<%=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>"<% if registered_perm.blank? and public_perm.blank?%> checked="true"<% end %> /> <span class="label label-danger">Private</span> Visible to users/groups specified below, if any.
     </label>
   </div>
+
+  <!-- Share With -->
+  <% share_with_text = capture do %>
+    <%= render partial: 'generic_files/share_with' %>
+  <% end %>
   <div class="row">
-      <h3 class="col-sm-12">Share With <small>(optional)</small></h3>
+    <h3 class="col-sm-12">Share With <small>(optional)</small>
+      <span id="share_with_tooltip" class="h5"><%= help_icon('share_with', share_with_text) %></span>
+    </h3>
   </div>
   <div class="form-group">
     <div id="new-user">
@@ -106,7 +75,9 @@
       </div>
     </div>
   </div>
+
 </div><!-- /.well -->
+
 <table class="table table-bordered">
   <tr>
     <th width="60%">Person/Group</th>

--- a/app/views/generic_files/_share_with.html.erb
+++ b/app/views/generic_files/_share_with.html.erb
@@ -1,0 +1,14 @@
+<p>You may grant &quot;View/Download&quot; or &quot;Edit&quot; access for specific users and/or groups to files.
+  Enter a valid <%=t('sufia.account_name') %>, one at a time, select the access level for that user and click
+  <button class='btn btn-xs btn-inverse' onclick='return false;'><i class='glyphicon glyphicon-plus' ></i>Add</button>.
+</p>
+
+<%= render partial: 'generic_files/groups_description' %>
+
+<h5><b>Permission Definitions</b></h5>
+<p>
+  <strong>View/Download:</strong> this file (both contents and metadata) is accessible from within
+  <%=t('sufia.product_name') %>.<br />
+  <strong>Edit:</strong> this file (both contents and metadata) can be edited. You may only grant
+  this permission to <%=t('sufia.institution_name') %> users and/or groups.
+</p>

--- a/app/views/generic_files/_visibility.html.erb
+++ b/app/views/generic_files/_visibility.html.erb
@@ -1,0 +1,17 @@
+<p>This setting will determine who can view your file, and the associated metadata. Setting
+  the visibility to <span class='label label-success'>Open Access</span> will allow your
+  content to be discovered in Google and viewed by anyone. The visibility setting
+  <span class='label label-info'><%=t('sufia.institution_name') %></span> will only allow
+  users who are logged into <%=t('sufia.product_name') %> (via WebAccess) to view the content.
+  Files that are marked <span class='label label-danger'>Private</span> are only able to be viewed
+  by users and/or groups that have been given specific access in the &quot;Share With&quot; section.
+</p>
+
+<p>
+  Permissions in <%=t('sufia.product_name') %> are hierarchical. This means that you cannot set
+  the visibility of a file to <span class='label label-success'>Open Access</span> or
+  <span class='label label-info'><%=t('sufia.institution_name') %></span> and simultaneously
+  try to restrict the access of a single user. However, you may mark the visibility of
+  a file as <span class='label label-danger'>Private</span> and then grant access to
+  particular users and/or groups for that file in the &quot;Share With&quot; section.
+</p>

--- a/spec/views/batch/edit.html.erb_spec.rb
+++ b/spec/views/batch/edit.html.erb_spec.rb
@@ -22,8 +22,14 @@ describe 'batch/edit.html.erb' do
     @page = Capybara::Node::Simple.new(rendered)
   end
 
-  it "should draw modal for license" do
-    expect(@page).to have_selector("div#myModal .modal-dialog .modal-content", count: 1)
+  it "should draw tooltip for visibility" do
+    expect(@page).to have_selector("span#visibility_tooltip", count: 1)
+    expect(@page).to have_selector("a#generic_file_visibility_help", count: 1)
+  end
+
+  it "should draw tooltip for share_with" do
+    expect(@page).to have_selector("span#share_with_tooltip", count: 1)
+    expect(@page).to have_selector("a#generic_file_share_with_help", count: 1)
   end
 
   it "should draw modal for rights" do


### PR DESCRIPTION
..."Visibility" and "Share With" help on the Upload file page.

The following two screenshots show the new layout:

![whats_this_is_gone](https://cloud.githubusercontent.com/assets/568286/3554259/5e2a16c6-090b-11e4-9683-c9e6bfab575b.png)

![help_text](https://cloud.githubusercontent.com/assets/568286/3554260/60c7697e-090b-11e4-9124-cf0e868ce824.png)
