### PR TITLE
made search result metadata not use headers

### DIFF
--- a/app/assets/stylesheets/styles.css.scss
+++ b/app/assets/stylesheets/styles.css.scss
@@ -18,9 +18,10 @@ body {
   background-image: linear-gradient(to bottom, #E1E1E1 0%, #FFFFFF 100%);
 }
 
-#page-positioner h1, #page-positioner h2, #page-positioner h3,
-#page-positioner h4, #page-positioner h5, #page-positioner h6 {
-  font-family: 'Lato', Verdana, Arail, Helvetica, sans-serif;
+#page-positioner {
+  h1, h2, h3, h4, h5, h6, .attribute-label {
+    font-family: 'Lato', Verdana, Arail, Helvetica, sans-serif;
+  }
 }
 
 #page-positioner {
@@ -31,8 +32,10 @@ body {
   font-weight: 300;
 }
 
-#page-positioner h3, #page-positioner h4 {
-  font-weight: 400;
+#page-positioner {
+  h3, h4, .attribute-label {
+    font-weight: 400;
+  }
 }
 
 .input-group {

--- a/app/views/shared/_attributes.html.erb
+++ b/app/views/shared/_attributes.html.erb
@@ -1,26 +1,26 @@
       <table class="table">
         <tr>
-          <th><h4>Title:</h4></th>
+          <th><span class="attribute-label h4">Title:</span></th>
           <td><%= work.title %></td>
         </tr>
         <tr>
-          <th><h4>Depositor:<h4></div>
+          <th><span class="attribute-label h4">Depositor:</span></div>
           <td><%= link_to_profile work.depositor("no depositor value") %></td>
         </tr>
         <tr>
-          <th><h4>Creator:</h4></th>
+          <th><span class="attribute-label h4">Creator:</span></th>
           <td><%= work.creator %></td>
         </tr>
         <tr>
-          <th><h4>Description:</h4></th>
+          <th><span class="attribute-label h4">Description:</span></th>
           <td><%= iconify_auto_link(work.description) %></th>
         </tr>
         <tr>
-          <th><h4>Keywords:</h4></th>
+          <th><span class="attribute-label h4">Keywords:</span></th>
           <td><%= work.tags.join(', ') %></td>
         </tr>
         <tr>
-          <th><h4>Date Uploaded:</h4></th>
+          <th><span class="attribute-label h4">Date Uploaded:</span></th>
           <td><%= work.date_uploaded %></td>
         </tr>
       </table>


### PR DESCRIPTION
This should allow screen reader users to step through each search result when they want to instead of having to step through each piece of metadata on each search result. The rendered display is unchanged.
