### PR TITLE
Refactoring breadcrumbs; adding BreadcrumbHelperBehavior

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,0 +1,3 @@
+module BreadcrumbHelper
+  include Sufia::BreadcrumbHelperBehavior
+end

--- a/app/helpers/sufia/breadcrumb_helper_behavior.rb
+++ b/app/helpers/sufia/breadcrumb_helper_behavior.rb
@@ -1,0 +1,26 @@
+module Sufia
+  module BreadcrumbHelperBehavior
+
+    def crumbs
+      if request.referer.match(/dashboard/)
+        [link_to(t('sufia.dashboard.title'), sufia.dashboard_index_path)]
+      else
+        []
+      end
+    end
+
+    def breadcrumb_links
+      case request.referer
+      when /collections/
+        crumbs << link_to(t('sufia.dashboard.my.collections'), sufia.dashboard_collections_path)
+      when /files/
+        crumbs << link_to(t('sufia.dashboard.my.files'), sufia.dashboard_files_path)
+      when /catalog/
+        crumbs << link_to(t('sufia.bread_crumb.search_results'), request.referer)
+      else
+        crumbs
+      end
+    end
+
+  end
+end

--- a/app/views/generic_files/_breadcrumbs.html.erb
+++ b/app/views/generic_files/_breadcrumbs.html.erb
@@ -1,31 +1,19 @@
-<%# convert class variable to a local variable if the local hasn't been set %>
-<% generic_file = @generic_file unless generic_file  %>
-<% include_file ||= true %>
+<%
+  generic_file ||= @generic_file
+  include_file ||= true
+  crumbs = request.referer.nil? ? [] : breadcrumb_links
+  crumbs << generic_file.title.first if include_file
+%>
 
-<div class="breadcrumbs">
-  <%
-     crumbs = []
-     crumbs << link_to('Home', root_path)
-
-     case request.referer
-     when /collections/
-       crumbs << link_to(t('sufia.bread_crumb.collections_list'), sufia.dashboard_collections_path)
-     when /dashboard/
-       crumbs << link_to(t('sufia.bread_crumb.file_list'), sufia.dashboard_files_path)
-     when /files/
-       crumbs << link_to(t('sufia.bread_crumb.previous'), request.referer)
-     when /catalog/
-       crumbs << link_to(t('sufia.bread_crumb.search_results'), request.referer)
-     end
-
-     crumbs << generic_file.title.first if include_file
-
-     crumbs.each do |crumb| %>
-       <% if crumb == crumbs.last %>
-       <span class="active"> <%= crumb %>
-       <% else %>
-       <span> <%= crumb %> <span class="divider">/</span>
-       <% end %>
-       </span>
-  <% end %>
-</div><!-- /breadcrumbs -->
+<% unless crumbs.empty? %>
+  <div class="breadcrumbs">
+    <% crumbs.each do |crumb| %>
+      <% if crumb == crumbs.last %>
+        <span class="active"> <%= crumb %>
+      <% else %>
+        <span> <%= crumb %> <span class="divider">/</span>
+      <% end %>
+      </span>
+    <% end %>
+  </div><!-- /breadcrumbs -->
+<% end %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -111,8 +111,6 @@ en:
       rights: "Licensing and distribution information governing access to the file. Select from the provided drop-down list. <em>This is a required field</em>."
     background_attribution: "Background image courtesy of Penn State University"
     bread_crumb:
-      file_list: "Your File Listing"
-      collections_list: "Your Collections"
       previous:  "Back to Previous"
       search_results: "Back to search results"
     visibility:

--- a/spec/helpers/breadcrumb_helper_spec.rb
+++ b/spec/helpers/breadcrumb_helper_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe BreadcrumbHelper do
+
+  let(:request) { double("request", referer: referer) }
+
+  context "when comming from the catalog" do
+    let! (:referer) { "http://...catalog" }
+    specify "then the first crumb link to the homepage should be omitted" do
+      allow(view).to receive(:request).and_return(request)
+      expect(helper.breadcrumb_links.first).to include(t('sufia.bread_crumb.search_results'))
+    end
+  end
+
+  context "when comming from the user's dashboard" do
+    let! (:referer) { "http://...dashboard" }
+    specify "then the only crumb link should be back to the user's dashboard" do
+      allow(view).to receive(:request).and_return(request)
+      expect(helper.breadcrumb_links.first).to include(t('sufia.dashboard.title'))
+    end
+  end
+
+  context "when comming from the user's files" do
+    let! (:referer) { "http://...dashboard/files" }
+    specify "then the first crumb link should be back to the user's dashboard" do
+      allow(view).to receive(:request).and_return(request)
+      expect(helper.breadcrumb_links.first).to include(t('sufia.dashboard.title'))
+    end
+    specify "then the second crumb should be back to the user's files" do
+      allow(view).to receive(:request).and_return(request)
+      expect(helper.breadcrumb_links.second).to include(t('sufia.dashboard.my.files'))     
+    end
+  end
+
+  context "when comming from the user's collections" do
+    let! (:referer) { "http://...dashboard/collections" }
+    specify "then the first crumb link should be back to the user's dashboard" do
+      allow(view).to receive(:request).and_return(request)
+      expect(helper.breadcrumb_links.first).to include(t('sufia.dashboard.title'))
+    end
+    specify "then the second crumb should be back to the user's collections" do
+      allow(view).to receive(:request).and_return(request)
+      expect(helper.breadcrumb_links.second).to include(t('sufia.dashboard.my.collections'))     
+    end
+  end
+
+end

--- a/spec/views/generic_file/_breadcrumbs.html.erb_spec.rb
+++ b/spec/views/generic_file/_breadcrumbs.html.erb_spec.rb
@@ -10,7 +10,7 @@ describe 'generic_files/_breadcrumbs.html.erb' do
     it "should link back to dashboard" do
       allow(view).to receive(:request).and_return(request)
       render partial: 'generic_files/breadcrumbs', locals: {include_file: false, generic_file: generic_file }
-      expect(rendered).to have_link(t('sufia.bread_crumb.file_list'), sufia.dashboard_files_path)
+      expect(rendered).to have_link(t('sufia.dashboard.title'), sufia.dashboard_index_path)
     end
   end
   describe 'when coming from files list' do
@@ -18,7 +18,7 @@ describe 'generic_files/_breadcrumbs.html.erb' do
     it "should link back to files list" do
       allow(view).to receive(:request).and_return(request)
       render partial: 'generic_files/breadcrumbs', locals: {include_file: false, generic_file: generic_file }
-      expect(rendered).to have_link(t('sufia.bread_crumb.file_list'), sufia.dashboard_files_path)
+      expect(rendered).to have_link(t('sufia.dashboard.my.files'), sufia.dashboard_files_path)
     end
   end
   describe 'when coming from collections list' do
@@ -26,7 +26,7 @@ describe 'generic_files/_breadcrumbs.html.erb' do
     it "should link back to collections" do
       allow(view).to receive(:request).and_return(request)
       render partial: 'generic_files/breadcrumbs', locals: {include_file: false, generic_file: generic_file }
-      expect(rendered).to have_link(t('sufia.bread_crumb.collections_list'), sufia.dashboard_collections_path)
+      expect(rendered).to have_link(t('sufia.dashboard.my.collections'), sufia.dashboard_collections_path)
     end
   end
 end


### PR DESCRIPTION
This makes the breadcrumb navigation clearer, regarding the links to the dashboard, which should appear when coming from either of the user's files or collections views.  This also removes the redundant breadcrumb link to the "Home" page which is duplicated in the navigation header.
