### PR TITLE
Show tab using anchor

### DIFF
--- a/app/assets/javascripts/sufia/tabs.js
+++ b/app/assets/javascripts/sufia/tabs.js
@@ -1,7 +1,20 @@
 Blacklight.onLoad(function () {
-    $('#homeTabs a, #myTab a').click(function (e) {
-        e.preventDefault();
-        $(this).tab('show');
-    });
-    $('#homeTabs a:first, #myTab a:first').tab('show'); // Select first tab
+  $('#homeTabs a, #myTab a').click(function (e) {
+    e.preventDefault();
+    $(this).tab('show');
+  });
+  $('#homeTabs a:first, #myTab a:first').tab('show'); // Select first tab
+
+  // Show the tabs in GenericFile#edit given an anchor
+  switch (window.location.hash.substring(1)) {
+    case 'versioning_display':
+      $('#edit_versioning_link a').tab('show');
+      break;
+    case 'descriptions_display':
+      $('#edit_descriptions_link a').tab('show');
+      break;
+    case 'permissions_display':
+      $('#edit_permissions_link a').tab('show');
+      break;
+  }
 });


### PR DESCRIPTION
Bootstrap uses anchors to show different tabs in the page.  This patch enables the anchors to be recognized in GenericFile#edit so that the correct tab will be displayed when the page loads.
