### PR TITLE
remove featured files that are deleted

### DIFF
--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -255,6 +255,17 @@ describe GenericFilesController do
       Sufia.queue.should_receive(:push).with(s1).once
       delete :destroy, id: @generic_file.pid
     end
+
+    context "when the file is featured" do
+      before do
+        FeaturedWork.create(generic_file_id: @generic_file.pid)
+      end
+      it "should make the file not featured" do
+        expect(FeaturedWorkList.new.featured_works.map(&:generic_file_id)).to include(@generic_file.pid)
+        delete :destroy, id: @generic_file.pid
+        expect(FeaturedWorkList.new.featured_works.map(&:generic_file_id)).to_not include(@generic_file.pid)
+      end
+    end
   end
 
   describe 'stats' do

--- a/sufia-models/app/actors/sufia/generic_file/actor.rb
+++ b/sufia-models/app/actors/sufia/generic_file/actor.rb
@@ -69,6 +69,7 @@ module Sufia::GenericFile
     def destroy
       pid = generic_file.pid  #Work around for https://github.com/projecthydra/active_fedora/issues/422
       generic_file.destroy
+      FeaturedWork.where(generic_file_id: pid).destroy_all
       if Sufia.config.respond_to?(:after_destroy)
         Sufia.config.after_destroy.call(pid, user)
       end


### PR DESCRIPTION
If someone deletes a file that is currently featured, the root page crashes when trying to look it up.

PSU bug: https://scm.dlt.psu.edu/issues/9479
