### PR TITLE
Forces to require Sufia version 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you have questions or need help, please email [the Hydra community developmen
 ```rails new my_app```
 ### Add gems to Gemfile
 ```
-gem 'sufia'
+gem 'sufia', '~> 4.0.0'
 gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'  # required to handle pagination properly in dashboard. See https://github.com/amatsuda/kaminari/pull/322
 ```
 Then `bundle install`


### PR DESCRIPTION
Forcing to require version 4.x of Sufia otherwise step `rails generate sufia:install -f` does not work.
