### PR TITLE
Show collections on generic_file view

### DIFF
--- a/app/views/generic_files/_show_collections.html.erb
+++ b/app/views/generic_files/_show_collections.html.erb
@@ -1,0 +1,17 @@
+    <h2 class="non lower">Collections</h2>
+    <% if @generic_file.collections.blank? %>
+        <p><%= t('sufia.file.collections_list.empty') %></p>
+    <% else %>
+        <p><%= t('sufia.file.collections_list.heading') %></p>
+      <table class="table table-striped">
+        <tbody>
+        <% @generic_file.collections.each do |collection| %>
+        <tr class="collection attributes">
+          <%= content_tag :td, class: 'attribute title', data: { noid: collection.noid } do %>
+            <%= link_to collection.title, collections.collection_path(collection.noid) %>
+          <% end %>
+        </tr>
+      <% end %>
+      </tbody>
+      </table>
+    <% end %>

--- a/app/views/generic_files/show.html.erb
+++ b/app/views/generic_files/show.html.erb
@@ -47,6 +47,7 @@
   <div class="col-xs-12 col-sm-4">
     <%= render partial: 'generic_files/media_display' %>
     <%= render partial: 'show_actions' %>
+    <%= render partial: 'show_collections' %>
   </div>
   <div itemscope itemtype="<%= @generic_file.itemtype %>" class="col-xs-12 col-sm-8">
     <h1><%= @generic_file %></h1>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -74,6 +74,10 @@ en:
         collections:  "My Collections" 
         highlights:   "My Highlights"
         shares:       "Files Shared with Me"
+    file:
+      collections_list:
+        heading:   "This file is in the following collections:"
+        empty:     "This file is not currently in any collections." 
 
     metadata_help:
       resource_type: "Pre-defined categories to describe the type of file content being uploaded, such as \"article\" or \"dataset.\"  More than one type may be selected."

--- a/spec/views/generic_file/show.html.erb_spec.rb
+++ b/spec/views/generic_file/show.html.erb_spec.rb
@@ -295,4 +295,32 @@ describe 'generic_files/show.html.erb' do
       end
     end
   end
+
+  describe 'collections list' do
+    context "when the file is not featured in any collections" do
+
+      it "should display the empty message" do
+        render
+        expect(rendered).to have_text(t('sufia.file.collections_list.empty'))
+      end
+    end
+
+    context "when the file is featured in collections" do
+      let(:collection1) {
+        stub_model(Collection,
+          title: 'collection1',
+          noid: '456')
+      }
+ 
+      before do
+        allow(generic_file).to receive(:collections).and_return([collection1])
+      end
+
+      it "should display the header and titles of collections it belongs to" do
+        render
+        expect(rendered).to have_text(t('sufia.file.collections_list.heading'))
+        expect(rendered).to have_text('collection1')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This enhancement shows the list of collections of which this file is a member, on the generic_file view.  Same info as is now being rendered on each item in the My Files list in the dashboard.

CLA is hopefully coming within the next few days... apologies that it's taking so long.
