### PR TITLE
Allowing the default activity time to be configurable, and to set the de...

### DIFF
--- a/app/controllers/concerns/sufia/dashboard_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/dashboard_controller_behavior.rb
@@ -32,7 +32,7 @@ module Sufia
     # in your dashboard view.  You'll need to alter dashboard/index.html.erb accordingly.
     def gather_dashboard_information
       @user = current_user
-      @activity = current_user.get_all_user_activity(params[:since].blank? ? DateTime.now.to_i - 8640 : params[:since].to_i)
+      @activity = current_user.get_all_user_activity(params[:since].blank? ? DateTime.now.to_i - Sufia.config.activity_to_show_default_seconds_since_now : params[:since].to_i)
       @notifications = current_user.mailbox.inbox
     end
 

--- a/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
@@ -105,6 +105,9 @@ Sufia.config do |config|
   # Specify the path to the file characterization tool:
   # config.fits_path = "fits.sh"
 
+  # Specify how many seconds back from the current time that we should show by default of the user's activity on the user's dashboard
+  # config.activity_to_show_default_seconds_since_now = 24*60*60
+
   # If browse-everything has been configured, load the configs.  Otherwise, set to nil.
   begin
     if defined? BrowseEverything

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -26,6 +26,7 @@ module Sufia
       config.analytics = false
       config.queue = Sufia::Resque::Queue
       config.max_notifications_for_dashboard = 5
+      config.activity_to_show_default_seconds_since_now = 24*60*60
 
       config.autoload_paths += %W(
         #{config.root}/app/models/datastreams


### PR DESCRIPTION
...fault to 24 hours instead of a few hours like it currently is

This is to make the system more configurable and make it so the default time is 24 hours instead of 2hours and some minutes, since I stripped a zero from 86400 a while back...
