### PR TITLE
Batch edit now uses Bootstrap grid rather than HTML table. This fixes th...

### DIFF
--- a/app/assets/javascripts/sufia/batch_edit.js
+++ b/app/assets/javascripts/sufia/batch_edit.js
@@ -151,11 +151,27 @@ function batch_edit_init () {
         setTimeout(ajaxManager.runNow(), 100);
     }
 
+    function enable_show_hide_links() {
+        // Show/hide field details when clicking on a link with ID "expand_link_XXX".
+        // We expect to find an element named detail_XXX in addition to the expand_link_XXX.
+        // The "detail_XXX" element has the chevron icon.
+        $('.glyphicon-chevron-right-helper').on('click', function() {
+            var array = this.id.split("expand_link_");
+            if (array.length > 1) {
+                var docId = array[1];
+                $("#detail_" + docId + " .expanded-details").slideToggle();
+                var button = $("#expand_" + docId);
+                button.toggleClass('glyphicon-chevron-right glyphicon-chevron-down');
+            }
+            return false;
+        });
+    }
+
     $("#permissions_save").click(runSave);
     $(".field-save").click(runSave);
+    enable_show_hide_links();
 
 }
-
 
 
 

--- a/app/views/batch_edits/edit.html.erb
+++ b/app/views/batch_edits/edit.html.erb
@@ -14,35 +14,34 @@
     </ul>
     <div class="tab-content">
       <div class="well tab-pane active" id="descriptions_display">
-        <table class="table table-striped"><!-- class="verticalheadings"> -->
-        <tbody>
         <% @terms.each do |term| %>
           <% vals = @show_file.send(term) %>
-              <tr id='row_<%= term.to_s %>' class="expandable">
-                <th width="20%">
-                   <a class="accordion-toggle grey" data-toggle="collapse" data-parent="#row_<%= term.to_s %>" href="#collapse_<%=term.to_s%>">
-                      <%= get_label(term) %>&nbsp;<i class="toggle glyphicon glyphicon-chevron-right grey"></i>
-                   </a>
-                </th>
-                <td  width="50%" class="scrolly">
-
-                    <div id="collapse_<%= term.to_s %>" class="accordion-body collapse scrolly">
-                      <%= form_for @generic_file, url: batch_edits_path, method: :put, remote: true, html: { id: "form_#{term.to_s}", class: "ajax-form"} do |f| %>
-                          <%= hidden_field_tag('update_type', 'update') %>
-                          <%= hidden_field_tag('key', term.to_s) %>
-                          <%= render partial: "generic_files/field_form", locals: { generic_file: @show_file, f: f, render_req: false, key: term } %>
-                        <div class="row">
-                           <%= f.submit "Save changes", class: 'btn btn-primary field-save updates-batches' , id: "#{term.to_s}_save" %>
-                           <a class="accordion-toggle btn" data-toggle="collapse" data-parent="#row_<%= term.to_s %>" href="#collapse_<%= term.to_s %>">Cancel </a>
-                           <div id="status_<%= term.to_s %>" class="status fleft"></div>
-                        </div>
-                      <% end %>
-                    </div>
-                </td>
-              </tr>
-         <% end %>
-          </tbody></table> <!-- class="verticalheadings"> -->
+          <div class="row">
+            <!-- look into dashboard_actions.js -->
+            <div class="col-sm-2 col-sm-offset-1">
+              <a class="accordion-toggle grey glyphicon-chevron-right-helper" data-toggle="collapse" data-parent="#row_<%= term.to_s %>" href="#" id="expand_link_<%=term.to_s%>">
+                <%= get_label(term) %>
+              </a>
+              <a href="#collapse_<%=term.to_s%>" class="small" id="chevron_link_<%=term.to_s%>"><span id="expand_<%=term.to_s%>" class="glyphicon glyphicon-chevron-right"></span></a>
+            </div>
+            <div id="detail_<%= term.to_s %>" class="col-sm-6">
+              <div class="accordion-body collapse expanded-details scrolly">
+                <%= form_for @generic_file, url: batch_edits_path, method: :put, remote: true, html: { id: "form_#{term.to_s}", class: "ajax-form"} do |f| %>
+                  <%= hidden_field_tag('update_type', 'update') %>
+                  <%= hidden_field_tag('key', term.to_s) %>
+                  <%= render partial: "generic_files/field_form", locals: { generic_file: @show_file, f: f, render_req: false, key: term } %>
+                  <div>
+                    <%= f.submit "Save changes", class: 'btn btn-primary field-save updates-batches' , id: "#{term.to_s}_save" %>
+                    <a class="accordion-toggle btn" data-toggle="collapse" data-parent="#row_<%= term.to_s %>" href="#collapse_<%= term.to_s %>">Cancel </a>
+                    <div id="status_<%= term.to_s %>" class="status fleft"></div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        <% end %>
       </div><!-- /well -->
+
       <div id="permissions_display" class="tab-pane">
         <%= form_for @generic_file, url: batch_edits_path, method: :put, remote: true, html: { id: "form_permissions", class: "ajax-form"} do |f| %>
            <%= hidden_field_tag('update_type', 'update') %>


### PR DESCRIPTION
...e scrollbar issue when editing field details. The links for details have also been fixed so that the text and the chevron icon show/hide details

The following screenshots show how the layout looks now (no ugly horizontal scroll bars when editing details) and it scales nicely when screen is narrow.

![screen shot 2014-08-04 at 9 43 26 am](https://cloud.githubusercontent.com/assets/568286/3797992/b3f1bece-1bdf-11e4-93ba-6d2e2385c84b.png)
![screen shot 2014-08-04 at 9 43 09 am](https://cloud.githubusercontent.com/assets/568286/3797993/b3f2dcc8-1bdf-11e4-91c0-0e6559fd0491.png)
