### PR TITLE
Fixes alignment issue with Terms of Service checkbox

### DIFF
--- a/app/views/generic_files/upload/_tos_checkbox.html.erb
+++ b/app/views/generic_files/upload/_tos_checkbox.html.erb
@@ -1,3 +1,3 @@
-<label class="checkbox"> 
-  <%= check_box_tag 'terms_of_service', 1, nil, {"data-activate" => 'activate-submit'} %> I have read and do agree to <%= link_to t('sufia.deposit_agreement'), '/agreement/', target: "_blank" %>.  
+<label>
+  <%= check_box_tag 'terms_of_service', 1, nil, {data: {activate: 'activate-submit'}} %><strong> I have read and do agree to <%= link_to t('sufia.deposit_agreement'), '/agreement/', target: "_blank" %>.</strong>
 </label>


### PR DESCRIPTION
`<scratch this>`The default checkbox style (inherited from some gem) sets the margin to `-20px` with messes up with the use of the checkbox when uploading a new document. This fixes that issue.`</scratch this>`
