### PR TITLE
made long facet labels and images not cause div explosions

### DIFF
--- a/app/assets/stylesheets/catalog.css.scss
+++ b/app/assets/stylesheets/catalog.css.scss
@@ -1,0 +1,5 @@
+// makes it so images don't bleed into the content on the right
+.catalog img {
+  max-width: 100%;
+  max-height: auto;
+}

--- a/app/assets/stylesheets/sufia.css.scss
+++ b/app/assets/stylesheets/sufia.css.scss
@@ -9,6 +9,7 @@
  *= require featured
  *= require usage-stats
  *= require nestable
+ *= require catalog
 */
 
 @import 'bootstrap';

--- a/app/views/layouts/sufia-dashboard.html.erb
+++ b/app/views/layouts/sufia-dashboard.html.erb
@@ -16,8 +16,10 @@
         </div>
         <div class="container-fluid">
           <div id="content" class="row">
-            <div class="col-xs-12 col-sm-3"><%= yield :sidebar %></div>
-            <div class="col-xs-12 col-sm-9"><%= yield %></div>
+            <div class="col-xs-12">
+              <div id="sidebar" class="col-md-3"><%= yield :sidebar %></div>
+              <div class="col-sm-9"><%= yield %></div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR fixes some problems that appear in narrower browsers.
### /dashboard/files
#### Before

Note the facet arrow ">" dropping down out of place
![before-dashboard](https://cloud.githubusercontent.com/assets/74879/3741098/6541a00a-175c-11e4-8902-39bc0478eef4.png)
#### After

![after-dashboard](https://cloud.githubusercontent.com/assets/74879/3741101/6986ff66-175c-11e4-9cfd-4d8902842482.png)
### search results
#### Before

The image bleeds into the details
![before-search](https://cloud.githubusercontent.com/assets/74879/3741103/6dbd0c4c-175c-11e4-9f25-a5ba52e222e1.png)
#### After

The image shrinks to fit the column. If the page is wide, the image will remain its original size--it only shrinks as necessary.
![after-search](https://cloud.githubusercontent.com/assets/74879/3741105/73bf1374-175c-11e4-834f-cb5c7e19a4d6.png)
