### PR TITLE
improved accessibility of tag cloud

### DIFF
--- a/app/views/homepage/_home_content.html.erb
+++ b/app/views/homepage/_home_content.html.erb
@@ -17,6 +17,7 @@
     <%- if blacklight_config.respond_to?(:tag_cloud_field_name) && blacklight_config.tag_cloud_field_name %>
         <div class="row">
           <h2 class="heading1 pull-left">Explore</h2>
+          <span class="sr-only">Popular Keywords</span>
           <%= render partial: 'tagcloud', locals: { tag_cloud_field_name: blacklight_config.tag_cloud_field_name } %>
         </div>
     <%- end %>

--- a/app/views/homepage/_tagcloud.html.erb
+++ b/app/views/homepage/_tagcloud.html.erb
@@ -1,7 +1,8 @@
-<a role="button" class="btn btn-default tag-toggle-list">List</a>
-<ul class="tagcloud" data-facet="<%= tag_cloud_field_name %>"></ul>
-<div class="btn-group btn-group-justified tag-sort">
+<a role="button" aria-hidden="true" class="btn btn-default tag-toggle-list">List</a>
+<label for="tag-cloud" class="sr-only">Sort By</label>
+<div id="tag-cloud" class="btn-group btn-group-justified tag-sort">
   <a role="button" class="btn btn-default tag-sort-za">Z-A</a>
   <a role="button" class="btn btn-default tag-sort-az">A-Z</a>
   <a role="button" class="btn btn-default tag-sort-numerical">Rank</a>
 </div>
+<ul class="tagcloud" data-facet="<%= tag_cloud_field_name %>"></ul>


### PR DESCRIPTION
This makes it easier for screen readers to use the tag cloud (and associated sort buttons).

The only thing that is visible for non-screen reader users is that the sorting appears above the tag cloud instead of below. Screen reader users didn't see the sort options in tests when it was below.
![tag-cloud](https://cloud.githubusercontent.com/assets/74879/3897977/b98b207c-2266-11e4-9798-f88af5717b1c.png)
