### PR TITLE
Using Sufia::Messages for notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sass-rails', '~> 4.0.3'
 
 group :development, :test do
   gem "simplecov", require: false
+  gem "byebug", require: false
 end # (leave this comment here to catch a stray line inserted by blacklight!)
 
 file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path("../spec/internal", __FILE__))

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -79,7 +79,21 @@ en:
       collections_list:
         heading:   "This file is in the following collections:"
         empty:     "This file is not currently in any collections."
-
+    messages:
+      success:
+        single: "has been saved."
+        multiple:
+          link: "These files"
+          tag: "have been saved."
+        title:  "Files uploaded successfully" 
+        subject: "Batch upload complete"
+      failure:
+        single: "could not be updated. You do not have sufficient privileges to edit it."
+        multiple:
+          link: "These files" 
+          tag: "could not be updated. You do not have sufficient privileges to edit them."
+        title:  "Files failed" 
+        subject: "Batch upload permission denied"
     metadata_help:
       resource_type: "Pre-defined categories to describe the type of file content being uploaded, such as \"article\" or \"dataset.\"  More than one type may be selected."
       title: "A name for the file to aid in identifying it. Defaults to the file name, though a more descriptive title is encouraged. <em>This is a required field</em>."

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,15 +13,43 @@ FactoryGirl.define do
 
     factory :user_with_mail do
       after(:create) do |user|
-        message = '<span class="batchid ui-helper-hidden">fake_batch_noid</span>You\'ve got mail.'
-        (1..6).each do |number|
-          User.batchuser().send_message(user, message, "Sample notification #{number.to_s}.")
+        # TODO: what is this class for?
+        # <span class="batchid ui-helper-hidden">fake_batch_noid</span>
+        message = BatchMessage.new
+
+        # Create examples of single file successes and failures
+        (1..10).each do |number|
+          file = MockFile.new(number.to_s, "Single File #{number.to_s}")
+          User.batchuser().send_message(user, message.single_success("single-batch-success", file), message.success_subject, sanitize_text = false)
+          User.batchuser().send_message(user, message.single_failure("single-batch-failure", file), message.failure_subject, sanitize_text = false)
         end
+
+        # Create examples of mulitple file successes and failures
+        files = []
+        (1..50).each do |number|
+          files << MockFile.new(number.to_s, "File #{number.to_s}")
+        end
+        User.batchuser().send_message(user, message.multiple_success("multiple-batch-success", files), message.success_subject, sanitize_text = false)
+        User.batchuser().send_message(user, message.multiple_failure("multiple-batch-failure", files), message.failure_subject, sanitize_text = false)
       end
     end
 
     factory :curator do
       email 'curator1@example.com'
     end
+
   end
+end
+
+class MockFile
+  attr_accessor :noid, :to_s, :id
+  def initialize id, string
+    self.noid = id
+    self.id = id
+    self.to_s = string
+  end
+end
+
+class BatchMessage
+  include Sufia::Messages
 end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -4,17 +4,22 @@ describe "Notifications page" do
 
   before do
     sign_in FactoryGirl.create(:user_with_mail)
+    visit "/notifications"
   end
 
   it "should list notifications with date, subject and message" do
-    visit "/notifications"
     page.should have_content "User Notifications"
     page.find(:xpath, '//thead/tr').should have_content "Date"
     page.find(:xpath, '//thead/tr').should have_content "Subject"
     page.find(:xpath, '//thead/tr').should have_content "Message"
-    page.should have_content "Sample notification 1."
-    page.should have_content "less than a minute ago"
-    page.should have_content "You've got mail."
+    page.should have_content "These files could not be updated. You do not have sufficient privileges to edit them. "
+    page.should have_content "These files have been saved"
+    page.should have_content "File 1 could not be updated. You do not have sufficient privileges to edit it."
+    page.should have_content "File 1 has been saved"
+    page.should have_content "Batch upload permission denied  "
+    page.should have_content "Batch upload complete"
   end
+
+
 
 end

--- a/spec/jobs/batch_update_job_spec.rb
+++ b/spec/jobs/batch_update_job_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe BatchUpdateJob do
+  
   before do
     @user = FactoryGirl.find_or_create(:jill)
     @batch = Batch.new
@@ -12,36 +13,50 @@ describe BatchUpdateJob do
     @file2.apply_depositor_metadata('otherUser')
     @file2.save
   end
+  
   after do
+    @user.mailbox.inbox[0].messages[0].move_to_trash @user
     @batch.delete
     @file.delete
     @file2.delete
   end
-  describe "failing update" do
-    it "should check permissions for each file before updating" do
-      User.any_instance.should_receive(:can?).with(:edit, @file).and_return(false)
-      User.any_instance.should_receive(:can?).with(:edit, @file2).and_return(false)
-       params = {'generic_file' => {'read_groups_string' => '', 'read_users_string' => 'archivist1, archivist2', 'tag' => ['']}, 'id' => @batch.pid, 'controller' => 'batch', 'action' => 'update'}.with_indifferent_access
-      BatchUpdateJob.new(@user.user_key, params).run
-      @user.mailbox.inbox[0].messages[0].subject.should == "Batch upload permission denied"
-      @user.mailbox.inbox[0].messages[0].move_to_trash @user
-      #b = Batch.find(@batch.pid)
+  
+  describe "#run" do
+    let(:params) do
+      {
+        generic_file: {
+          read_groups_string: '', read_users_string: 'archivist1, archivist2', tag: ['']
+        }, 
+        id: @batch.pid,
+        controller: 'batch',
+        action: 'update'
+      }.with_indifferent_access
     end
-  end
-  describe "passing update" do
-    it "should log a content update event" do
-      User.any_instance.should_receive(:can?).with(:edit, @file).and_return(true)
-      User.any_instance.should_receive(:can?).with(:edit, @file2).and_return(true)
-      s1 = double('one')
-      ContentUpdateEventJob.should_receive(:new).with(@file.pid, @user.user_key).and_return(s1)
-      Sufia.queue.should_receive(:push).with(s1).once
-      s2 = double('two')
-      ContentUpdateEventJob.should_receive(:new).with(@file2.pid, @user.user_key).and_return(s2)
-      Sufia.queue.should_receive(:push).with(s2).once
-      params = {'generic_file' => {'read_groups_string' => '', 'read_users_string' => 'archivist1, archivist2', 'tag' => ['']}, 'id' => @batch.pid, 'controller' => 'batch', 'action' => 'update'}.with_indifferent_access
-      BatchUpdateJob.new(@user.user_key, params).run
-      @user.mailbox.inbox[0].messages[0].subject.should == "Batch upload complete"
-      @user.mailbox.inbox[0].messages[0].move_to_trash @user
+    context "with a failing update" do
+      it "should check permissions for each file before updating" do
+        User.any_instance.should_receive(:can?).with(:edit, @file).and_return(false)
+        User.any_instance.should_receive(:can?).with(:edit, @file2).and_return(false)
+        BatchUpdateJob.new(@user.user_key, params).run
+        @user.mailbox.inbox[0].messages[0].subject.should == "Batch upload permission denied"
+        @user.mailbox.inbox[0].messages[0].body.should include("data-content")
+        @user.mailbox.inbox[0].messages[0].body.should include("These files")
+      end
+    end
+    context "with a passing update" do
+      let(:s1) { double('one') }
+      let(:s2) { double('two') }
+      it "should log a content update event" do
+        User.any_instance.should_receive(:can?).with(:edit, @file).and_return(true)
+        User.any_instance.should_receive(:can?).with(:edit, @file2).and_return(true)
+        ContentUpdateEventJob.should_receive(:new).with(@file.pid, @user.user_key).and_return(s1)
+        Sufia.queue.should_receive(:push).with(s1).once
+        ContentUpdateEventJob.should_receive(:new).with(@file2.pid, @user.user_key).and_return(s2)
+        Sufia.queue.should_receive(:push).with(s2).once
+        BatchUpdateJob.new(@user.user_key, params).run
+        @user.mailbox.inbox[0].messages[0].subject.should == "Batch upload complete"
+        @user.mailbox.inbox[0].messages[0].body.should include("data-content")
+        @user.mailbox.inbox[0].messages[0].body.should include("These files")
+      end
     end
   end
 end

--- a/spec/lib/sufia/messages_spec.rb
+++ b/spec/lib/sufia/messages_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe Sufia::Messages do
+
+  let(:message) do
+    class TestClass
+      include Sufia::Messages
+    end
+    TestClass.new
+  end
+
+  let(:batch_id)  { "1" }
+  let(:single)    { double(noid: "1", to_s: "File 1") }
+  let(:multiple)  { [ double(noid: "1", to_s: "File 1"), double(noid: "2", to_s: "File 2"), double(noid: "3", to_s: "File 3") ] }
+  let(:file_list) { "<a href='/files/1'>File 1</a>, <a href='/files/2'>File 2</a>, <a href='/files/3'>File 3</a>"  }
+
+  describe "message subjects" do
+    it "should provide a subject for a success message" do
+      expect(message.success_subject).to eq("Batch upload complete")
+    end
+    it "should provide a subject for a failure message" do
+      expect(message.failure_subject).to eq("Batch upload permission denied")
+    end
+  end
+
+  describe "#single_success" do
+    let(:expected) { '<span id="ss-1"><a href="/files/1">File 1</a> has been saved.</span>' }
+    it "should render a success message for a single file" do
+      expect(message.single_success(batch_id, single)).to eq(expected)
+    end
+  end
+
+  describe "#multiple_success" do
+    let(:expected) { '<span id="ss-1"><a data-content="'+file_list+'" data-title="Files uploaded successfully" href="#" rel="popover">These files</a> have been saved.</span>' }
+    it "should render a success message for multiple files" do
+      expect(message.multiple_success(batch_id, multiple)).to eq(expected)
+    end
+  end
+
+  describe "#single_failure" do
+    let(:expected) { '<span id="ss-1"><a href="/files/1">File 1</a> could not be updated. You do not have sufficient privileges to edit it.</span>' }
+    it "should render a failure message for a single file" do
+      expect(message.single_failure(batch_id, single)).to eq(expected)
+    end
+  end
+
+  describe "#multiple_failure" do
+    let(:expected) { '<span id="ss-1"><a data-content="'+file_list+'" data-title="Files failed" href="#" rel="popover">These files</a> could not be updated. You do not have sufficient privileges to edit them.</span>' }
+    it "should render a failure message for multiple files" do
+      expect(message.multiple_failure(batch_id, multiple)).to eq(expected)
+    end
+  end
+
+  describe "#file_list" do
+    it "should replace double-quotes with single quotes" do
+      expect(message.file_list(multiple)).to eq(file_list)
+    end
+  end
+
+end

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -100,14 +100,14 @@ describe "dashboard/index.html.erb" do
 
       it "defaults to a limited number of notifications" do
         render
-        expect(rendered).to include "Sample notification 2."
-        expect(rendered).to_not include "Sample notification 1."
+        expect(rendered).to include "Single File 9"
+        expect(rendered).to_not include "Single File 2"
       end
 
       it "allows showing more notifications" do
         Sufia.config.max_notifications_for_dashboard = 6
         render
-        expect(rendered).to include "Sample notification 1."
+        expect(rendered).to include "Single File 1"
       end
 
 

--- a/sufia-models/lib/sufia/messages.rb
+++ b/sufia-models/lib/sufia/messages.rb
@@ -1,0 +1,67 @@
+module Sufia
+  module Messages
+    extend ActiveSupport::Concern
+
+    # Borrowed from AbstractController so we can render html content tags
+    attr_accessor :output_buffer
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::UrlHelper
+
+    def success_subject
+      I18n.t("sufia.messages.success.subject")
+    end
+
+    def failure_subject
+      I18n.t("sufia.messages.failure.subject")
+    end
+
+    def single_success id, file
+      content_tag :span, id: "ss-"+id do
+        [link_to_file(file), I18n.t("sufia.messages.success.single")].join(" ").html_safe
+      end
+    end
+
+    def multiple_success id, files
+      content_tag :span, id: "ss-"+id do
+        [success_link(files), I18n.t("sufia.messages.success.multiple.tag")].join(" ").html_safe
+      end
+    end
+
+    def single_failure id, file
+      content_tag :span, id: "ss-"+id do
+        [link_to_file(file), I18n.t("sufia.messages.failure.single")].join(" ").html_safe
+      end
+    end
+
+    def multiple_failure id, files
+      content_tag :span, id: "ss-"+id do
+        [failure_link(files), I18n.t("sufia.messages.failure.multiple.tag")].join(" ").html_safe
+      end
+    end
+
+    # Double-quotes are replaced with single ones so this list can be included in a data block. Ex:
+    #   <a href="#" data-content="<a href='#'>embedded link</a>" rel="popover">Click me</a>
+    def file_list files
+      files.map { |gf| link_to_file(gf) }.join(', ').gsub(/"/, "'")
+    end
+
+    def link_to_file file
+      link_to(file.to_s, Sufia::Engine.routes.url_helpers.generic_file_path(file.noid))
+    end
+
+    private
+
+    def success_link files
+      link_to I18n.t("sufia.messages.success.multiple.link"), "#", 
+        rel: "popover", 
+        data: { content: file_list(files).html_safe, title: I18n.t("sufia.messages.success.title") }
+    end
+
+    def failure_link files
+      link_to I18n.t("sufia.messages.failure.multiple.link"), "#", 
+        rel: "popover", 
+        data: { content: file_list(files).html_safe, title: I18n.t("sufia.messages.failure.title") }
+    end
+
+  end
+end

--- a/sufia-models/lib/sufia/models.rb
+++ b/sufia-models/lib/sufia/models.rb
@@ -16,6 +16,7 @@ module Sufia
 
   autoload :Utils, 'sufia/models/utils'
   autoload :Permissions
+  autoload :Messages
 
   attr_writer :queue
 


### PR DESCRIPTION
This is to address a problem where a long list of files is displayed for a batch upload:
![bad](https://cloud.githubusercontent.com/assets/312085/3802348/30b45e34-1c0e-11e4-9a44-a51656187d45.png)
Using the popover feature in Bootstrap, it'll look something like:
![good](https://cloud.githubusercontent.com/assets/312085/3802357/54e188cc-1c0e-11e4-8947-d1ee0d81d9d1.png)
and the files are displayed in the popover when the user clicks on the link, and they can click and individual file from there.

To do this, I refactored `BatchUpdateJob` to include the new class `Sufia::Messages` which mixes in some html-ish-ness.  I'm not sure about this solution, as it's mixing in html display stuff into a class that's under `lib`. Another option would be to use Rails' `AbstractController` and use an actual view to render the html that's going in the email message.  Thoughts?

Also, note the `sanitize_text = false` option in `#send_message`.  This is needed to render the complex bits of html, otherwise, it's just removed.

Comments?
@jcoyne @mjgiarlo @cam156 
