### PR TITLE
Removing second call to after_ajax

### DIFF
--- a/app/assets/javascripts/sufia/batch_edit.js
+++ b/app/assets/javascripts/sufia/batch_edit.js
@@ -143,7 +143,6 @@ function batch_edit_init () {
                 after_ajax(form_id);
                 if (e.status == 200) {
                     eval(e.responseText);
-                    after_ajax(form_id);
                 } else {
                     alert("Error!  Status: " + e.status);
                 }


### PR DESCRIPTION
Removing the second after_ajax call so that it does not get called twice.
