### PR TITLE
Redirect to the current MyController

### DIFF
--- a/app/controllers/concerns/sufia/batch_edits_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_edits_controller_behavior.rb
@@ -40,8 +40,12 @@ module Sufia
     end
 
     def after_update
-      redirect_to sufia.dashboard_files_path unless request.xhr?
+      redirect_to_return_controller unless request.xhr?
     end
+
+    def after_destroy_collection
+      redirect_to_return_controller unless request.xhr?
+    end 
 
     def update_document(obj)
       super
@@ -86,5 +90,14 @@ module Sufia
          file[key] = attributes[key].empty? ? [''] : attributes[key]
        end
     end
+
+    def redirect_to_return_controller
+      if params[:return_controller]
+        redirect_to sufia.url_for(controller: params[:return_controller], only_path: true)
+      else
+        redirect_to sufia.dashboard_index_path
+      end
+    end
+
   end
 end

--- a/app/views/batch_edits/_delete_selected.html.erb
+++ b/app/views/batch_edits/_delete_selected.html.erb
@@ -1,4 +1,5 @@
 <%= form_tag(batch_edits_path, method: :delete, class: "batch-select-all hidden", "data-behavior" => 'batch-select-all') do -%>
     <%= hidden_field_tag('update_type', 'delete_all') %>
+    <%= hidden_field_tag('return_controller', params[:controller]) %>
   <%= submit_tag("Delete Selected", class: 'batch-all-button btn btn-primary submits-batches', data: { confirm: "Deleting a file from #{t('sufia.product_name')} is permanent. Click OK to delete this file from #{t('sufia.product_name')}, or Cancel to cancel this operation" }) %>
 <% end %>

--- a/spec/controllers/batch_edits_controller_spec.rb
+++ b/spec/controllers/batch_edits_controller_spec.rb
@@ -47,11 +47,16 @@ describe BatchEditsController do
       expect(controller).to receive(:can?).with(:edit, @one.pid).and_return(true)
       expect(controller).to receive(:can?).with(:edit, @two.pid).and_return(true)
     end
+    let(:mycontroller) { "my/files" }
     it "should be successful" do
       put :update , update_type: "delete_all"
-      expect(response).to be_redirect
+      expect(response).to redirect_to(Sufia::Engine.routes.url_for(controller: "dashboard", only_path: true))
       expect { GenericFile.find(@one.id) }.to raise_error(ActiveFedora::ObjectNotFoundError)
       expect { GenericFile.find(@two.id) }.to raise_error(ActiveFedora::ObjectNotFoundError)
+    end
+    it "should redirect to the return controller" do
+      put :update , update_type: "delete_all", return_controller: mycontroller
+      expect(response).to redirect_to(Sufia::Engine.routes.url_for(controller: mycontroller, only_path: true))
     end
     it "should update the records" do
       put :update , update_type: "update", "generic_file"=>{"subject"=>["zzz"]}


### PR DESCRIPTION
Editing using BatchEdits controller redirected to the catalog, but since we're using the dashboard now, we should redirect back to whichever of the controllers we came from.

Although, as I was writing 

``` ruby
def persist_current_controller
  session[:controller] = params[:controller]
end
```

I had the feeling that this might have been done before, somewhere else.
