### PR TITLE
License Descriptions button is gone from the Upload page and instead the...

### DIFF
--- a/app/helpers/sufia/records_helper_behavior.rb
+++ b/app/helpers/sufia/records_helper_behavior.rb
@@ -18,6 +18,12 @@ module Sufia
       end
     end
 
+    def help_icon_modal(modal_id)
+      link_to '#' + modal_id, id: "generic_file_#{modal_id}_help_modal", rel: 'button', data: { toggle: 'modal' } do
+        content_tag 'i', '', class: 'glyphicon glyphicon-question-sign large-icon'
+      end
+    end
+
     def metadata_help(key)
       I18n.t("sufia.metadata_help.#{key}", default: key.to_s.humanize)
     end

--- a/app/views/batch/_metadata.html.erb
+++ b/app/views/batch/_metadata.html.erb
@@ -60,12 +60,12 @@
       <%= f.label :rights, '<span class="error">*</span> Rights'.html_safe, class: "control-label" %>
       <div id="additional_rights_clone">
         <%= f.select "rights", options_for_select(Sufia::Engine::config.cc_licenses, 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'), required: true %>
-          <button class="adder btn" name="additional_rights" id="additional_rights_submit">+<span class="sr-only">add another Rights</span></button>
+        <button class="adder btn" name="additional_rights" id="additional_rights_submit">+<span class="sr-only">add another Rights</span></button>
         &nbsp;
-        <%= help_icon(:rights) %>
+        <%= help_icon_modal('rightsModal') %>
         <%= render partial: "generic_files/rights_modal" %>
-
       </div>
+
       <div id="additional_rights_elements"></div>
     </div>
 

--- a/app/views/generic_files/_rights_modal.html.erb
+++ b/app/views/generic_files/_rights_modal.html.erb
@@ -1,6 +1,4 @@
 <div class="modal-div">
-<!-- Button to trigger modal -->
-<a href="#rightsModal" role="button" class="btn btn-warning fright" data-toggle="modal">License Descriptions <i class="glyphicon glyphicon-question-sign large-icon"></i></a>
 <!-- Modal -->
 <div class="modal fade" id="rightsModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="modal-dialog">

--- a/spec/helpers/records_helper_spec.rb
+++ b/spec/helpers/records_helper_spec.rb
@@ -23,6 +23,18 @@ describe RecordsHelper do
     i.attr('class').should == 'glyphicon glyphicon-question-sign large-icon'
   end
 
+  specify "draws help_icon_modal" do
+    str = String.new(helper.help_icon_modal('myModal'))
+    doc = Nokogiri::HTML(str)
+    a = doc.xpath('//a').first
+
+    expect(a.attr('href')).to eq('#myModal')
+    expect(a.attr('data-toggle')).to eq('modal')
+    expect(a.attr('id')).to eq('generic_file_myModal_help_modal')
+    i = a.children.first
+    expect(i.attr('class')).to eq('glyphicon glyphicon-question-sign large-icon')
+  end
+
   describe "download links" do
 
     before :all do


### PR DESCRIPTION
... descriptions are displayed when clicking on the question mark icon. Descriptions are still displayed in a Modal window since there is too much text to display them as a tooltip.

![license_button_gone](https://cloud.githubusercontent.com/assets/568286/3598988/f667cf32-0ce9-11e4-8d7b-76f8bf30a618.png)
