### PR TITLE
Full module name for Legato::Model

### DIFF
--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -292,7 +292,7 @@ describe GenericFilesController do
             OpenStruct.new(date: '2014-01-05', pageviews: 2)])
         allow(mock_query).to receive(:map).and_return(mock_query.for_path.map(&:marshal_dump))
         profile = double('profile')
-        allow(profile).to receive(:pageview).and_return(mock_query)
+        allow(profile).to receive(:sufia__pageview).and_return(mock_query)
         allow(Sufia::Analytics).to receive(:profile).and_return(profile)
 
         download_query = double('query')
@@ -300,7 +300,7 @@ describe GenericFilesController do
           OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "sufia:123456789", totalEvents: "3")
         ])
         allow(download_query).to receive(:map).and_return(download_query.for_file.map(&:marshal_dump))
-        allow(profile).to receive(:download).and_return(download_query)
+        allow(profile).to receive(:sufia__download).and_return(download_query)
       end
 
       it 'renders the stats view' do

--- a/sufia-models/app/models/file_usage.rb
+++ b/sufia-models/app/models/file_usage.rb
@@ -28,12 +28,16 @@ class FileUsage
 
   private
 
+  # Sufia::Download is sent to Sufia::Analytics.profile as #sufia__download
+  # see Legato::ProfileMethods.method_name_from_klass
   def download_statistics
-    Sufia::Analytics.profile.download(sort: 'date').for_file(self.id)
+    Sufia::Analytics.profile.sufia__download(sort: 'date').for_file(self.id)
   end
 
+  # Sufia::Pageview is sent to Sufia::Analytics.profile as #sufia__pageview
+  # see Legato::ProfileMethods.method_name_from_klass
   def pageview_statistics
-    Sufia::Analytics.profile.pageview(sort: 'date').for_path(self.path)
+    Sufia::Analytics.profile.sufia__pageview(sort: 'date').for_path(self.path)
   end
 
   def pageviews_to_flot values = Array.new


### PR DESCRIPTION
This fixes a problem that wasn't present until recently, possibly due to an update to the Legato gem.  `Sufia::Analytics.profile` takes as a method a custom defined class such as `Sufia::Download` or `Sufia::Pageview`.  Previously, you only needed to pass either `download` or `pageview`, but that has changed and now you must use `sufia__download` which is then converted to `Sufia::Download` by `Legato::ProfileMethods.method_name_from_klass`.
