### PR TITLE
Changing to not use the path if the label has already been set.  

### DIFF
--- a/spec/actors/generic_file/actor_spec.rb
+++ b/spec/actors/generic_file/actor_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe Sufia::GenericFile::Actor do
+
+  let(:user) { FactoryGirl.create(:user) }
+
   describe "#virus_check" do
     it "should return the results of running ClamAV scanfile method" do
       expect(ClamAV.instance).to receive(:scanfile).and_return(1)
@@ -9,7 +12,6 @@ describe Sufia::GenericFile::Actor do
   end
 
   describe "#featured_work" do
-    let(:user) { FactoryGirl.create(:user) }
     let(:gf) { FactoryGirl.create(:generic_file, visibility: 'open') }
     let(:actor) { Sufia::GenericFile::Actor.new(gf, user)}
 
@@ -21,6 +23,23 @@ describe Sufia::GenericFile::Actor do
       # Switch document from public to restricted
       attributes = {'permissions'=>{'group' =>{'public' => '1', 'registered'=>'2'}}}
       expect { actor.update_metadata(attributes, 'restricted') }.to change { FeaturedWork.count }.by(-1)
+    end
+  end
+
+  context "when a label is already specified" do
+    let(:generic_file_with_label) do
+      GenericFile.new.tap do |f|
+        f.apply_depositor_metadata(user.user_key)
+        f.label = "test_file.name"
+      end
+    end
+
+    let(:actor) { Sufia::GenericFile::Actor.new(generic_file_with_label, user)}
+
+    it "uses the label instead of the path" do
+      allow(actor).to receive(:save_characterize_and_record_committer).and_return("true")
+      actor.create_content(Tempfile.new('foo'), 'tmp\foo', 'content')
+      expect(generic_file_with_label.content.dsLabel).to eq generic_file_with_label.label
     end
   end
 

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -46,7 +46,8 @@ describe ImportUrlJob do
     it "should create a content datastream" do
       Net::HTTP.any_instance.should_receive(:request_get).with(file_path).and_yield(mock_response)
       job.run
-      generic_file.reload.content.size.should == 4218
+      expect(generic_file.reload.content.size).to eq 4218
+      expect(generic_file.content.dsLabel).to eq file_path
     end
   end
 

--- a/sufia-models/app/actors/sufia/generic_file/actor.rb
+++ b/sufia-models/app/actors/sufia/generic_file/actor.rb
@@ -28,7 +28,8 @@ module Sufia::GenericFile
     end
 
     def create_content(file, file_name, dsid)
-      generic_file.add_file(file, dsid, file_name)
+      fname = generic_file.label.blank? ? file_name.truncate(255) : generic_file.label
+      generic_file.add_file(file, dsid, fname)
       save_characterize_and_record_committer do
         if Sufia.config.respond_to?(:after_create_content)
           Sufia.config.after_create_content.call(generic_file, user)


### PR DESCRIPTION
The path can be more than 255 characters which messes with Fedora...

If the path is long (which happens with browse-everything/Box integration) you get the following error...
ERROR 2014-08-07 21:38:35.383 [http-apr-8080-exec-25](DatastreamResource) Unexpected error fulfilling REST API request
org.fcrepo.server.errors.ValidationException: Datastream label is too long. Maximum length is 255 characters.

The browse-everything integration passes back a file name which is set to the label here: https://github.com/projecthydra/sufia/blob/master/app/controllers/concerns/sufia/files_controller/browse_everything.rb#L26
