### PR TITLE
Adds labels and ARIA hints for screen-readers

### DIFF
--- a/app/views/homepage/_featured_fields.html.erb
+++ b/app/views/homepage/_featured_fields.html.erb
@@ -1,18 +1,20 @@
-      <h3>
-        <%= link_to truncate(featured.title_or_label, length: 28, separator: ' '),
-          sufia.generic_file_path(featured), title: featured.title_or_label  %>
-      </h3>
-      <div> 
-        <%= link_to_profile featured.depositor("no depositor value") %>
-      </div>
-      <div> 
-        <%= link_to truncate(featured.label, length: 25),
-            sufia.generic_file_path(featured), title: featured.label %>
-      </div>
-      <div> 
-        <%= link_to_facet_list(featured.resource_type, 'desc_metadata__resource_type', 'no resource specified') %>
-      </div>
-      <div> 
-        <%= link_to_facet_list(featured.tags, 'desc_metadata__tag', 'no keywords specified') %>
-      </div>
-
+<h3>
+  <span class="sr-only">Title</span>
+  <%= link_to truncate(featured.title_or_label, length: 28, separator: ' '), sufia.generic_file_path(featured), title: featured.title_or_label  %>
+</h3>
+<div> 
+  <span class="sr-only">Depositor</span>
+  <%= link_to_profile featured.depositor("no depositor value") %>
+</div>
+<div> 
+  <span class="sr-only">Filename</span>
+  <%= link_to truncate(featured.label, length: 25), sufia.generic_file_path(featured), title: featured.label %>
+</div>
+<div> 
+  <span class="sr-only">File type</span>
+  <%= link_to_facet_list(featured.resource_type, 'desc_metadata__resource_type', 'no resource specified') %>
+</div>
+<div> 
+  <span class="sr-only">Keywords</span>
+  <%= link_to_facet_list(featured.tags, 'desc_metadata__tag', 'no keywords specified') %>
+</div>

--- a/app/views/homepage/_home_content.html.erb
+++ b/app/views/homepage/_home_content.html.erb
@@ -1,15 +1,15 @@
 <div class="col-xs-12 col-sm-6">
   <ul id="homeTabs" class="nav nav-tabs">
-    <li><a href="#featured_container" data-toggle="tab"><%= t('sufia.homepage.featured_works') %></a></li>
-    <li><a href="#recently_uploaded" data-toggle="tab">Recently Uploaded</a></li>
+    <li><a href="#featured_container" data-toggle="tab" role="tab" id="featureTab"><%= t('sufia.homepage.featured_works') %></a></li>
+    <li><a href="#recently_uploaded" data-toggle="tab" role="tab" id="recentTab">Recently Uploaded</a></li>
   </ul>
   <div class="tab-content">
-    <div class="tab-pane fade in" id="featured_container">
+    <div class="tab-pane fade in" id="featured_container" role="tabpanel" aria-labelledby="featureTab">
       <%= render partial: '/homepage/featured_works' %>
     </div>
-     <div class="tab-pane fade" id="recently_uploaded">
-       <%= render partial: 'recents', locals: { recent_documents: @recent_documents, msg: "No public work has been contributed.", display_thumbs: true, display_access: false } %>
-     </div>
+    <div class="tab-pane fade" id="recently_uploaded" role="tabpanel" aria-labelledby="recentTab">
+      <%= render partial: 'recents', locals: { recent_documents: @recent_documents, msg: "No public work has been contributed.", display_thumbs: true, display_access: false } %>
+    </div>
   </div>
 </div><!-- /.col-xs-6 -->
 <div class="col-xs-12 col-sm-6">

--- a/app/views/homepage/_recent_document.html.erb
+++ b/app/views/homepage/_recent_document.html.erb
@@ -9,8 +9,7 @@
       <% end %>
       <td>
         <h3>
-          <%= link_to truncate(recent_document.title_or_label, length: 28, separator: ' '), sufia.generic_file_path(recent_document.noid), title: recent_document.title_or_label  %>
-
+          <span class="sr-only">Title</span><%= link_to truncate(recent_document.title_or_label, length: 28, separator: ' '), sufia.generic_file_path(recent_document.noid), title: recent_document.title_or_label  %>
           <% if display_access %>
               <% if recent_document.registered? %>
                  <span class="label label-info" title="<%=t('sufia.institution_name') %>"><%=t('sufia.institution_name') %></span>
@@ -22,9 +21,9 @@
           <% end %>
         </h3>
         <p>
-          <%= link_to truncate(recent_document.label, length: 25),
+          <span class="sr-only">Filename</span><%= link_to truncate(recent_document.label, length: 25),
               sufia.generic_file_path(recent_document.noid), title: recent_document.label %><br />
-          <%= link_to_facet_list(recent_document.tags, 'desc_metadata__tag', 'no keywords specified').html_safe %>
+          <span class="sr-only">Keywords</span><%= link_to_facet_list(recent_document.tags, 'desc_metadata__tag', 'no keywords specified').html_safe %>
         </p>
       </td>
     </tr>

--- a/app/views/homepage/_recents.html.erb
+++ b/app/views/homepage/_recents.html.erb
@@ -4,9 +4,12 @@
     <% msg = 'You have no documents to display. Contribute some of your documents!' if msg.blank? %>
     <h3><%= msg %></h3>
   <% else %>
-
     <div id="recent_docs">
       <table class="table table-bordered table-striped">
+        <tr>
+          <th scope="col">Depositor</th>
+          <th scope="col">File Details</th>
+        </tr>
         <%= render partial: "recent_document", collection: recent_documents, locals: {display_thumbs: display_thumbs, display_access: display_access} %>
       </table>
     </div>


### PR DESCRIPTION
This is to try to help screen readers understand better the structure of the data under "Recently Uploaded" and "Featured Works" on the home page. 

The Mozilla web site recommends tagging headers and content with role="tab" and role="tabpanel" to that the screen readers can provide more context ( https://developer.mozilla.org/en-US/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets) I also added a few screen-reader only labels. 
