### PR TITLE
Changing from file path to label since the the base file name from box i...

### DIFF
--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -4,10 +4,12 @@ describe ImportUrlJob do
   let(:user) { FactoryGirl.find_or_create(:jill) }
 
   let(:file_path) { '/world.png' }
+  let(:file_hash)  {'/673467823498723948237462429793840923582'}
 
   let(:generic_file) do
     GenericFile.new.tap do |f|
-      f.import_url = "http://example.org#{file_path}"
+      f.import_url = "http://example.org#{file_hash}"
+      f.label = file_path
       f.apply_depositor_metadata(user.user_key)
       f.save
     end
@@ -44,10 +46,11 @@ describe ImportUrlJob do
     end
 
     it "should create a content datastream" do
-      Net::HTTP.any_instance.should_receive(:request_get).with(file_path).and_yield(mock_response)
+      Net::HTTP.any_instance.should_receive(:request_get).with(file_hash).and_yield(mock_response)
       job.run
       expect(generic_file.reload.content.size).to eq 4218
       expect(generic_file.content.dsLabel).to eq file_path
+      expect(user.mailbox.inbox.first.last_message.body).to eq("The file (#{file_path}) was successfully imported.")
     end
   end
 

--- a/sufia-models/app/jobs/import_url_job.rb
+++ b/sufia-models/app/jobs/import_url_job.rb
@@ -16,7 +16,7 @@ class ImportUrlJob < ActiveFedoraPidBasedJob
       # attach downloaded file to generic file stubbed out
       if Sufia::GenericFile::Actor.new(generic_file, user).create_content(f, path, 'content')
         # add message to user for downloaded file
-        message = "The file (#{File.basename(path)}) was successfully imported."
+        message = "The file (#{generic_file.content.label}) was successfully imported."
         job_user.send_message(user, message, 'File Import')
       else
         job_user.send_message(user, generic_file.errors.full_messages.join(', '), 'File Import Error')


### PR DESCRIPTION
...s a hash code and the label has the file name

The url that comes back from box contains a really long hash for the file path, which is confusing and looks bad in the message.  The label is what we really want the user to see.
