### PR TITLE
swapped order of items in dashboard sidebar

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -9,11 +9,11 @@
 <%= content_for :sidebar do %>
   
   <div class="row">
-    <div class="portal"><%= render partial: "dashboard/_index_partials/user_info" %></div>
+    <div class="portal"><%= render partial: "dashboard/_index_partials/stats" %></div>
   </div>
 
   <div class="row">
-    <div class="portal"><%= render partial: "dashboard/_index_partials/stats" %></div>
+    <div class="portal"><%= render partial: "dashboard/_index_partials/user_info" %></div>
   </div>
 
 <% end %>

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -62,6 +62,9 @@ describe "dashboard/index.html.erb" do
       expect(@sidebar).to include '<span class="label label-default">3</span>'
     end
 
+    it "should show the statistics before the profile" do
+      expect(@sidebar).to match /Your Statistics.*Charles Francis Xavier/m
+    end
   end
 
   describe "main" do


### PR DESCRIPTION
This is just swapping the order. The idea is that users already know their own name (and profile) and would be more interested in their current statistics.
