### PR TITLE
Sufia::BootstrapBreadcrumbsBuilder for rendering breadcrumbs

### DIFF
--- a/app/builders/sufia/bootstrap_breadcrumbs_builder.rb
+++ b/app/builders/sufia/bootstrap_breadcrumbs_builder.rb
@@ -1,0 +1,28 @@
+# The BootstrapBreadcrumbsBuilder is a Bootstrap compatible breadcrumb builder.
+# It provides basic functionalities to render a breadcrumb navigation according to Bootstrap's conventions.
+#
+# BootstrapBreadcrumbsBuilder accepts a limited set of options:
+#
+# You can use it with the :builder option on render_breadcrumbs:
+#     <%= render_breadcrumbs builder: Sufia::BootstrapBreadcrumbsBuilder %>
+#
+class Sufia::BootstrapBreadcrumbsBuilder < BreadcrumbsOnRails::Breadcrumbs::Builder
+  include ActionView::Helpers::OutputSafetyHelper
+  def render
+    if @elements.blank?
+      return ""
+    end
+
+    @context.content_tag(:ul, class: 'breadcrumb') do
+      safe_join(@elements.uniq.collect {|e| render_element(e)})
+    end 
+  end
+
+  def render_element(element)
+    html_class = 'active' if @context.current_page?(compute_path(element))
+
+    @context.content_tag(:li, class: html_class) do
+      @context.link_to_unless_current(@context.truncate(compute_name(element), length: 30, separator: ' '), compute_path(element), element.options)
+    end
+  end
+end

--- a/app/views/batch_edits/edit.html.erb
+++ b/app/views/batch_edits/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs %>
+<%= render_breadcrumbs builder: Sufia::BootstrapBreadcrumbsBuilder %>
 <h2 class="non lower">Batch Edit Descriptions &nbsp;&nbsp;&nbsp;<small>Click on labels below to edit file descriptions.</small> </h2>
 <div class="scrollx scrolly fileHeight"> <!-- original values -->
   <h3> <b>Changes will be applied to: (<%= @names.size %> files) </b></h3>

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -1,5 +1,5 @@
 <% @page_title = "Edit Collection #{display_title(@collection)} - #{application_name}" %>
-<%= render_breadcrumbs %>
+<%= render_breadcrumbs builder: Sufia::BootstrapBreadcrumbsBuilder %>
 
 <h1>Edit Collection: <%= display_title(@collection) %></h1>
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = "#{@collection.title} - #{application_name}" %>
 
-<%= render_breadcrumbs %>
+<%= render_breadcrumbs builder: Sufia::BootstrapBreadcrumbsBuilder %>
 
   <div itemscope itemtype="http://schema.org/CollectionPage" class="row">
     <div class="col-sm-10 pull-right">

--- a/app/views/generic_files/edit.html.erb
+++ b/app/views/generic_files/edit.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "edit", formats: [:js] %>
 <% end %>
 
-<%= render_breadcrumbs %>
+<%= render_breadcrumbs builder: Sufia::BootstrapBreadcrumbsBuilder %>
 <h1 class="lower">Edit <%= @generic_file %></h1>
 
 <div class="row">

--- a/app/views/generic_files/show.html.erb
+++ b/app/views/generic_files/show.html.erb
@@ -41,7 +41,7 @@
   initialize_audio();
 <% end %>
 
-<%= render_breadcrumbs %>
+<%= render_breadcrumbs builder: Sufia::BootstrapBreadcrumbsBuilder %>
 <div class="container-fluid">
 <div class="row">
   <div class="col-xs-12 col-sm-4">

--- a/app/views/generic_files/stats.html.erb
+++ b/app/views/generic_files/stats.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs %>
+<%= render_breadcrumbs builder: Sufia::BootstrapBreadcrumbsBuilder %>
 
 <!-- Adapted from jquery-flot examples https://github.com/flot/flot/blob/master/examples/visitors/index.html -->
 <!--[if lte IE 8]><%= javascript_include_tag 'excanvas' %><![endif]-->


### PR DESCRIPTION
This creates a builder class for rendering breadcrumbs.  It's an exact copy of Spotlight's code and is designed to be used with Boostrap's breadcrumb styles.  It can be easily overridden for any local implementor's needs.
