### PR TITLE
Makes sure only visible files are picked up on the Recent Uploads panel

### DIFF
--- a/app/controllers/concerns/sufia/homepage_controller.rb
+++ b/app/controllers/concerns/sufia/homepage_controller.rb
@@ -8,7 +8,7 @@ module Sufia::HomepageController
     include Sufia::Controller
     include Blacklight::SolrHelper
 
-    self.solr_search_params_logic += [:only_generic_files]
+    self.solr_search_params_logic += [:only_generic_files, :add_access_controls_to_solr_params]
     layout 'homepage'
   end
 

--- a/spec/controllers/homepage_controller_spec.rb
+++ b/spec/controllers/homepage_controller_spec.rb
@@ -9,7 +9,7 @@ describe HomepageController do
       @gf1 = GenericFile.new(title:['Test Document PDF'], filename:['test.pdf'], tag:['rocks'], read_groups:['public'])
       @gf1.apply_depositor_metadata('mjg36')
       @gf1.save
-      @gf2 = GenericFile.new(title:['Test 2 Document'], filename:['test2.doc'], tag:['clouds'], contributor:['Contrib1'], read_groups:['public'])
+      @gf2 = GenericFile.new(title:['Test Private Document'], filename:['test2.doc'], tag:['clouds'], contributor:['Contrib1'], read_groups:['private'])
       @gf2.apply_depositor_metadata('mjg36')
       @gf2.save
     end
@@ -41,6 +41,13 @@ describe HomepageController do
         expect(marketing.name).to eq 'marketing_text'
       end
     end
+
+    it "should not include other user's private documents in recent documents" do
+      get :index
+      expect(response).to be_success
+      titles = assigns(:recent_documents).map {|d| d['desc_metadata__title_tesim'][0]}
+      expect(titles).to_not include('Test Private Document')
+    end    
 
     context "with a document not created this second" do
       before do


### PR DESCRIPTION
The change itself is pretty simple, I am just making sure the call to Solr returns only documents that the user has access to see. 

This prevents the site from requesting information (title, thumbnail, et cetera) for documents that the user does not have access to. This in turns prevents an intermittent "you are not authorized" flash message that was confusing to users. 
