### PR TITLE
Adding the created date as the start date for the google analytics query...

### DIFF
--- a/spec/models/file_usage_spec.rb
+++ b/spec/models/file_usage_spec.rb
@@ -84,8 +84,60 @@ describe FileUsage do
       expect(usage.to_flot[1][:label]).to eq("Downloads")
       expect(usage.to_flot[0][:data]).to include([1388534400000, 4], [1388620800000, 8], [1388707200000, 6], [1388793600000, 10], [1388880000000, 2]) 
       expect(usage.to_flot[1][:data]).to include([1388534400000, 1], [1388620800000, 1], [1388707200000, 2], [1388793600000, 3],  [1388880000000, 5])
-    end 
+    end
 
+    let(:create_date) {DateTime.new(2014, 01, 01)}
+
+    describe "analytics start date set" do
+      let(:earliest) {
+        DateTime.new(2014, 01, 02)
+      }
+
+      before do
+        Sufia.config.analytic_start_date = earliest
+      end
+
+      describe "create date before earliest date set" do
+        let(:usage) {
+          allow_any_instance_of(GenericFile).to receive(:create_date).and_return(create_date.to_s)
+          allow_any_instance_of(FileUsage).to receive(:download_statistics).and_return(sample_download_statistics)
+          allow_any_instance_of(FileUsage).to receive(:pageview_statistics).and_return(sample_pageview_statistics)
+          FileUsage.new(@file.id)
+        }
+        it "should set the created date to the earliest date not the created date" do
+          expect(usage.created).to eq(earliest)
+        end
+
+      end
+
+      describe "create date after earliest" do
+        let(:usage) {
+          allow_any_instance_of(FileUsage).to receive(:download_statistics).and_return(sample_download_statistics)
+          allow_any_instance_of(FileUsage).to receive(:pageview_statistics).and_return(sample_pageview_statistics)
+          Sufia.config.analytic_start_date = earliest
+          FileUsage.new(@file.id)
+        }
+        it "should set the created date to the earliest date not the created date" do
+          expect(usage.created).to eq(@file.create_date)
+        end
+      end
+    end
+    describe "start date not set" do
+      before do
+        Sufia.config.analytic_start_date = nil
+      end
+
+      let(:usage) {
+        allow_any_instance_of(GenericFile).to receive(:create_date).and_return(create_date.to_s)
+        allow_any_instance_of(FileUsage).to receive(:download_statistics).and_return(sample_download_statistics)
+        allow_any_instance_of(FileUsage).to receive(:pageview_statistics).and_return(sample_pageview_statistics)
+        FileUsage.new(@file.id)
+      }
+      it "should set the created date to the earliest date not the created date" do
+        expect(usage.created).to eq(create_date)
+      end
+
+    end
   end
 
 end

--- a/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
@@ -108,6 +108,11 @@ Sufia.config do |config|
   # Specify how many seconds back from the current time that we should show by default of the user's activity on the user's dashboard
   # config.activity_to_show_default_seconds_since_now = 24*60*60
 
+  # Specify a date you wish to start collecting Google Analytic statistics for.
+  # Leaving it blank will set the start date to when ever the file was uploaded by
+  # NOTE: if you have always sent analytics to GA for downloads and page views leave this commented out
+  # config.analytic_start_date = DateTime.new(2014,9,10)
+
   # If browse-everything has been configured, load the configs.  Otherwise, set to nil.
   begin
     if defined? BrowseEverything

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -28,6 +28,9 @@ module Sufia
       config.max_notifications_for_dashboard = 5
       config.activity_to_show_default_seconds_since_now = 24*60*60
 
+      # Defaulting analytic start date to when ever the file was uploaded by leaving it blank
+      config.analytic_start_date = nil
+
       config.autoload_paths += %W(
         #{config.root}/app/models/datastreams
       )


### PR DESCRIPTION
... and adding an earliest cut off for older systems who were not collecting google analytics in the past.

Why the earliest analytics date:
If you were not sending download statistics (that were not included before sufia 4.0) to the system you may want to not say the statistics are valid since when the files were deposited.  Instead you may want to say for older files that the statistics are valid since the time you started keeping track.
