### PR TITLE
Changing toggle to work correctly for glyphicon right and down

### DIFF
--- a/app/assets/javascripts/sufia.js
+++ b/app/assets/javascripts/sufia.js
@@ -115,11 +115,11 @@ Blacklight.onLoad(function() {
    */
   $("li.expandable").click(function(){
     $(this).next("ul").slideToggle();
-    $(this).find('i').toggleClass("glyphicon glyphicon-chevron-down");
+    $(this).find('i').toggleClass("glyphicon-chevron-right glyphicon-chevron-down");
   });
 
   $("li.expandable_new").click(function(){
-    $(this).find('i').toggleClass("glyphicon glyphicon-chevron-down");
+    $(this).find('i').toggleClass("glyphicon-chevron-right glyphicon-chevron-down");
   });
 
   $(".sorts-dash").click(function(){


### PR DESCRIPTION
Currently it just switches between glyphicon and glyphicon-chevron-down leaving the glyphicon-chevron right in there which gives you an empty icon.
