### PR TITLE
Adjusting metadata-related tests

### DIFF
--- a/spec/actors/generic_file/actor_spec.rb
+++ b/spec/actors/generic_file/actor_spec.rb
@@ -56,11 +56,10 @@ describe Sufia::GenericFile::Actor do
 
     let(:actor) { Sufia::GenericFile::Actor.new(generic_file_with_label, user)}
 
-    it "uses the label instead of the path" do
-      skip "Fedora4 doesn't have labels. Should we use something else?"
+    it "uses the original name instead of the path" do
       allow(actor).to receive(:save_characterize_and_record_committer).and_return("true")
       actor.create_content(Tempfile.new('foo'), 'tmp\foo', 'content')
-      expect(generic_file_with_label.content.dsLabel).to eq generic_file_with_label.label
+      expect(generic_file_with_label.content.original_name).to eq generic_file_with_label.label
     end
   end
 

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -33,12 +33,10 @@ describe DownloadsController do
           expect(response.body).to eq expected_content
           expect(response).to be_success
         end
-        context "when grabbing a metadata datastream" do
-          #let(:expected_datastream) { object.descMetadata }
+        context "when grabbing the characterization datastream" do
+          let(:expected_content) { "" }
           it "should return requested datastreams" do
-            skip "Datastream doesn't exist anymore because terms are now properties. Is this neceesary?"
-            expect(controller).to receive(:send_file_headers!).with({filename: 'descMetadata', disposition: 'inline', type: 'text/plain' })
-            get "show", id: file, datastream_id: "descMetadata"
+            get "show", id: file, datastream_id: "characterization"
             expect(response.body).to eq expected_content
             expect(response).to be_success
           end

--- a/spec/models/fits_datastream_spec.rb
+++ b/spec/models/fits_datastream_spec.rb
@@ -35,10 +35,15 @@ describe FitsDatastream, unless: $in_travis do
     let(:datastream) { @file.characterization }
     let(:xml) { datastream.ng_xml }
     let(:namespace) { {'ns'=>'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'} }
+    let(:solr_doc) { @file.to_solr }
 
     it "should make the fits XML" do
       expect(xml.xpath('//ns:imageWidth/text()', namespace).inner_text).to eq '50'
     end
+
+    it "should index into solr" do
+      expect(solr_doc[Solrizer.solr_name("mime_type")].first).to eq "image/png"
+    end 
   end
 
   describe "video" do

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -977,35 +977,44 @@ describe GenericFile do
     end
   end
 
-  describe "should create a full to_solr record" do
+  describe "to_solr record" do
+    let(:depositor) { 'jcoyne' }
     subject do
       GenericFile.new.tap do |f|
-        f.apply_depositor_metadata('jcoyne')
+        f.apply_depositor_metadata(depositor)
         f.save
       end
     end
-    let(:mime_type_key) { Solrizer.solr_name("mime_type") }
+    let(:depositor_key) { Solrizer.solr_name("depositor") }
     let(:title_key) { Solrizer.solr_name("title", :stored_searchable, type: :string) }
+    let(:title) { ["abc123"] }
+    let(:no_terms) { GenericFile.find(subject.id).to_solr }
+    let(:terms) { 
+      file = GenericFile.find(subject.id)
+      file.title = title
+      file.save
+      file.to_solr
+    }
 
     after do
       subject.destroy
     end
 
-    it "gets both sets of data into solr" do
-      skip "We need to store characterization info in a property"
-      f1 =  GenericFile.find(subject.id)
-      f2 =  GenericFile.find(subject.id)
-      f1.mime_type = "video/abc123" # stored in the characterization datastream
-      f2.title = ["abc123"]
-      expect(f2.mime_type).to eq ''
-      f1.save
-      f2.save
-      solr = f2.to_solr
-      expect {
-        f2.save
-      }.to change{ f2.to_solr[mime_type_key] }.from(['']).to(["video/abc123"])
-      expect(f2.to_solr[title_key]).to eq ["abc123"]
+    context "without terms" do
+      specify "title is nil" do
+        expect(no_terms[title_key]).to be_nil
+      end
     end
+
+    context "with terms" do
+      specify "depositor is set" do
+        expect(terms[depositor_key].first).to eql(depositor)
+      end
+      specify "title is set" do
+        expect(terms[title_key]).to eql(title)
+      end
+    end
+
   end
 
   describe "public?" do


### PR DESCRIPTION
Some minor changes to metadata-related tests in Sufia so that they'll be compatible with Fedora4.
