### PR TITLE
made collection show not have a redundant title and description

### DIFF
--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -95,18 +95,21 @@ describe 'collection' do
     end
 
     it "should show a collection with a listing of Descriptive Metadata and catalog-style search results" do
-      page.should have_content(@collection.title)
+      expect(page).to have_content(@collection.title)
       within('#document_'+@collection.noid) do
         click_link("collection title")
       end
-      page.should have_content(@collection.title)
-      page.should have_content(@collection.description)
+      expect(page).to have_content(@collection.title)
+      expect(page).to have_content(@collection.description)
+      # Should not show title and description a second time
+      expect(page).to_not have_css('.metadata-collections', text: @collection.title)
+      expect(page).to_not have_css('.metadata-collections', text: @collection.description)
       # Should not have Collection Descriptive metadata table
-      page.should have_content("Descriptions")
+      expect(page).to have_content("Descriptions")
       # Should have search results / contents listing
-      page.should have_content(@gf1.title.first)
-      page.should have_content(@gf2.title.first)
-      page.should_not have_css(".pager")
+      expect(page).to have_content(@gf1.title.first)
+      expect(page).to have_content(@gf2.title.first)
+      expect(page).to_not have_css(".pager")
 
       click_link "Gallery"
       expect(page).to have_content(@gf1.title.first)

--- a/sufia-models/app/models/concerns/sufia/collection.rb
+++ b/sufia-models/app/models/concerns/sufia/collection.rb
@@ -15,12 +15,13 @@ module Sufia
     end
 
     def terms_for_display
-      [:resource_type, :title, :creator, :contributor, :description, :tag, :rights, :publisher, :date_created,
-       :subject, :language, :identifier, :based_near, :related_url]
+      terms_for_editing - [:title, :description]
     end
 
     def terms_for_editing
-      terms_for_display - [:date_modified, :date_uploaded]
+      [:resource_type, :title, :creator, :contributor, :description, :tag,
+        :rights, :publisher, :date_created, :subject, :language, :identifier,
+        :based_near, :related_url]
     end
 
     # Test to see if the given field is required


### PR DESCRIPTION
On the Collection show page the title and description are displayed, then a list of most of the collections attributes--including the title and description again. This removes the redundant title and description.

PSU issue: https://scm.dlt.psu.edu/issues/9468
