### PR TITLE
Visibility status in show and list views

### DIFF
--- a/app/assets/stylesheets/generic_files.css.erb
+++ b/app/assets/stylesheets/generic_files.css.erb
@@ -43,3 +43,8 @@ h2 small {
 .loading {
    background: white url(<%= image_path('loading.gif') %>) center bottom no-repeat;
 }
+
+h1.visibility span.label {
+  font-size: 30%;
+  vertical-align: middle;
+}

--- a/app/helpers/generic_file_helper.rb
+++ b/app/helpers/generic_file_helper.rb
@@ -80,4 +80,13 @@ module GenericFileHelper
       image_tag sufia.download_path(@generic_file, datastream_id: 'thumbnail'), { class: "img-responsive", alt: "#{title} of #{@generic_file.title.first}" }
     end
   end
+
+  def render_visibility_badge
+    if can? :edit, @generic_file
+      render_visibility_link @generic_file
+    else
+      render_visibility_label @generic_file
+    end
+  end
+
 end

--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -120,6 +120,21 @@ module Sufia
       end
     end
 
+    def render_visibility_link document
+      link_to render_visibility_label(document), sufia.edit_generic_file_path(document.noid, {anchor: "permissions_display"}),
+        id: "permission_"+document.noid, class: "visibility-link"
+    end
+
+    def render_visibility_label document
+      if document.registered?
+        content_tag :span, t('sufia.institution_name'), class: "label label-info", title: t('sufia.institution_name')
+      elsif document.public?
+        content_tag :span, t('sufia.visibility.open'), class: "label label-success", title: t('sufia.visibility.open')
+      else
+        content_tag :span, t('sufia.visibility.private'), class: "label label-danger", title: t('sufia.visibility.private')
+      end
+    end
+
     private
 
     def search_action_for_dashboard

--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -3,7 +3,8 @@ module Sufia
   module SolrDocumentBehavior
     extend ActiveSupport::Concern
     include Sufia::GenericFile::MimeTypes
-
+    include Sufia::Permissions::Readable
+    
     # Add a schema.org itemtype
     def itemtype
       Sufia.config.resource_types_to_schema[resource_type.first] || 'http://schema.org/CreativeWork'
@@ -102,12 +103,5 @@ module Sufia
       Array(self[::Ability.edit_user_field])
     end
 
-    def public?
-      read_groups.include?('public')
-    end
-
-    def registered?
-      read_groups.include?('registered')
-    end
   end
 end

--- a/app/views/generic_files/show.html.erb
+++ b/app/views/generic_files/show.html.erb
@@ -50,7 +50,7 @@
     <%= render partial: 'show_collections' %>
   </div>
   <div itemscope itemtype="<%= @generic_file.itemtype %>" class="col-xs-12 col-sm-8">
-    <h1><%= @generic_file %></h1>
+    <h1 class="visibility"><%= @generic_file %> <%= render_visibility_badge %></h1>
     <%= render partial: 'show_descriptions' %>
     <%= render partial: 'show_details' %>
     <%= render partial: 'users/activity_log', locals: {events: @events} %>

--- a/app/views/my/_index_partials/_list_files.html.erb
+++ b/app/views/my/_index_partials/_list_files.html.erb
@@ -25,15 +25,7 @@
   </td>
   <td class="text-center"><%= document.date_uploaded %> </td>
   <td class="text-center">
-    <a href="<%= sufia.generic_file_path(noid) %>/edit/?tab=permissions" id="permission_<%= noid %>" class="visibility-link">
-      <% if document.registered? %>
-          <span class="label label-info" title="<%= t('sufia.institution_name') %>"><%= t('sufia.institution_name') %></span>
-      <% elsif document.public? %>
-          <span class="label label-success" title="Open Access">Open Access</span>
-      <% else %>
-          <span class="label label-danger" title="Private">Private</span>
-      <% end %>
-    </a>
+    <%= render_visibility_link document %>
   </td>
   <td class="text-center">
     <%= render partial: 'action_menu', locals: { noid: noid, gf: gf } %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -100,3 +100,6 @@ en:
       collections_list: "Your Collections"
       previous:  "Back to Previous"
       search_results: "Back to search results"
+    visibility:
+      open: "Open Access"
+      private: "Private"

--- a/spec/features/browse_dashboard_files_spec.rb
+++ b/spec/features/browse_dashboard_files_spec.rb
@@ -20,10 +20,15 @@ describe "Browse Dashboard" do
       visit "dashboard/files"
     end
 
-    it "should show me files that are not part of any collection" do
+    it "should display all the necessary information" do
       expect(page).to have_content("Edit File")
       expect(page).to have_content("Download File")
       expect(page).to_not have_content("Is part of:")
+      first(".label-success") do
+        expect(page).to have_content("Open Access")
+      end
+      expect(page).to have_link("Create Collection")
+      expect(page).to have_link("Upload")
     end
 
     it "should allow you to search your own files and remove constraints" do
@@ -66,14 +71,6 @@ describe "Browse Dashboard" do
       first('input#check_all').click
       click_button('Edit Selected')
       expect(page).to have_content('3 files')
-    end
-
-    it "should display a button for uploading files" do
-      click_link('Upload')
-    end
-
-    it "should display a button for creating collections" do
-      click_link('Create Collection')
     end
 
   end

--- a/spec/lib/sufia/readable_permissions_spec.rb
+++ b/spec/lib/sufia/readable_permissions_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Sufia::Permissions::Readable do
+
+  class SubjectClass
+    include Sufia::Permissions::Readable
+    attr_accessor :read_groups 
+  end
+  let(:subject) { SubjectClass.new }
+
+  describe "#public?" do
+    it "should return true for public items" do
+      subject.read_groups = ["public","othergroup"]
+      expect(subject).to be_public
+    end
+    it "should return fale for non-public items" do
+      subject.read_groups = ["notpublic","othergroup"]
+      expect(subject).to_not be_public
+    end
+  end
+
+  describe "#registered?" do
+    it "should return true for registered items" do
+      subject.read_groups = ["registered","othergroup"]
+      expect(subject).to be_registered
+    end
+    it "should return fale for non-registered items" do
+      subject.read_groups = ["othergroup"]
+      expect(subject).to_not be_registered
+    end
+  end
+
+  describe "#private?" do
+    context "is true" do
+      specify "when there are no groups defined" do
+        subject.read_groups = []
+        expect(subject).to be_private
+      end
+      specify "when groups do not include 'public' or 'registered'" do
+        subject.read_groups = ["othergroup"]
+        expect(subject).to be_private
+      end
+    end
+    context "is false" do
+      specify "when 'registered' group is present" do
+        subject.read_groups = ["registered"]
+        expect(subject).to_not be_private
+      end
+      specify "when 'public' group is present" do
+        subject.read_groups = ["public"]
+        expect(subject).to_not be_private
+      end
+    end
+  end
+
+end

--- a/spec/lib/sufia/writable_permissions_spec.rb
+++ b/spec/lib/sufia/writable_permissions_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Sufia::Permissions::Writable do
+
+  class SampleModel < ActiveFedora::Base
+    include Sufia::Permissions::Writable
+  end
+  let(:subject) { SampleModel.new }
+
+  it "should initialized with a parnoid rightsMetadata datastream" do
+    expect(subject.rightsMetadata).to be_kind_of ParanoidRightsDatastream
+  end
+
+  describe "#permissions" do
+    it "should initialize with nothing specified" do
+      expect(subject.permissions).to be_empty
+    end
+  end
+
+end

--- a/spec/views/generic_file/show.html.erb_spec.rb
+++ b/spec/views/generic_file/show.html.erb_spec.rb
@@ -323,4 +323,15 @@ describe 'generic_files/show.html.erb' do
       end
     end
   end
+
+  describe 'visibility' do
+    let(:expected) do
+      '<span class="label label-danger" title="'+t('sufia.visibility.private')+'">'+t('sufia.visibility.private')+'</span></a>' 
+    end
+    it "should display the visibility badge" do
+      render
+      expect(rendered).to include(expected)
+    end
+  end
+
 end

--- a/sufia-models/app/models/concerns/sufia/generic_file/permissions.rb
+++ b/sufia-models/app/models/concerns/sufia/generic_file/permissions.rb
@@ -2,57 +2,10 @@ module Sufia
   module GenericFile
     module Permissions
       extend ActiveSupport::Concern
-      #we're overriding the permissions= method which is in Hydra::AccessControls::Permissions
-      include Hydra::AccessControls::Permissions
-      include Hydra::AccessControls::Visibility
 
-      included do
-        has_metadata "rightsMetadata", type: ParanoidRightsDatastream
-        validate :paranoid_permissions
-      end
+      include Sufia::Permissions::Writable
+      include Sufia::Permissions::Readable
 
-      def paranoid_permissions
-        # let the rightsMetadata ds make this determination
-        # - the object instance is passed in for easier access to the props ds
-        rightsMetadata.validate(self)
-      end
-
-      ## Updates those permissions that are provided to it. Does not replace any permissions unless they are provided
-      def permissions=(params)
-        perm_hash = permission_hash
-        params[:new_user_name].each { |name, access| perm_hash['person'][name] = access } if params[:new_user_name].present?
-        params[:new_group_name].each { |name, access| perm_hash['group'][name] = access } if params[:new_group_name].present?
-
-        params[:user].each { |name, access| perm_hash['person'][name] = access} if params[:user]
-        params[:group].each { |name, access| perm_hash['group'][name] = access if ['read', 'edit'].include?(access)} if params[:group]
-
-        rightsMetadata.update_permissions(perm_hash)
-      end
-
-      def permissions
-        perms = super
-        perms.map {|p| { name: p.name, access: p.access, type:p.type } }
-      end
-
-      def public?
-        read_groups.include?('public')
-      end
-
-      private
-
-      def permission_hash
-        old_perms = self.permissions
-        user_perms =  {}
-        old_perms.select{|r| r[:type] == 'user'}.each do |r|
-          user_perms[r[:name]] = r[:access]
-        end
-        user_perms
-        group_perms =  {}
-        old_perms.select{|r| r[:type] == 'group'}.each do |r|
-          group_perms[r[:name]] = r[:access]
-        end
-        {'person'=>user_perms, 'group'=>group_perms}
-      end
     end
   end
 end

--- a/sufia-models/lib/sufia/models.rb
+++ b/sufia-models/lib/sufia/models.rb
@@ -15,6 +15,7 @@ module Sufia
   end
 
   autoload :Utils, 'sufia/models/utils'
+  autoload :Permissions
 
   attr_writer :queue
 

--- a/sufia-models/lib/sufia/permissions.rb
+++ b/sufia-models/lib/sufia/permissions.rb
@@ -1,0 +1,9 @@
+module Sufia
+  module Permissions
+    extend ActiveSupport::Autoload
+
+    autoload :Writable
+    autoload :Readable
+
+  end
+end

--- a/sufia-models/lib/sufia/permissions/readable.rb
+++ b/sufia-models/lib/sufia/permissions/readable.rb
@@ -1,0 +1,20 @@
+module Sufia
+  module Permissions
+    module Readable
+      extend ActiveSupport::Concern
+
+      def public?
+        read_groups.include?('public')
+      end
+
+      def registered?
+        read_groups.include?('registered')
+      end
+
+      def private?
+        !(public? || registered?)
+      end
+
+    end
+  end
+end

--- a/sufia-models/lib/sufia/permissions/writable.rb
+++ b/sufia-models/lib/sufia/permissions/writable.rb
@@ -1,0 +1,56 @@
+module Sufia
+  module Permissions
+    module Writable
+      extend ActiveSupport::Concern
+
+      #we're overriding the permissions= method which is in Hydra::AccessControls::Permissions
+      include Hydra::AccessControls::Permissions
+      include Hydra::AccessControls::Visibility
+
+      included do
+        has_metadata "rightsMetadata", type: ParanoidRightsDatastream
+        validate :paranoid_permissions
+      end
+
+      def paranoid_permissions
+        # let the rightsMetadata ds make this determination
+        # - the object instance is passed in for easier access to the props ds
+        rightsMetadata.validate(self)
+      end
+
+      ## Updates those permissions that are provided to it. Does not replace any permissions unless they are provided
+      def permissions=(params)
+        perm_hash = permission_hash
+        params[:new_user_name].each { |name, access| perm_hash['person'][name] = access } if params[:new_user_name].present?
+        params[:new_group_name].each { |name, access| perm_hash['group'][name] = access } if params[:new_group_name].present?
+
+        params[:user].each { |name, access| perm_hash['person'][name] = access} if params[:user]
+        params[:group].each { |name, access| perm_hash['group'][name] = access if ['read', 'edit'].include?(access)} if params[:group]
+
+        rightsMetadata.update_permissions(perm_hash)
+      end
+
+      def permissions
+        perms = super
+        perms.map {|p| { name: p.name, access: p.access, type:p.type } }
+      end
+
+      private
+
+      def permission_hash
+        old_perms = self.permissions
+        user_perms =  {}
+        old_perms.select{|r| r[:type] == 'user'}.each do |r|
+          user_perms[r[:name]] = r[:access]
+        end
+        user_perms
+        group_perms =  {}
+        old_perms.select{|r| r[:type] == 'group'}.each do |r|
+          group_perms[r[:name]] = r[:access]
+        end
+        {'person'=>user_perms, 'group'=>group_perms}
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Creates `Sufia::Permissions::Readable` and `Sufia::Permissions::Writable` modules, which can be used in the models or isolr documents.  Helper methods take care of displaying labels with the pertinent information.
