### PR TITLE
Moves featured researcher above tag cloud, refs #9619

### DIFF
--- a/app/views/homepage/_home_content.html.erb
+++ b/app/views/homepage/_home_content.html.erb
@@ -14,6 +14,9 @@
 </div><!-- /.col-xs-6 -->
 <div class="col-xs-12 col-sm-6">
   <div>
+    <%= render partial: 'featured_researcher' %>
+  </div>
+  <div>
     <%- if blacklight_config.respond_to?(:tag_cloud_field_name) && blacklight_config.tag_cloud_field_name %>
         <div class="row">
           <h2 class="heading1 pull-left"><%= t('sufia.homepage.explore') %></h2>
@@ -21,8 +24,5 @@
           <%= render partial: 'tagcloud', locals: { tag_cloud_field_name: blacklight_config.tag_cloud_field_name } %>
         </div>
     <%- end %>
-  </div>
-  <div>
-    <%= render partial: 'featured_researcher' %>
   </div>
 </div>


### PR DESCRIPTION
Moves curated content above generated content, so that featured researchers get more prominence above the "digital fold."
