### PR TITLE
Move the Collection model into the Sufia namespace

### DIFF
--- a/sufia-models/app/models/collection.rb
+++ b/sufia-models/app/models/collection.rb
@@ -1,3 +1,0 @@
-class Collection < ActiveFedora::Base
-  include Sufia::Collection
-end

--- a/sufia-models/app/models/concerns/sufia/collection_behavior.rb
+++ b/sufia-models/app/models/concerns/sufia/collection_behavior.rb
@@ -1,5 +1,5 @@
 module Sufia
-  module Collection
+  module CollectionBehavior
     extend ActiveSupport::Concern
     include Hydra::Collection
     include Sufia::ModelMethods

--- a/sufia-models/app/models/sufia/collection.rb
+++ b/sufia-models/app/models/sufia/collection.rb
@@ -1,0 +1,5 @@
+module Sufia
+  class Collection < ActiveFedora::Base
+    include Sufia::CollectionBehavior
+  end
+end

--- a/sufia-models/lib/generators/sufia/models/install_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/install_generator.rb
@@ -84,6 +84,10 @@ This generator makes the following changes to your application:
     copy_file 'config/resque_config.rb', 'config/initializers/resque_config.rb'
   end
 
+  def create_collection
+    copy_file 'app/models/collection.rb', 'app/models/collection.rb'
+  end
+
   def install_mailboxer
     generate "mailboxer:install"
   end

--- a/sufia-models/lib/generators/sufia/models/templates/app/models/collection.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/app/models/collection.rb
@@ -1,0 +1,2 @@
+class Collection < Sufia::Collection
+end


### PR DESCRIPTION
Many engines may define a Collection model, so we don't want to pollute
the namespace.  For backwards compatibility there is a Collection model
generated into the application's directory that extends the
Sufia::Collection.  This ensures that we don't need to update the
hasModel assertions in the Fedora repository.

As this is a breaking change (if the Collection model is not generated
into the application), it's recommended that this PR target the next
major revision of Sufia (5.0)