### PR TITLE
removed 40 deprecation warnings

### DIFF
--- a/spec/factories/generic_files.rb
+++ b/spec/factories/generic_files.rb
@@ -22,7 +22,7 @@ FactoryGirl.define do
         subject %w"lorem ipsum dolor sit amet"
         before(:create) do |gf|
           gf.apply_depositor_metadata "archivist1@example.com"
-          gf.title = "Fake Document Title"
+          gf.title = ["Fake Document Title"]
           gf.label = "fake_document.pdf"
         end
       end

--- a/spec/features/browse_files_spec.rb
+++ b/spec/features/browse_files_spec.rb
@@ -8,7 +8,7 @@ describe "Browse files" do
 
   before(:all) do
     @fixtures = find_or_create_file_fixtures
-    @fixtures[0].tag = "key"
+    @fixtures[0].tag = ["key"]
     (1..25).each do |i|
       @fixtures[0].tag << i
     end

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -4,14 +4,14 @@ describe 'catalog searching' do
 
   before(:all) do
     @gf1 = GenericFile.new.tap do |f|
-      f.title = 'title 1'
+      f.title = ['title 1']
       f.tag = ["tag1", "tag2"]
       f.apply_depositor_metadata('jilluser')
       f.read_groups = ['public']
       f.save!
     end
     @gf2 = GenericFile.new.tap do |f|
-      f.title = 'title 2'
+      f.title = ['title 2']
       f.tag = ["tag2", "tag3"]
       f.apply_depositor_metadata('jilluser')
       f.read_groups = ['public']

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -28,7 +28,7 @@ describe 'collection' do
     @gfs = []
     (0..12).each do |x|
       @gfs[x] =  GenericFile.new.tap do |f|
-        f.title = "title #{x}"
+        f.title = ["title #{x}"]
         f.apply_depositor_metadata('archivist1@example.com')
         f.save!
       end

--- a/spec/jobs/event_jobs_spec.rb
+++ b/spec/jobs/event_jobs_spec.rb
@@ -7,7 +7,7 @@ describe 'event jobs' do
     @third_user = FactoryGirl.find_or_create(:curator)
     @gf = GenericFile.new(pid: 'test:123')
     @gf.apply_depositor_metadata(@user)
-    @gf.title = 'Hamlet'
+    @gf.title = ['Hamlet']
     @gf.save
   end
   after(:each) do

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -284,7 +284,7 @@ describe GenericFile do
       subject.title = ["The Work"]
       subject.description = ["The work by Allah"]
       subject.publisher = ["Vertigo Comics"]
-      subject.date_created = "1200-01-01"
+      subject.date_created = ["1200-01-01"]
       subject.date_uploaded = Date.parse("2011-01-01")
       subject.date_modified = Date.parse("2012-01-01")
       subject.subject = ["Theology"]
@@ -1021,7 +1021,7 @@ describe GenericFile do
      f2 = GenericFile.find(subject.id)
      f2.reload_on_save = true
      f1.mime_type = "video/abc123"
-     f2.title = "abc123"
+     f2.title = ["abc123"]
      f1.save
      mime_type_key = Solrizer.solr_name("mime_type")
      title_key = Solrizer.solr_name("desc_metadata__title", :stored_searchable, type: :string)


### PR DESCRIPTION
This removes warnings like this:

```
DEPRECATION WARNING: You attempted to set the attribute `title' on `GenericFile' to a scalar value. However, this attribute is declared as being multivalued. This behavior is deprecated and will raise an ArgumentError in active-fedora 8.0.0.
```
