### PR TITLE
FC4 Datasteams

### DIFF
--- a/app/controllers/concerns/sufia/files_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller_behavior.rb
@@ -138,7 +138,7 @@ module Sufia
     protected
 
     def wants_to_revert?
-      params.has_key?(:revision) && params[:revision] != @generic_file.content.latest_version.versionID
+      params.has_key?(:revision) && params[:revision] != @generic_file.content.latest_version.to_s
     end
 
     def actor
@@ -146,7 +146,7 @@ module Sufia
     end
 
     def update_version
-      actor.revert_content(params[:revision], datastream_id)
+      actor.revert_content(params[:revision])
     end
 
     def update_file

--- a/spec/actors/generic_file/actor_spec.rb
+++ b/spec/actors/generic_file/actor_spec.rb
@@ -47,19 +47,27 @@ describe Sufia::GenericFile::Actor do
   end
 
   context "when a label is already specified" do
+    let(:label)    { "test_file.png" }
+    let(:new_file) { "foo.jpg" }
     let(:generic_file_with_label) do
       GenericFile.new.tap do |f|
         f.apply_depositor_metadata(user.user_key)
-        f.label = "test_file.name"
+        f.label = label
       end
     end
-
     let(:actor) { Sufia::GenericFile::Actor.new(generic_file_with_label, user)}
 
-    it "uses the original name instead of the path" do
+    before do
       allow(actor).to receive(:save_characterize_and_record_committer).and_return("true")
-      actor.create_content(Tempfile.new('foo'), 'tmp\foo', 'content')
-      expect(generic_file_with_label.content.original_name).to eq generic_file_with_label.label
+      actor.create_content(Tempfile.new(new_file), new_file, "content")
+    end
+
+    it "will retain the object's original label" do
+      expect(generic_file_with_label.label).to eql(label)
+    end
+
+    it "will use the new file's name" do
+      expect(generic_file_with_label.content.original_name).to eql(new_file)
     end
   end
 

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -6,8 +6,7 @@ describe GenericFilesController do
     allow(controller).to receive(:has_access?).and_return(true)
     sign_in user
     allow_any_instance_of(User).to receive(:groups).and_return([])
-    allow(controller).to receive(:clear_session_user) ## Don't clear out the authenticated session
-    #allow_any_instance_of(GenericFile).to receive(:characterize)
+    allow(controller).to receive(:clear_session_user) # Don't clear out the authenticated session
   end
 
   describe "#create" do
@@ -384,106 +383,82 @@ describe GenericFilesController do
       end
     end
 
-    describe "restoring an old version" do
+    context "with two existing versions from different users" do
+
+      let(:file1)       { "world.png" }
+      let(:file1_type)  { "image/png" }
+      let(:file2)       { "image.jpg" }
+      let(:file2_type)  { "image/jpeg" }
+      let(:first_user)  { FactoryGirl.find_or_create(:jill)}
+      let(:second_user) { FactoryGirl.find_or_create(:archivist) }
+      let(:version1)    { generic_file.content.versions[1] }
+      let(:version2)    { generic_file.content.versions[2] }
+
       before do
         allow_any_instance_of(GenericFile).to receive(:characterize)
+        sign_in first_user
+        actor1 = Sufia::GenericFile::Actor.new(generic_file, first_user)
+        image1 = fixture_file_upload(file1)
+        actor1.create_content(image1, file1, 'content')
+        sign_in second_user
+        actor2 = Sufia::GenericFile::Actor.new(generic_file, second_user)
+        image2 = fixture_file_upload(file2)
+        actor2.create_content(image2, file2, 'content')
       end
 
-      it "should change mime type when restoring a revision with a different mime type" do
-        skip "Skipping version restore for now"
-        @user = FactoryGirl.find_or_create(:jill)
-        sign_in @user
-        actor = Sufia::GenericFile::Actor.new(generic_file, @user)
-
-        image1 = fixture_file_upload('/world.png','image/png')
-        actor.create_content(image1, 'world.png', 'content')
-
-        posted_file = GenericFile.find(generic_file.pid)
-        version1 = posted_file.content.latest_version
-        posted_file.content.version_committer(version1).should == @user.user_key
-
-        image2 = fixture_file_upload('/image.jpg','image/jpg')
-        actor.create_content(image2, 'image.jpg', 'content')
-
-        posted_file = GenericFile.find(generic_file.pid)
-        version2 = posted_file.content.latest_version
-        expect(version2).to_not eq version1
-        posted_file.content.version_committer(version2).should == @user.user_key
-
-        posted_file.content.mime_type.should == "image/jpeg"
-        post :update, id: generic_file, revision: 'content.0'
-
-        restored_file = GenericFile.find(generic_file.pid)
-        version3 = restored_file.content.latest_version
-        version3.should_not == version2
-        version3.should_not == version1
-        restored_file.content.version_committer(version3).should == @user.user_key
-        restored_file.content.mime_type.should == "image/png"
+      it "should have two versions (plus the root version)" do
+        expect(generic_file.content.versions.count).to eq 3
       end
 
-      context "when two users edit a file" do
-        let(:archivist) { FactoryGirl.find_or_create(:archivist) }
-        let(:user) { FactoryGirl.find_or_create(:jill) }
-        let(:generic_file) do
-          GenericFile.new.tap do |gf|
-            gf.apply_depositor_metadata(user)
-            gf.edit_users = [user.user_key, archivist.user_key]
-            gf.save!
+      it "should have the current version" do
+        expect(generic_file.content.latest_version).to eql(version2)
+        expect(generic_file.content.mime_type).to eql(file2_type)
+        expect(generic_file.content.original_name).to eql(file2)
+      end
+
+      it "should use the first version for the object's title and label" do
+        expect(generic_file.label).to eql(file1)
+        expect(generic_file.title.first).to eql(file1)
+      end
+
+      it "should note the user for each version" do
+        expect(generic_file.content.version_committer(version1)).to eql(first_user.user_key)
+        expect(generic_file.content.version_committer(version2)).to eql(second_user.user_key)
+      end
+
+      describe "restoring a previous verion" do
+
+        context "as the first user" do
+          before do
+            sign_in first_user
+          end
+
+          context "using the first user's version" do
+            before do
+              post :update, id: generic_file, revision: version1
+            end
+            let(:restored_file)  { GenericFile.find(generic_file.pid) }
+            let(:latest_version) { GenericFile.find(generic_file.pid).content.latest_version }
+            it "should create a new version with the previous version's info" do
+              expect(restored_file.content.mime_type).to eql(file1_type)
+              expect(restored_file.content.original_name).to eql(file1)
+              expect(restored_file.content.versions.count).to eq 4
+              expect(restored_file.content.versions[3]).to eql(latest_version)
+              expect(restored_file.content.version_committer(latest_version)).to eql(first_user.user_key)
+            end
           end
         end
-        before do
-          allow_any_instance_of(Sufia::GenericFile::Actor).to receive(:push_characterize_job)
-          sign_in user
+
+        context "as the second user" do
+          before do
+            sign_in second_user
+          end
+          it "should not create a new version" do
+            post :update, id: generic_file, revision: version1
+            expect(response).to be_redirect
+          end
         end
 
-        it "records which user added a new version" do
-          skip "Skipping version restore for now"
-          file = fixture_file_upload('/world.png','image/png')
-          post :update, id: generic_file, filedata: file
-
-          posted_file = GenericFile.find(generic_file.pid)
-          version1 = posted_file.content.latest_version
-          expect(posted_file.content.version_committer(version1)).to eq(user.user_key)
-
-          # other user uploads new version
-          # TODO this should be a separate test
-          allow(controller).to receive(:current_user).and_return(archivist)
-          # reset controller:
-          controller.instance_variable_set(:@actor, nil)
-
-          expect(ContentUpdateEventJob).to receive(:new).with(generic_file.pid, 'jilluser@example.com').never
-
-          s1 = double('one')
-          allow(ContentNewVersionEventJob).to receive(:new).with(generic_file.pid, archivist.user_key).and_return(s1)
-          expect(Sufia.queue).to receive(:push).with(s1).once
-
-          file = fixture_file_upload('/image.jpg', 'image/jpg')
-          post :update, id: generic_file, filedata: file
-
-          edited_file = generic_file.reload
-          version2 = edited_file.content.latest_version
-          expect(version2).not_to eq(version1)
-          expect(edited_file.content.version_committer(version2)).to eq(archivist.user_key)
-
-          # original user restores his or her version
-          allow(controller).to receive(:current_user).and_return(user)
-          sign_in user
-          expect(ContentUpdateEventJob).to receive(:new).with(generic_file.pid, 'jilluser@example.com').never
-          s1 = double('one')
-          allow(ContentRestoredVersionEventJob).to receive(:new).with(generic_file.pid, user.user_key, 'content.0').and_return(s1)
-          expect(Sufia.queue).to receive(:push).with(s1).once
-
-          # reset controller:
-          controller.instance_variable_set(:@actor, nil)
-
-          post :update, id: generic_file, revision: 'content.0'
-
-          restored_file = generic_file.reload
-          version3 = restored_file.content.latest_version
-          expect(version3).not_to eq(version2)
-          expect(version3).not_to eq(version1)
-          expect(restored_file.content.version_committer(version3)).to eq(user.user_key)
-        end
       end
     end
 

--- a/spec/models/file_content_datastream_spec.rb
+++ b/spec/models/file_content_datastream_spec.rb
@@ -12,40 +12,38 @@ describe FileContentDatastream do
     after do
       @file.delete
     end
-    it "should have a list of versions with one entry" do
-      @file.content.versions.count == 1
+    let(:root_version) { @file.content.versions.first }
+    it "should have a list of versions including the root version" do
+      expect(@file.content.versions).to be_kind_of(Array)
+      expect(@file.content.versions.count).to eql(2)
     end
-    it "should return the expected version ID" do
-      skip "Skipping versions for now"
-      @file.content.versions.first.versionID.should == "content.0"
+    it "should return a RDF::URI for the version" do
+      expect(@file.content.versions.first).to be_kind_of(RDF::URI)
     end
-    it "should support latest_version" do
-      skip "Skipping versions for now"
-      @file.content.latest_version.versionID.should == "content.0"
+    it "should contain the root version" do
+      expect(@file.content.root_version).to eql(root_version) 
     end
-    it "should return the same version via get_version" do
-      skip "Skipping versions for now"
-      @file.content.get_version("content.0").versionID.should == @file.content.latest_version.versionID
-    end
-    it "should not barf when a garbage ID is provided to get_version"  do
-      skip "Skipping versions for now"
-      @file.content.get_version("foobar").should be_nil
+    context "with the latest version" do
+      let(:latest_version) { @file.content.versions.last }
+      it "should return the latest version" do
+        expect(@file.content.latest_version.to_s).to eql(latest_version.to_s)
+      end
     end
     describe "add a version" do
       before do
         @file.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
         @file.save
       end
-      it "should return two versions" do
-        @file.content.versions.count == 2
+      let(:latest_version) { @file.content.versions.last }
+      let(:uuid) { @file.content.versions.last.to_s.split("/").last  }
+      it "should return the root verion and two additional versions" do
+        expect(@file.content.versions.count).to eql(3)
       end
       it "should return the newer version via latest_version" do
-        skip "Skipping versions for now"
-        @file.content.versions.first.versionID.should == "content.1"
+        expect(@file.content.latest_version.to_s).to eql(latest_version.to_s)
       end
-      it "should return the same version via get_version" do
-        skip "Skipping versions for now"
-        @file.content.get_version("content.1").versionID.should == @file.content.latest_version.versionID
+      it "should return the same version using the version's UUID" do
+        expect(@file.content.uuid_for(latest_version)).to eql(uuid)
       end
     end
   end

--- a/sufia-models/app/actors/sufia/generic_file/actor.rb
+++ b/sufia-models/app/actors/sufia/generic_file/actor.rb
@@ -28,8 +28,7 @@ module Sufia::GenericFile
     end
 
     def create_content(file, file_name, dsid)
-      fname = generic_file.label.blank? ? file_name.truncate(255) : generic_file.label
-      generic_file.add_file(file, dsid, fname)
+      generic_file.add_file(file, dsid, file_name.truncate(255))
       save_characterize_and_record_committer do
         if Sufia.config.respond_to?(:after_create_content)
           Sufia.config.after_create_content.call(generic_file, user)
@@ -37,9 +36,9 @@ module Sufia::GenericFile
       end
     end
 
-    def revert_content(revision_id, datastream_id)
-      revision = generic_file.content.get_version(revision_id)
-      generic_file.add_file(revision.content, datastream_id, revision.label)
+    def revert_content(revision_id)
+      uuid = generic_file.content.uuid_for(revision_id)
+      generic_file.content.restore_version(uuid)
       save_characterize_and_record_committer do
         if Sufia.config.respond_to?(:after_revert_content)
           Sufia.config.after_revert_content.call(generic_file, user, revision_id)

--- a/sufia-models/app/models/datastreams/fits_datastream.rb
+++ b/sufia-models/app/models/datastreams/fits_datastream.rb
@@ -1,14 +1,6 @@
 class FitsDatastream < ActiveFedora::OmDatastream
   include OM::XML::Document
 
-  has_many_versions
-
-  def save
-    super.tap do |passing|
-      create_version if passing
-    end
-  end
-
   def prefix
     ""
   end

--- a/sufia-models/lib/sufia/models/file_content/versions.rb
+++ b/sufia-models/lib/sufia/models/file_content/versions.rb
@@ -7,12 +7,16 @@ module Sufia
         has_many_versions
       end
 
-      def get_version(version_id)
-        versions.select { |v| v.versionID == version_id}.first
+      def uuid_for(version_id)
+        version_id.to_s.split("/").last
       end
 
       def latest_version
         versions.last
+      end
+
+      def root_version
+        versions.first
       end
 
       def version_committer(version)
@@ -25,6 +29,7 @@ module Sufia
           create_version if passing
         end
       end
+      
     end
   end
 end


### PR DESCRIPTION
Restores existing versions of datastreams under Fedora4, also fixes #669 
