### PR TITLE
Convert specs to RSpec 3.1.7 syntax with Transpec. Fixes #702

### DIFF
--- a/spec/controllers/authorities_controller_spec.rb
+++ b/spec/controllers/authorities_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe AuthoritiesController do
+describe AuthoritiesController, :type => :controller do
   describe "#query" do
     it "should return an array of hashes" do
       mock_hits = [{label: "English", uri: "http://example.org/eng"},
@@ -9,12 +9,12 @@ describe AuthoritiesController do
                    {label: "Edgar", uri: "http://example.org/edga"},
                    {label: "Eddie", uri: "http://example.org/edd"},
                    {label: "Economics", uri: "http://example.org/eco"}]
-      LocalAuthority.should_receive(:entries_by_term).and_return(mock_hits)
+      expect(LocalAuthority).to receive(:entries_by_term).and_return(mock_hits)
       xhr :get, :query, model: "generic_files", term: "subject", q: "E"
-      response.should be_success
-      JSON.parse(response.body).count.should == 6
-      JSON.parse(response.body)[0]["label"].should == "English"
-      JSON.parse(response.body)[0]["uri"].should == "http://example.org/eng"
+      expect(response).to be_success
+      expect(JSON.parse(response.body).count).to eq(6)
+      expect(JSON.parse(response.body)[0]["label"]).to eq("English")
+      expect(JSON.parse(response.body)[0]["uri"]).to eq("http://example.org/eng")
     end
   end
 end

--- a/spec/controllers/batch_controller_spec.rb
+++ b/spec/controllers/batch_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe BatchController do
+describe BatchController, :type => :controller do
   before do
-    controller.stub(:has_access?).and_return(true)
+    allow(controller).to receive(:has_access?).and_return(true)
     @user = FactoryGirl.find_or_create(:jill)
     sign_in @user
-    User.any_instance.stub(:groups).and_return([])
-    controller.stub(:clear_session_user) ## Don't clear out the authenticated session
+    allow_any_instance_of(User).to receive(:groups).and_return([])
+    allow(controller).to receive(:clear_session_user) ## Don't clear out the authenticated session
   end
   after do
     @user.delete
@@ -35,82 +35,82 @@ describe BatchController do
     it "should enqueue a batch update job" do
       params = {'generic_file' => {'read_groups_string' => '', 'read_users_string' => 'archivist1, archivist2', 'tag' => ['']}, 'id' => @batch.pid, 'controller' => 'batch', 'action' => 'update'}
       s1 = double('one')
-      BatchUpdateJob.should_receive(:new).with(@user.user_key, params).and_return(s1)
-      Sufia.queue.should_receive(:push).with(s1).once
+      expect(BatchUpdateJob).to receive(:new).with(@user.user_key, params).and_return(s1)
+      expect(Sufia.queue).to receive(:push).with(s1).once
       post :update, id: @batch.pid, "generic_file" => {"read_groups_string" => "", "read_users_string" => "archivist1, archivist2", "tag" => [""]}
     end
     it "should show flash messages" do
       post :update, id: @batch.pid, "generic_file" => {"read_groups_string" => "","read_users_string" => "archivist1, archivist2", "tag" => [""]}
-      response.should redirect_to @routes.url_helpers.dashboard_files_path
-      flash[:notice].should_not be_nil
-      flash[:notice].should_not be_empty
-      flash[:notice].should include("Your files are being processed")
+      expect(response).to redirect_to @routes.url_helpers.dashboard_files_path
+      expect(flash[:notice]).not_to be_nil
+      expect(flash[:notice]).not_to be_empty
+      expect(flash[:notice]).to include("Your files are being processed")
     end
 
     describe "when user has edit permissions on a file" do
       it "should set the groups" do
         post :update, id: @batch.pid, "generic_file"=>{"permissions"=>{"group"=>{"public"=>"1", "registered"=>"2"}}}
-        @file.reload.read_groups.should == []
-        @file.reload.edit_groups.should == []
-        response.should redirect_to @routes.url_helpers.dashboard_files_path
+        expect(@file.reload.read_groups).to eq([])
+        expect(@file.reload.edit_groups).to eq([])
+        expect(response).to redirect_to @routes.url_helpers.dashboard_files_path
       end
 
       it "should set the users with read access" do
         post :update, id: @batch.pid, "generic_file"=>{"read_groups_string"=>"", "read_users_string"=>"archivist1, archivist2", "tag"=>[""]}
         file = GenericFile.find(@file.pid)
-        file.read_users.should == ['archivist1', 'archivist2']
+        expect(file.read_users).to eq(['archivist1', 'archivist2'])
 
-        response.should redirect_to @routes.url_helpers.dashboard_files_path
+        expect(response).to redirect_to @routes.url_helpers.dashboard_files_path
       end
       it "should set the groups with read access" do
         post :update, id: @batch.pid, "generic_file"=>{"read_groups_string"=>"group1, group2", "read_users_string"=>"", "tag"=>[""]}
         file = GenericFile.find(@file.pid)
-        file.read_groups.should == ['group1', 'group2']
+        expect(file.read_groups).to eq(['group1', 'group2'])
       end
       it "should set public read access" do
         post :update, id: @batch.pid, "visibility"=>"open", "generic_file"=>{"read_groups_string"=>"", "read_users_string"=>"", "tag"=>[""]}
         file = GenericFile.find(@file.pid)
-        file.read_groups.should == ['public']
+        expect(file.read_groups).to eq(['public'])
       end
       it "should set public read access and groups at the same time" do
         post :update, id: @batch.pid, "visibility"=>"open", "generic_file"=>{"read_groups_string"=>"group1, group2", "read_users_string"=>"", "tag"=>[""]}
         file = GenericFile.find(@file.pid)
-        file.read_groups.should == ['group1', 'group2', 'public']
+        expect(file.read_groups).to eq(['group1', 'group2', 'public'])
       end
       it "should set public discover access and groups at the same time" do
         post :update, id: @batch.pid, "permission"=>{"group"=>{"public"=>"none"}}, "generic_file"=>{"read_groups_string"=>"group1, group2", "read_users_string"=>"", "tag"=>[""]}
         file = GenericFile.find(@file.pid)
-        file.read_groups.should == ['group1', 'group2']
-        file.discover_groups.should == []
+        expect(file.read_groups).to eq(['group1', 'group2'])
+        expect(file.discover_groups).to eq([])
       end
       it "should set metadata like title" do
         post :update, id: @batch.pid, "generic_file"=>{"tag"=>["footag", "bartag"]}, "title"=>{@file.pid=>["New Title"]}
         file = GenericFile.find(@file.pid)
-        file.title.should == ["New Title"]
-        file.tag.should == ["footag", "bartag"]
+        expect(file.title).to eq(["New Title"])
+        expect(file.tag).to eq(["footag", "bartag"])
       end
       it "should not set any tags" do
         post :update, id: @batch.pid, "generic_file"=>{"read_groups_string"=>"", "read_users_string"=>"archivist1", "tag"=>[""]}
         file = GenericFile.find(@file.pid)
-        file.tag.should be_empty
+        expect(file.tag).to be_empty
       end
     end
     describe "when user does not have edit permissions on a file" do
       it "should not modify the object" do
         file = GenericFile.find(@file2.pid)
         file.title = ["Original Title"]
-        file.read_groups.should == []
+        expect(file.read_groups).to eq([])
         file.save
         post :update, id: @batch.pid, "generic_file"=>{"read_groups_string"=>"group1, group2", "read_users_string"=>"", "tag"=>[""]}, "title"=>{@file2.pid=>["Title Wont Change"]}
         file = GenericFile.find(@file2.pid)
-        file.title.should == ["Original Title"]
-        file.read_groups.should == []
+        expect(file.title).to eq(["Original Title"])
+        expect(file.read_groups).to eq([])
       end
     end
   end
   describe "#edit" do
     before do
-      User.any_instance.stub(:display_name).and_return("Jill Z. User")
+      allow_any_instance_of(User).to receive(:display_name).and_return("Jill Z. User")
       @b1 = Batch.new
       @b1.save
       @file = GenericFile.new(batch: @b1, label: 'f1')
@@ -127,8 +127,8 @@ describe BatchController do
     end
     it "should default creator" do
       get :edit, id: @b1.id
-      assigns[:generic_file].creator[0].should == @user.display_name
-      assigns[:generic_file].title[0].should == 'f1'
+      expect(assigns[:generic_file].creator[0]).to eq(@user.display_name)
+      expect(assigns[:generic_file].title[0]).to eq('f1')
     end
   end
 end

--- a/spec/controllers/batch_edits_controller_spec.rb
+++ b/spec/controllers/batch_edits_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe BatchEditsController do
+describe BatchEditsController, :type => :controller do
   before do
-    controller.stub(:has_access?).and_return(true)
+    allow(controller).to receive(:has_access?).and_return(true)
     @user = FactoryGirl.find_or_create(:jill)
     sign_in @user
-    User.any_instance.stub(:groups).and_return([])
-    controller.stub(:clear_session_user) ## Don't clear out the authenticated session
+    allow_any_instance_of(User).to receive(:groups).and_return([])
+    allow(controller).to receive(:clear_session_user) ## Don't clear out the authenticated session
     request.env["HTTP_REFERER"] = 'test.host/original_page'
   end
 
@@ -26,9 +26,9 @@ describe BatchEditsController do
     end
     it "should be successful" do
       get :edit
-      response.should be_successful
-      assigns[:terms].should == [:creator, :contributor, :description, :tag, :rights, :publisher,
-                        :date_created, :subject, :language, :identifier, :based_near, :related_url]
+      expect(response).to be_successful
+      expect(assigns[:terms]).to eq([:creator, :contributor, :description, :tag, :rights, :publisher,
+                        :date_created, :subject, :language, :identifier, :based_near, :related_url])
       expect(assigns[:show_file].creator).to eq ["Fred", "Wilma"]
       expect(assigns[:show_file].publisher).to eq ["Rand McNally"]
       expect(assigns[:show_file].language).to eq ["en"]

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CatalogController do
+describe CatalogController, :type => :controller do
   routes { Rails.application.class.routes }
 
   let(:user) { @user }
@@ -38,8 +38,8 @@ describe CatalogController do
         get :index, q: 'full_textfull_text'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        assigns(:document_list).count.should eql(1)
-        assigns(:document_list).map(&:id).should == [@gf2.id]
+        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).map(&:id)).to eq([@gf2.id])
       end
     end
 
@@ -47,10 +47,10 @@ describe CatalogController do
       it "should find records" do
         get :index, q: "pdf", owner: 'all'
         expect(response).to be_success
-        response.should render_template('catalog/index')
-        assigns(:document_list).map(&:id).should == [@gf1.id]
-        assigns(:document_list).count.should eql(1)
-        assigns(:document_list).first['desc_metadata__title_tesim'].should == ['Test Document PDF']
+        expect(response).to render_template('catalog/index')
+        expect(assigns(:document_list).map(&:id)).to eq([@gf1.id])
+        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).first['desc_metadata__title_tesim']).to eq(['Test Document PDF'])
       end
     end
 
@@ -61,8 +61,8 @@ describe CatalogController do
       end
       it "should find facet files" do
         expect(response).to be_success
-        response.should render_template('catalog/index')
-        assigns(:document_list).count.should eql(1)
+        expect(response).to render_template('catalog/index')
+        expect(assigns(:document_list).count).to eql(1)
       end
     end
 

--- a/spec/controllers/content_blocks_controller_spec.rb
+++ b/spec/controllers/content_blocks_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ContentBlocksController do
+describe ContentBlocksController, :type => :controller do
   describe "#update" do
     let(:content_block) { FactoryGirl.create(:content_block) }
     before { request.env["HTTP_REFERER"] = "whence_i_came" }
@@ -14,10 +14,10 @@ describe ContentBlocksController do
 
     context "when logged in" do
       let(:user) { FactoryGirl.create(:user) }
-      before { controller.stub(current_user: user) }
+      before { allow(controller).to receive_messages(current_user: user) }
 
       context "as a user in the admin group" do
-        before { user.should_receive(:groups).and_return( ['admin', 'registered']) }
+        before { expect(user).to receive(:groups).and_return( ['admin', 'registered']) }
 
         it "should save" do
           patch :update, id: content_block, content_block: { value: 'foo' }

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DashboardController do
+describe DashboardController, :type => :controller do
   
   context "with an unauthenticated user" do
 

--- a/spec/controllers/depositors_controller_spec.rb
+++ b/spec/controllers/depositors_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DepositorsController do
+describe DepositorsController, :type => :controller do
   let (:user) { FactoryGirl.find_or_create(:jill) }
   let (:grantee) { FactoryGirl.find_or_create(:archivist) }
 

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DownloadsController do
+describe DownloadsController, :type => :controller do
 
   describe "with a file" do
     before do
@@ -17,42 +17,42 @@ describe DownloadsController do
     describe "when logged in as reader" do
       before do
         sign_in FactoryGirl.find_or_create(:archivist)
-        User.any_instance.stub(:groups).and_return([])
-        controller.stub(:clear_session_user) ## Don't clear out the authenticated session
+        allow_any_instance_of(User).to receive(:groups).and_return([])
+        allow(controller).to receive(:clear_session_user) ## Don't clear out the authenticated session
       end
       describe "show" do
         it "should default to returning configured default download" do
-          DownloadsController.default_content_dsid.should == "content"
-          controller.stub(:render) # send_data calls render internally
+          expect(DownloadsController.default_content_dsid).to eq("content")
+          allow(controller).to receive(:render) # send_data calls render internally
           expected_content = ActiveFedora::Base.find("sufia:test1", cast: true).content.content
-          controller.should_receive(:send_file_headers!).with({filename: 'world.png', disposition: 'inline', type: 'image/png' })
+          expect(controller).to receive(:send_file_headers!).with({filename: 'world.png', disposition: 'inline', type: 'image/png' })
           get "show", id: "test1"
-          response.body.should == expected_content
-          response.should be_success
+          expect(response.body).to eq(expected_content)
+          expect(response).to be_success
         end
         it "should return requested datastreams" do
-          controller.stub(:render) # send_data calls render internally
+          allow(controller).to receive(:render) # send_data calls render internally
           expected_content = ActiveFedora::Base.find("sufia:test1", cast: true).descMetadata.content
           expect(controller).to receive(:send_file_headers!).with(filename: 'descMetadata', disposition: 'inline', type: 'application/n-triples')
           get "show", id: "test1", datastream_id: "descMetadata"
-          response.body.should == expected_content
-          response.should be_success
+          expect(response.body).to eq(expected_content)
+          expect(response).to be_success
         end
         it "should support setting disposition to inline" do
-          controller.stub(:render) # send_data calls render internally
+          allow(controller).to receive(:render) # send_data calls render internally
           expected_content = ActiveFedora::Base.find("sufia:test1", cast: true).content.content
-          controller.should_receive(:send_file_headers!).with({filename: 'world.png', disposition: 'inline', type: 'image/png' })
+          expect(controller).to receive(:send_file_headers!).with({filename: 'world.png', disposition: 'inline', type: 'image/png' })
           get "show", id: "test1", disposition: "inline"
-          response.body.should == expected_content
-          response.should be_success
+          expect(response.body).to eq(expected_content)
+          expect(response).to be_success
         end
 
         it "should allow you to specify filename for download" do
-          controller.stub(:render) # send_data calls render internally
+          allow(controller).to receive(:render) # send_data calls render internally
           expected_content = ActiveFedora::Base.find("sufia:test1", cast: true).content.content
-          controller.should_receive(:send_file_headers!).with({filename: 'my%20dog.png', disposition: 'inline', type: 'image/png' })
+          expect(controller).to receive(:send_file_headers!).with({filename: 'my%20dog.png', disposition: 'inline', type: 'image/png' })
           get "show", id: "test1", "filename" => "my%20dog.png"
-          response.body.should == expected_content
+          expect(response.body).to eq(expected_content)
         end
       end
     end
@@ -60,15 +60,15 @@ describe DownloadsController do
     describe "when not logged in as reader" do
       before do
         sign_in FactoryGirl.find_or_create(:jill)
-        User.any_instance.stub(:groups).and_return([])
-        controller.stub(:clear_session_user) ## Don't clear out the authenticated session
+        allow_any_instance_of(User).to receive(:groups).and_return([])
+        allow(controller).to receive(:clear_session_user) ## Don't clear out the authenticated session
       end
 
       describe "show" do
         it "should deny access" do
           get "show", id: "test1"
-          response.should redirect_to root_path
-          flash[:alert].should == 'You are not authorized to access this page.'
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to eq('You are not authorized to access this page.')
         end
       end
     end

--- a/spec/controllers/featured_work_lists_controller_spec.rb
+++ b/spec/controllers/featured_work_lists_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FeaturedWorkListsController do
+describe FeaturedWorkListsController, :type => :controller do
   describe "#create" do
     before do
       expect(controller).to receive(:authorize!).with(:update, FeaturedWork)

--- a/spec/controllers/featured_works_controller_spec.rb
+++ b/spec/controllers/featured_works_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FeaturedWorksController do
+describe FeaturedWorksController, :type => :controller do
   describe "#create" do
     before do
       sign_in FactoryGirl.create(:user)

--- a/spec/controllers/homepage_controller_spec.rb
+++ b/spec/controllers/homepage_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe HomepageController do
+describe HomepageController, :type => :controller do
   routes { Rails.application.class.routes }
 
   describe "#index" do

--- a/spec/controllers/mailbox_controller_spec.rb
+++ b/spec/controllers/mailbox_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MailboxController do
+describe MailboxController, :type => :controller do
   before(:each) do
     @user = FactoryGirl.find_or_create(:jill)
     @another_user = FactoryGirl.find_or_create(:archivist)
@@ -8,7 +8,7 @@ describe MailboxController do
     @subject = "Test Subject"
     @rec1 = @another_user.send_message(@user, @message, @subject)
     @rec2 = @user.send_message(@another_user, @message, @subject)
-    MailboxController.any_instance.stub(:authenticate_user!).and_return(true)
+    allow_any_instance_of(MailboxController).to receive(:authenticate_user!).and_return(true)
     sign_in @user
   end
   after(:each) do
@@ -18,10 +18,10 @@ describe MailboxController do
   describe "#index" do
     it "should show message" do
       get :index
-      response.should be_success
-      assigns[:messages].first.last_message.body.should == 'Test Message'
-      assigns[:messages].first.last_message.subject.should == 'Test Subject'
-      @user.mailbox.inbox(unread: true).count.should == 0
+      expect(response).to be_success
+      expect(assigns[:messages].first.last_message.body).to eq('Test Message')
+      expect(assigns[:messages].first.last_message.subject).to eq('Test Subject')
+      expect(@user.mailbox.inbox(unread: true).count).to eq(0)
     end
   end
   describe "#delete" do
@@ -29,7 +29,7 @@ describe MailboxController do
       rec = @another_user.send_message(@user, 'message 2', 'subject 2')
       expect {
         delete :destroy, id: rec.conversation.id
-        response.should redirect_to(@routes.url_helpers.notifications_path)
+        expect(response).to redirect_to(@routes.url_helpers.notifications_path)
       }.to change {@user.mailbox.inbox.count}.by(-1)
     end
     it "should not delete message" do
@@ -37,7 +37,7 @@ describe MailboxController do
       rec = @another_user.send_message(@curator, 'message 3', 'subject 3')
       expect {
         delete :destroy, id: rec.conversation.id
-        response.should redirect_to(@routes.url_helpers.notifications_path)
+        expect(response).to redirect_to(@routes.url_helpers.notifications_path)
       }.to_not change { @curator.mailbox.inbox.count}
     end
   end
@@ -45,9 +45,9 @@ describe MailboxController do
     it "should delete message" do
       rec1 = @another_user.send_message(@user, 'message 2', 'subject 2')
       rec2 = @another_user.send_message(@user, 'message 3', 'subject 3')
-      @user.mailbox.inbox.count.should == 3
+      expect(@user.mailbox.inbox.count).to eq(3)
       get :delete_all
-      @user.mailbox.inbox.count.should == 0
+      expect(@user.mailbox.inbox.count).to eq(0)
     end
   end
 end

--- a/spec/controllers/my/collections_controller_spec.rb
+++ b/spec/controllers/my/collections_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe My::CollectionsController do
+describe My::CollectionsController, :type => :controller do
   describe "logged in user" do
     before (:each) do
       @user = FactoryGirl.find_or_create(:archivist)

--- a/spec/controllers/my/files_controller_spec.rb
+++ b/spec/controllers/my/files_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe My::FilesController do
+describe My::FilesController, :type => :controller do
 
   before :all do
     GenericFile.destroy_all

--- a/spec/controllers/my/highlights_controller_spec.rb
+++ b/spec/controllers/my/highlights_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe My::HighlightsController do
+describe My::HighlightsController, :type => :controller do
   describe "logged in user" do
     before (:each) do
       @user = FactoryGirl.find_or_create(:archivist)

--- a/spec/controllers/my/shares_controller_spec.rb
+++ b/spec/controllers/my/shares_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe My::SharesController do
+describe My::SharesController, :type => :controller do
   describe "logged in user" do
     before (:each) do
       @user = FactoryGirl.find_or_create(:archivist)

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MyController do
+describe MyController, :type => :controller do
 
   it "sets the controller name" do
     expect(controller.controller_name).to eq :my

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe PagesController do
+describe PagesController, :type => :controller do
   let (:page_name) {"about_page"}
   context "content exists" do
     describe "GET #show" do

--- a/spec/controllers/single_use_links_controller_spec.rb
+++ b/spec/controllers/single_use_links_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SingleUseLinksController do
+describe SingleUseLinksController, :type => :controller do
   let(:user) { FactoryGirl.find_or_create(:jill) }
   let(:file) do
     GenericFile.new.tap do |f|

--- a/spec/controllers/single_use_links_viewer_controller_spec.rb
+++ b/spec/controllers/single_use_links_viewer_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SingleUseLinksViewerController do
+describe SingleUseLinksViewerController, :type => :controller do
   before(:all) do
     @user = FactoryGirl.find_or_create(:jill)
     @file = GenericFile.new
@@ -18,8 +18,8 @@ describe SingleUseLinksViewerController do
     SingleUseLink.delete_all
   end
   before do
-    controller.stub(:has_access?).and_return(true)
-    controller.stub(:clear_session_user) ## Don't clear out the authenticated session
+    allow(controller).to receive(:has_access?).and_return(true)
+    allow(controller).to receive(:clear_session_user) ## Don't clear out the authenticated session
   end
   
   describe "retrieval links" do
@@ -44,24 +44,24 @@ describe SingleUseLinksViewerController do
     end
     describe "GET 'download'" do
       it "and_return http success" do
-        controller.stub(:render)
+        allow(controller).to receive(:render)
         expected_content = ActiveFedora::Base.find(@file.pid, cast: true).content.content
-        controller.should_receive(:send_file_headers!).with({filename: 'world.png', disposition: 'inline', type: 'image/png' })
+        expect(controller).to receive(:send_file_headers!).with({filename: 'world.png', disposition: 'inline', type: 'image/png' })
         get :download, id:download_link_hash 
-        response.body.should == expected_content
-        response.should be_success
+        expect(response.body).to eq(expected_content)
+        expect(response).to be_success
       end
       it "and_return 404 on second attempt" do
         get :download, id:download_link_hash
-        response.should be_success
+        expect(response).to be_success
         get :download, id:download_link_hash
-        response.should render_template('error/single_use_error') 
+        expect(response).to render_template('error/single_use_error') 
       end
       it "and_return 404 on attempt to get download with show" do
         get :download, id:download_link_hash
-        response.should be_success
+        expect(response).to be_success
         get :show, id:download_link_hash
-        response.should render_template('error/single_use_error')
+        expect(response).to render_template('error/single_use_error')
       end
     end
 
@@ -69,18 +69,18 @@ describe SingleUseLinksViewerController do
       it "and_return http success" do
 
         get 'show', id:show_link_hash
-        response.should be_success
-        assigns[:asset].pid.should == @file.pid
+        expect(response).to be_success
+        expect(assigns[:asset].pid).to eq(@file.pid)
       end
       it "and_return 404 on second attempt" do
         get :show, id:show_link_hash
-        response.should be_success
+        expect(response).to be_success
         get :show, id:show_link_hash
-        response.should render_template('error/single_use_error')
+        expect(response).to render_template('error/single_use_error')
       end
       it "and_return 404 on attempt to get show path with download hash" do
         get :show, id:download_link_hash
-        response.should render_template('error/single_use_error')
+        expect(response).to render_template('error/single_use_error')
       end
     end
   end

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -1,30 +1,30 @@
 require 'spec_helper'
 
-describe StaticController do
+describe StaticController, :type => :controller do
   routes { Sufia::Engine.routes }
   describe "#mendeley" do
     it "renders page" do
       get "mendeley"
-      response.should be_success
-      response.should render_template "layouts/homepage"
+      expect(response).to be_success
+      expect(response).to render_template "layouts/homepage"
     end
     it "renders no layout with javascript" do
       xhr :get, :mendeley
-      response.should be_success
-      response.should_not render_template "layouts/homepage"
+      expect(response).to be_success
+      expect(response).not_to render_template "layouts/homepage"
     end
   end
 
   describe "#zotero" do
     it "renders page" do
       get "zotero"
-      response.should be_success
-      response.should render_template "layouts/homepage"
+      expect(response).to be_success
+      expect(response).to render_template "layouts/homepage"
     end
     it "renders no layout with javascript" do
       xhr :get, :zotero
-      response.should be_success
-      response.should_not render_template "layouts/homepage"
+      expect(response).to be_success
+      expect(response).not_to render_template "layouts/homepage"
     end
   end
 end

--- a/spec/controllers/tinymce_assets_controller_spec.rb
+++ b/spec/controllers/tinymce_assets_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe TinymceAssetsController do
+describe TinymceAssetsController, :type => :controller do
   let(:file) { fixture_file_upload('/world.png','image/png') }
 
   context "when logged in" do

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe TransfersController do
+describe TransfersController, :type => :controller do
   describe "with a signed in user" do
     let(:another_user) { FactoryGirl.find_or_create(:jill) }
     let(:user) { FactoryGirl.find_or_create(:archivist) }
@@ -28,10 +28,10 @@ describe TransfersController do
       it "is successful" do
         get :index
         expect(response).to be_success
-        assigns[:incoming].first.should be_kind_of ProxyDepositRequest
-        assigns[:incoming].first.pid.should == incoming_file.pid
-        assigns[:outgoing].first.should be_kind_of ProxyDepositRequest
-        assigns[:outgoing].first.pid.should == outgoing_file.pid
+        expect(assigns[:incoming].first).to be_kind_of ProxyDepositRequest
+        expect(assigns[:incoming].first.pid).to eq(incoming_file.pid)
+        expect(assigns[:outgoing].first).to be_kind_of ProxyDepositRequest
+        expect(assigns[:outgoing].first.pid).to eq(outgoing_file.pid)
       end
 
       describe "When the incoming request is for a deleted file" do
@@ -40,8 +40,8 @@ describe TransfersController do
         end
         it "should not show that file" do
           get :index
-          response.should be_success
-          assigns[:incoming].should be_empty
+          expect(response).to be_success
+          expect(assigns[:incoming]).to be_empty
         end
       end
     end
@@ -57,10 +57,10 @@ describe TransfersController do
         it "should be successful" do
           sign_in user
           get :new, id: file
-          response.should be_success
-          assigns[:generic_file].should == file
-          assigns[:proxy_deposit_request].should be_kind_of ProxyDepositRequest
-          assigns[:proxy_deposit_request].pid.should == file.pid
+          expect(response).to be_success
+          expect(assigns[:generic_file]).to eq(file)
+          expect(assigns[:proxy_deposit_request]).to be_kind_of ProxyDepositRequest
+          expect(assigns[:proxy_deposit_request].pid).to eq(file.pid)
         end
       end
     end
@@ -73,26 +73,26 @@ describe TransfersController do
         end
       end
       it "should be successful" do
-        User.any_instance.stub(:display_name).and_return("Jill Z. User")
-        lambda {
+        allow_any_instance_of(User).to receive(:display_name).and_return("Jill Z. User")
+        expect {
           post :create, id: file.id, proxy_deposit_request: {transfer_to: another_user.user_key}
-        }.should change(ProxyDepositRequest, :count).by(1)
-        response.should redirect_to @routes.url_helpers.transfers_path
-        flash[:notice].should == 'Transfer request created'
+        }.to change(ProxyDepositRequest, :count).by(1)
+        expect(response).to redirect_to @routes.url_helpers.transfers_path
+        expect(flash[:notice]).to eq('Transfer request created')
         proxy_request = another_user.proxy_deposit_requests.first
-        proxy_request.pid.should == file.pid
-        proxy_request.sending_user.should == user
+        expect(proxy_request.pid).to eq(file.pid)
+        expect(proxy_request.sending_user).to eq(user)
         # AND A NOTIFICATION SHOULD HAVE BEEN CREATED
         notification = another_user.reload.mailbox.inbox[0].messages[0]
-        notification.subject.should == "Ownership Change Request"
-        notification.body.should == "<a href=\"/users/#{user.user_key}\">#{user.name}</a> wants to transfer a file to you. Review all <a href=\"#{@routes.url_helpers.transfers_path}\">transfer requests</a>"
+        expect(notification.subject).to eq("Ownership Change Request")
+        expect(notification.body).to eq("<a href=\"/users/#{user.user_key}\">#{user.name}</a> wants to transfer a file to you. Review all <a href=\"#{@routes.url_helpers.transfers_path}\">transfer requests</a>")
       end
       it "should give an error if the user is not found" do
-        lambda {
+        expect {
           post :create, id: file.id, proxy_deposit_request: {transfer_to: 'foo' }
-        }.should_not change(ProxyDepositRequest, :count)
-        assigns[:proxy_deposit_request].errors[:transfer_to].should == ['must be an existing user']
-        response.should redirect_to(root_path)
+        }.not_to change(ProxyDepositRequest, :count)
+        expect(assigns[:proxy_deposit_request].errors[:transfer_to]).to eq(['must be an existing user'])
+        expect(response).to redirect_to(root_path)
       end
     end
 
@@ -107,24 +107,24 @@ describe TransfersController do
         end
         it "should be successful when retaining access rights" do
           put :accept, id: user.proxy_deposit_requests.first
-          response.should redirect_to @routes.url_helpers.transfers_path
-          flash[:notice].should == "Transfer complete"
-          assigns[:proxy_deposit_request].status.should == 'accepted'
-          incoming_file.reload.edit_users.should == [another_user.user_key, user.user_key]
+          expect(response).to redirect_to @routes.url_helpers.transfers_path
+          expect(flash[:notice]).to eq("Transfer complete")
+          expect(assigns[:proxy_deposit_request].status).to eq('accepted')
+          expect(incoming_file.reload.edit_users).to eq([another_user.user_key, user.user_key])
         end
         it "should be successful when resetting access rights" do
           put :accept, id: user.proxy_deposit_requests.first, reset: true
-          response.should redirect_to @routes.url_helpers.transfers_path
-          flash[:notice].should == "Transfer complete"
-          assigns[:proxy_deposit_request].status.should == 'accepted'
-          incoming_file.reload.edit_users.should == [user.user_key]
+          expect(response).to redirect_to @routes.url_helpers.transfers_path
+          expect(flash[:notice]).to eq("Transfer complete")
+          expect(assigns[:proxy_deposit_request].status).to eq('accepted')
+          expect(incoming_file.reload.edit_users).to eq([user.user_key])
         end
         it "should handle sticky requests " do
           put :accept, id: user.proxy_deposit_requests.first, sticky: true
-          response.should redirect_to @routes.url_helpers.transfers_path
-          flash[:notice].should == "Transfer complete"
-          assigns[:proxy_deposit_request].status.should == 'accepted'
-          user.can_receive_deposits_from.should include(another_user)
+          expect(response).to redirect_to @routes.url_helpers.transfers_path
+          expect(flash[:notice]).to eq("Transfer complete")
+          expect(assigns[:proxy_deposit_request].status).to eq('accepted')
+          expect(user.can_receive_deposits_from).to include(another_user)
         end
       end
 
@@ -138,8 +138,8 @@ describe TransfersController do
         end
         it "should not allow me" do
           put :accept, id: another_user.proxy_deposit_requests.first
-          response.should redirect_to root_path
-          flash[:alert].should == "You are not authorized to access this page."
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to eq("You are not authorized to access this page.")
         end
       end
     end
@@ -155,9 +155,9 @@ describe TransfersController do
         end
         it "should be successful" do
           put :reject, id: user.proxy_deposit_requests.first
-          response.should redirect_to @routes.url_helpers.transfers_path
-          flash[:notice].should == "Transfer rejected"
-          assigns[:proxy_deposit_request].status.should == 'rejected'
+          expect(response).to redirect_to @routes.url_helpers.transfers_path
+          expect(flash[:notice]).to eq("Transfer rejected")
+          expect(assigns[:proxy_deposit_request].status).to eq('rejected')
         end
       end
 
@@ -171,8 +171,8 @@ describe TransfersController do
         end
         it "should not allow me" do
           put :reject, id: another_user.proxy_deposit_requests.first
-          response.should redirect_to root_path
-          flash[:alert].should == "You are not authorized to access this page."
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to eq("You are not authorized to access this page.")
         end
       end
     end
@@ -188,8 +188,8 @@ describe TransfersController do
         end
         it "should be successful" do
           delete :destroy, id: another_user.proxy_deposit_requests.first
-          response.should redirect_to @routes.url_helpers.transfers_path
-          flash[:notice].should == "Transfer canceled"
+          expect(response).to redirect_to @routes.url_helpers.transfers_path
+          expect(flash[:notice]).to eq("Transfer canceled")
         end
       end
 
@@ -203,8 +203,8 @@ describe TransfersController do
         end
         it "should not allow me" do
           delete :destroy, id: user.proxy_deposit_requests.first
-          response.should redirect_to root_path
-          flash[:alert].should == "You are not authorized to access this page."
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to eq("You are not authorized to access this page.")
         end
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe UsersController do
+describe UsersController, :type => :controller do
   before(:each) do
     @user = FactoryGirl.find_or_create(:jill)
     @another_user = FactoryGirl.find_or_create(:archivist)

--- a/spec/features/browse_dashboard_files_spec.rb
+++ b/spec/features/browse_dashboard_files_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Browse Dashboard" do
+describe "Browse Dashboard", :type => :feature do
 
   before :all do
     cleanup_jetty

--- a/spec/features/browse_files_spec.rb
+++ b/spec/features/browse_files_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Browse files" do
+describe "Browse files", :type => :feature do
 
   before :all do
     cleanup_jetty
@@ -28,16 +28,16 @@ describe "Browse files" do
   describe "when not logged in" do
     it "should let us browse some of the fixtures" do
       click_link "18"
-      page.should have_content "Search Results"
+      expect(page).to have_content "Search Results"
       click_link @fixtures[0].title[0]
-      page.should have_content "Download"
-      page.should_not have_content "Edit"
+      expect(page).to have_content "Download"
+      expect(page).not_to have_content "Edit"
     end
     it "should allow you to click next" do
       click_link 'Next »'
       within(".modal-body") do
-        page.should have_content "5"
-        page.should_not have_content "11"
+        expect(page).to have_content "5"
+        expect(page).not_to have_content "11"
       end
     end
   end

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'catalog searching' do
+describe 'catalog searching', :type => :feature do
 
   before(:all) do
     @gf1 = GenericFile.new.tap do |f|

--- a/spec/features/cloud_upload_spec.rb
+++ b/spec/features/cloud_upload_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Selecting files to import from cloud providers" do
+describe "Selecting files to import from cloud providers", :type => :feature do
   before do
     sign_in :user
     click_link "Upload"
@@ -8,9 +8,9 @@ describe "Selecting files to import from cloud providers" do
 
   it "should have a Cloud file picker using browse-everything" do
     click_link "Cloud Providers"
-    page.should have_content "Browse cloud files"
-    page.should have_content "Submit selected files"
-    page.should have_content "0 items selected"
+    expect(page).to have_content "Browse cloud files"
+    expect(page).to have_content "Submit selected files"
+    expect(page).to have_content "0 items selected"
     click_button 'Browse cloud files'
   end
 end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'collection' do
+describe 'collection', :type => :feature do
   def create_collection(title, description)
     visit '/dashboard'
     first('#hydra-collection-add').click
@@ -67,12 +67,12 @@ describe 'collection' do
     end
 
     it "should delete a collection" do
-      page.should have_content(@collection.title)
+      expect(page).to have_content(@collection.title)
       within('#document_'+@collection.noid) do
         first('button.dropdown-toggle').click
         first(".itemtrash").click
       end
-      page.should_not have_content(@collection.title)
+      expect(page).not_to have_content(@collection.title)
     end
   end
 
@@ -173,41 +173,41 @@ describe 'collection' do
     end
 
     it "should remove a file from a collection" do
-      page.should have_content(@collection.title)
+      expect(page).to have_content(@collection.title)
       within("#document_#{@collection.noid}") do
         first('button.dropdown-toggle').click
         click_link('Edit Collection')
       end
-      page.should have_field('collection_title', with: @collection.title)
-      page.should have_field('collection_description', with: @collection.description)
-      page.should have_content(@gf1.title.first)
-      page.should have_content(@gf2.title.first)
+      expect(page).to have_field('collection_title', with: @collection.title)
+      expect(page).to have_field('collection_description', with: @collection.description)
+      expect(page).to have_content(@gf1.title.first)
+      expect(page).to have_content(@gf2.title.first)
       within("#document_#{@gf1.noid}") do
         first('button.dropdown-toggle').click
         click_button('Remove from Collection')
       end
-      page.should have_content(@collection.title)
-      page.should have_content(@collection.description)
-      page.should_not have_content(@gf1.title.first)
-      page.should have_content(@gf2.title.first)
+      expect(page).to have_content(@collection.title)
+      expect(page).to have_content(@collection.description)
+      expect(page).not_to have_content(@gf1.title.first)
+      expect(page).to have_content(@gf2.title.first)
     end
 
     it "should remove all files from a collection", js: true do
-      page.should have_content(@collection.title)
+      expect(page).to have_content(@collection.title)
       within('#document_'+@collection.noid) do
         first('button.dropdown-toggle').click
         click_link('Edit Collection')
       end
-      page.should have_field('collection_title', with: @collection.title)
-      page.should have_field('collection_description', with: @collection.description)
-      page.should have_content(@gf1.title.first)
-      page.should have_content(@gf2.title.first)
+      expect(page).to have_field('collection_title', with: @collection.title)
+      expect(page).to have_field('collection_description', with: @collection.description)
+      expect(page).to have_content(@gf1.title.first)
+      expect(page).to have_content(@gf2.title.first)
       first('input#check_all').click
       click_button('Remove From Collection')
-      page.should have_content(@collection.title)
-      page.should have_content(@collection.description)
-      page.should_not have_content(@gf1.title.first)
-      page.should_not have_content(@gf2.title.first)
+      expect(page).to have_content(@collection.title)
+      expect(page).to have_content(@collection.description)
+      expect(page).not_to have_content(@gf1.title.first)
+      expect(page).not_to have_content(@gf2.title.first)
     end
   end
 
@@ -223,11 +223,11 @@ describe 'collection' do
     end
 
     it "should show a collection with a listing of Descriptive Metadata and catalog-style search results" do
-      page.should have_content(@collection.title)
+      expect(page).to have_content(@collection.title)
       within('#document_'+@collection.noid) do
         click_link("Display all details of collection title")
       end
-      page.should have_css(".pager")
+      expect(page).to have_css(".pager")
     end
   end
 end

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Sending an email via the contact form" do
+describe "Sending an email via the contact form", :type => :feature do
 
   before do
     sign_in :user_with_fixtures

--- a/spec/features/display_dashboard_spec.rb
+++ b/spec/features/display_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "The Dashboard" do
+describe "The Dashboard", :type => :feature do
 
   before do
     sign_in :user_with_fixtures
@@ -9,28 +9,28 @@ describe "The Dashboard" do
   context "upon sign-in" do
 
     it "should show the user's information" do
-      page.should have_content "My Dashboard"
-      page.should have_content "User Activity"
-      page.should have_content "User Notifications"
-      page.should have_content "Your Statistics"
+      expect(page).to have_content "My Dashboard"
+      expect(page).to have_content "User Activity"
+      expect(page).to have_content "User Notifications"
+      expect(page).to have_content "Your Statistics"
     end
 
     it "should let the user upload files" do
       click_link "Upload"
-      page.should have_content "Upload"
+      expect(page).to have_content "Upload"
     end
 
     it "should let the user create collections" do
       click_link "Create Collection"
-      page.should have_content "Create New Collection"
+      expect(page).to have_content "Create New Collection"
     end
 
     it "should let the user view files" do
       click_link "View Files"
-      page.should have_content "My Files"
-      page.should have_content "My Collections"
-      page.should have_content "My Highlights"
-      page.should have_content "Files Shared with Me"
+      expect(page).to have_content "My Files"
+      expect(page).to have_content "My Collections"
+      expect(page).to have_content "My Highlights"
+      expect(page).to have_content "Files Shared with Me"
     end
 
   end

--- a/spec/features/ingest_upload_files_spec.rb
+++ b/spec/features/ingest_upload_files_spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
 
-describe "Uploading files via web form" do
+describe "Uploading files via web form", :type => :feature do
   before do
     sign_in :user
     click_link "Upload"
   end
 
   it "should have an ingest screen" do
-    page.should have_content "Select files"
-    page.should have_content "Start upload"
-    page.should have_content "Cancel upload"
-    page.should have_xpath '//input[@type="file"]'
+    expect(page).to have_content "Select files"
+    expect(page).to have_content "Start upload"
+    expect(page).to have_content "Cancel upload"
+    expect(page).to have_xpath '//input[@type="file"]'
   end
 
   it "should require checking the terms of service" do
     attach_file("files[]", File.dirname(__FILE__)+"/../../spec/fixtures/image.jp2")
     attach_file("files[]", File.dirname(__FILE__)+"/../../spec/fixtures/jp2_fits.xml")
-    page.should have_css("button#main_upload_start[disabled]")
+    expect(page).to have_css("button#main_upload_start[disabled]")
     find('#main_upload_start_span').hover do
-      page.should have_content "Please accept Deposit Agreement before you can upload."
+      expect(page).to have_content "Please accept Deposit Agreement before you can upload."
     end
   end
 end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Notifications page" do
+describe "Notifications page", :type => :feature do
 
   before do
     sign_in FactoryGirl.create(:user_with_mail)
@@ -8,16 +8,16 @@ describe "Notifications page" do
   end
 
   it "should list notifications with date, subject and message" do
-    page.should have_content "User Notifications"
-    page.find(:xpath, '//thead/tr').should have_content "Date"
-    page.find(:xpath, '//thead/tr').should have_content "Subject"
-    page.find(:xpath, '//thead/tr').should have_content "Message"
-    page.should have_content "These files could not be updated. You do not have sufficient privileges to edit them. "
-    page.should have_content "These files have been saved"
-    page.should have_content "File 1 could not be updated. You do not have sufficient privileges to edit it."
-    page.should have_content "File 1 has been saved"
-    page.should have_content "Batch upload permission denied  "
-    page.should have_content "Batch upload complete"
+    expect(page).to have_content "User Notifications"
+    expect(page.find(:xpath, '//thead/tr')).to have_content "Date"
+    expect(page.find(:xpath, '//thead/tr')).to have_content "Subject"
+    expect(page.find(:xpath, '//thead/tr')).to have_content "Message"
+    expect(page).to have_content "These files could not be updated. You do not have sufficient privileges to edit them. "
+    expect(page).to have_content "These files have been saved"
+    expect(page).to have_content "File 1 could not be updated. You do not have sufficient privileges to edit it."
+    expect(page).to have_content "File 1 has been saved"
+    expect(page).to have_content "Batch upload permission denied  "
+    expect(page).to have_content "Batch upload complete"
   end
 
 

--- a/spec/features/ownership_transfer_spec.rb
+++ b/spec/features/ownership_transfer_spec.rb
@@ -5,7 +5,7 @@ include Selectors::Dashboard
 include Selectors::NewTransfers
 include Selectors::Transfers
 
-describe 'Transferring file ownership:' do
+describe 'Transferring file ownership:', :type => :feature do
   let(:original_owner) { FactoryGirl.create(:archivist, display_name: 'Original Owner') }
   let(:new_owner) { FactoryGirl.create(:jill, display_name: 'New Owner') }
   let!(:file) do
@@ -38,14 +38,14 @@ describe 'Transferring file ownership:' do
     context 'To myself' do
       before { transfer_ownership_of_file file, original_owner }
       it 'Displays an appropriate error message' do
-        page.should have_content 'Sending user must specify another user to receive the file'
+        expect(page).to have_content 'Sending user must specify another user to receive the file'
       end
     end
 
     context 'To someone else' do
       before { transfer_ownership_of_file file, new_owner }
       it 'Creates a transfer request' do
-        page.should have_content 'Transfer request created'
+        expect(page).to have_content 'Transfer request created'
       end
       context 'If the new owner accepts it' do
         before do
@@ -54,7 +54,7 @@ describe 'Transferring file ownership:' do
           click_link 'transfer requests'
         end
         specify 'I should see it was accepted' do
-          page.find('#outgoing-transfers').should have_content 'Accepted'
+          expect(page.find('#outgoing-transfers')).to have_content 'Accepted'
         end
       end
       context 'If I cancel it' do
@@ -64,7 +64,7 @@ describe 'Transferring file ownership:' do
           first_sent_cancel_button.click
         end
         specify 'I should see it was cancelled' do
-          page.should have_content 'Transfer canceled'
+          expect(page).to have_content 'Transfer canceled'
         end
       end
     end
@@ -81,27 +81,27 @@ describe 'Transferring file ownership:' do
       within '#user_utility_links' do
         click_link 'transfer requests'
       end
-      page.should have_content 'Transfer of Ownership'
+      expect(page).to have_content 'Transfer of Ownership'
     end
     specify 'I should receive a notification' do
       user_notifications_link.click
-      page.should have_content "#{original_owner.name} wants to transfer a file to you"
+      expect(page).to have_content "#{original_owner.name} wants to transfer a file to you"
     end
     specify 'I should be able to accept it' do
       first_received_accept_dropdown.click
       click_link 'Allow depositor to retain edit access'
-      page.should have_content 'Transfer complete'
+      expect(page).to have_content 'Transfer complete'
     end
     specify 'I should be able to reject it' do
       first_received_reject_button.click
-      page.should have_content 'Transfer rejected'
+      expect(page).to have_content 'Transfer rejected'
     end
   end
 
   def transfer_ownership_of_file(file, new_owner)
     db_item_actions_toggle(file).click
     click_link 'Transfer Ownership of File'
-    page.should have_content "Select a user to transfer #{file.title.first} to, add optional comments and then press transfer."
+    expect(page).to have_content "Select a user to transfer #{file.title.first} to, add optional comments and then press transfer."
     new_owner_dropdown.click
     new_owner_search_field.set new_owner.user_key
     new_owner_search_result.click

--- a/spec/features/proxy_spec.rb
+++ b/spec/features/proxy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'proxy' do
+describe 'proxy', :type => :feature do
   let(:user) { FactoryGirl.find_or_create(:archivist) }
   let(:second_user) { FactoryGirl.find_or_create(:jill) }
 
@@ -21,8 +21,8 @@ describe 'proxy' do
       ProxyDepositRights.create!(grantor: second_user, grantee: user)
     end
 
-    it "allows on-behalf-of deposit" do
-      pending 'This test was incomplete before and is still incomplete.'
+    # TODO: Finish this spec
+    xit "allows on-behalf-of deposit" do
       sign_in user
       visit '/'
       first('a.dropdown-toggle').click

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'searching' do
+describe 'searching', :type => :feature do
   before { GenericFile.destroy_all }
   let!(:file) { FactoryGirl.create(:public_file, title: "Toothbrush") }
 

--- a/spec/features/single_use_links_spec.rb
+++ b/spec/features/single_use_links_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Create and use single-use links" do
+describe "Create and use single-use links", :type => :feature do
   include Warden::Test::Helpers
   Warden.test_mode!
   include Sufia::Engine.routes.url_helpers

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "User Profile" do
+describe "User Profile", :type => :feature do
 
   before do
     sign_in FactoryGirl.create(:curator)

--- a/spec/helpers/batch_edits_helper_spec.rb
+++ b/spec/helpers/batch_edits_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe BatchEditsHelper do
+describe BatchEditsHelper, :type => :helper do
 
   describe "#render_check_all" do
 

--- a/spec/helpers/content_block_helper_spec.rb
+++ b/spec/helpers/content_block_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ContentBlockHelper do
+describe ContentBlockHelper, :type => :helper do
   let(:content_block) { FactoryGirl.create(:content_block, value: "<p>foo bar</p>") }
 
   subject { helper.editable_content_block(content_block) }

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DashboardHelper do
+describe DashboardHelper, :type => :helper do
   
   describe "#render_recent_activity" do
     context "when there is no activity" do

--- a/spec/helpers/generic_file_helper_spec.rb
+++ b/spec/helpers/generic_file_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe GenericFileHelper do
+describe GenericFileHelper, :type => :helper do
 
   describe "#render_collection_list" do
 

--- a/spec/helpers/records_helper_spec.rb
+++ b/spec/helpers/records_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RecordsHelper do
+describe RecordsHelper, :type => :helper do
   let(:adder) {
     "<button class=\"adder btn\" id=\"additional_test_submit\" name=\"additional_test\"><span aria-hidden=\"true\"><i class=\"glyphicon glyphicon-plus\"></i></span><span class=\"sr-only\">add another test</span></button>"
   }

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SufiaHelper do
+describe SufiaHelper, :type => :helper do
 
   describe "#link_to_facet_list" do
     before do
@@ -31,12 +31,12 @@ describe SufiaHelper do
     subject { helper }
     context "when cq is set" do
       before { allow(helper).to receive(:params).and_return({ cq: 'foo'}) }
-      it { should have_collection_search_parameters }
+      it { is_expected.to have_collection_search_parameters }
     end
 
     context "when cq is not set" do
       before { allow(helper).to receive(:params).and_return({ cq: ''}) }
-      it { should_not have_collection_search_parameters }
+      it { is_expected.not_to have_collection_search_parameters }
     end
   end
 
@@ -45,23 +45,23 @@ describe SufiaHelper do
       let(:document) { SolrDocument.new( mime_type_tesim: 'image/jpeg', noid_tsi: '1234') }
       it "should show the audio thumbnail" do
         rendered = helper.sufia_thumbnail_tag(document, { width: 90 })
-        rendered.should match /src="\/downloads\/1234\?datastream_id=thumbnail"/
-        rendered.should match /width="90"/
+        expect(rendered).to match /src="\/downloads\/1234\?datastream_id=thumbnail"/
+        expect(rendered).to match /width="90"/
       end
     end
     context "for an audio object" do
       let(:document) { SolrDocument.new( mime_type_tesim: 'audio/x-wave') }
       it "should show the audio thumbnail" do
         rendered = helper.sufia_thumbnail_tag(document, {})
-        rendered.should match /src="\/assets\/audio.png"/
+        expect(rendered).to match /src="\/assets\/audio.png"/
       end
     end
     context "for an document object" do
       let(:document) { SolrDocument.new( mime_type_tesim: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', noid_tsi: '1234') }
       it "should show the default thumbnail" do
         rendered = helper.sufia_thumbnail_tag(document, { width: 90 })
-        rendered.should match /src="\/downloads\/1234\?datastream_id=thumbnail"/
-        rendered.should match /width="90"/
+        expect(rendered).to match /src="\/downloads\/1234\?datastream_id=thumbnail"/
+        expect(rendered).to match /width="90"/
       end
     end
   end

--- a/spec/helpers/trophy_helper_spec.rb
+++ b/spec/helpers/trophy_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe TrophyHelper do
+describe TrophyHelper, :type => :helper do
   describe "#display_trophy_link" do
     let(:user) { FactoryGirl.create(:user) }
     let(:noid) { '9999' }

--- a/spec/jobs/audit_job_spec.rb
+++ b/spec/jobs/audit_job_spec.rb
@@ -13,19 +13,19 @@ describe AuditJob do
   end
   describe "passing audit" do
     it "should not send passing mail" do
-      ActiveFedora::RelsExtDatastream.any_instance.stub(:dsChecksumValid).and_return(true)
+      allow_any_instance_of(ActiveFedora::RelsExtDatastream).to receive(:dsChecksumValid).and_return(true)
       AuditJob.new(@file.pid, "RELS-EXT", @file.rels_ext.versionID).run
       @inbox = @user.mailbox.inbox
-      @inbox.count.should == 0
+      expect(@inbox.count).to eq(0)
     end
   end
   describe "failing audit" do
     it "should send failing mail" do
-      ActiveFedora::RelsExtDatastream.any_instance.stub(:dsChecksumValid).and_return(false)
+      allow_any_instance_of(ActiveFedora::RelsExtDatastream).to receive(:dsChecksumValid).and_return(false)
       AuditJob.new(@file.pid, "RELS-EXT", @file.rels_ext.versionID).run
       @inbox = @user.mailbox.inbox
-      @inbox.count.should == 1
-      @inbox.each { |msg| msg.last_message.subject.should == AuditJob::FAIL }
+      expect(@inbox.count).to eq(1)
+      @inbox.each { |msg| expect(msg.last_message.subject).to eq(AuditJob::FAIL) }
     end
   end
 end

--- a/spec/jobs/batch_update_job_spec.rb
+++ b/spec/jobs/batch_update_job_spec.rb
@@ -34,28 +34,28 @@ describe BatchUpdateJob do
     end
     context "with a failing update" do
       it "should check permissions for each file before updating" do
-        User.any_instance.should_receive(:can?).with(:edit, @file).and_return(false)
-        User.any_instance.should_receive(:can?).with(:edit, @file2).and_return(false)
+        expect_any_instance_of(User).to receive(:can?).with(:edit, @file).and_return(false)
+        expect_any_instance_of(User).to receive(:can?).with(:edit, @file2).and_return(false)
         BatchUpdateJob.new(@user.user_key, params).run
-        @user.mailbox.inbox[0].messages[0].subject.should == "Batch upload permission denied"
-        @user.mailbox.inbox[0].messages[0].body.should include("data-content")
-        @user.mailbox.inbox[0].messages[0].body.should include("These files")
+        expect(@user.mailbox.inbox[0].messages[0].subject).to eq("Batch upload permission denied")
+        expect(@user.mailbox.inbox[0].messages[0].body).to include("data-content")
+        expect(@user.mailbox.inbox[0].messages[0].body).to include("These files")
       end
     end
     context "with a passing update" do
       let(:s1) { double('one') }
       let(:s2) { double('two') }
       it "should log a content update event" do
-        User.any_instance.should_receive(:can?).with(:edit, @file).and_return(true)
-        User.any_instance.should_receive(:can?).with(:edit, @file2).and_return(true)
-        ContentUpdateEventJob.should_receive(:new).with(@file.pid, @user.user_key).and_return(s1)
-        Sufia.queue.should_receive(:push).with(s1).once
-        ContentUpdateEventJob.should_receive(:new).with(@file2.pid, @user.user_key).and_return(s2)
-        Sufia.queue.should_receive(:push).with(s2).once
+        expect_any_instance_of(User).to receive(:can?).with(:edit, @file).and_return(true)
+        expect_any_instance_of(User).to receive(:can?).with(:edit, @file2).and_return(true)
+        expect(ContentUpdateEventJob).to receive(:new).with(@file.pid, @user.user_key).and_return(s1)
+        expect(Sufia.queue).to receive(:push).with(s1).once
+        expect(ContentUpdateEventJob).to receive(:new).with(@file2.pid, @user.user_key).and_return(s2)
+        expect(Sufia.queue).to receive(:push).with(s2).once
         BatchUpdateJob.new(@user.user_key, params).run
-        @user.mailbox.inbox[0].messages[0].subject.should == "Batch upload complete"
-        @user.mailbox.inbox[0].messages[0].body.should include("data-content")
-        @user.mailbox.inbox[0].messages[0].body.should include("These files")
+        expect(@user.mailbox.inbox[0].messages[0].subject).to eq("Batch upload complete")
+        expect(@user.mailbox.inbox[0].messages[0].body).to include("data-content")
+        expect(@user.mailbox.inbox[0].messages[0].body).to include("These files")
       end
     end
   end

--- a/spec/jobs/event_jobs_spec.rb
+++ b/spec/jobs/event_jobs_spec.rb
@@ -24,168 +24,168 @@ describe 'event jobs' do
     @another_user.follow(@user)
     count_user = @user.events.length
     count_another = @another_user.events.length
-    Time.should_receive(:now).at_least(:once).and_return(1)
+    expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has edited his or her profile', timestamp: '1' }
     UserEditProfileEventJob.new(@user.user_key).run
-    @user.events.length.should == count_user + 1
-    @user.events.first.should == event
-    @another_user.events.length.should == count_another + 1
-    @another_user.events.first.should == event
+    expect(@user.events.length).to eq(count_user + 1)
+    expect(@user.events.first).to eq(event)
+    expect(@another_user.events.length).to eq(count_another + 1)
+    expect(@another_user.events.first).to eq(event)
   end
   it "should log user follow events" do
     # UserFollow should log the event to the follower's dashboard, the followee's dashboard, and followers' dashboards
     @third_user.follow(@user)
-    @user.events.length.should == 0
-    @another_user.events.length.should == 0
-    @third_user.events.length.should == 0
-    Time.should_receive(:now).at_least(:once).and_return(1)
+    expect(@user.events.length).to eq(0)
+    expect(@another_user.events.length).to eq(0)
+    expect(@third_user.events.length).to eq(0)
+    expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> is now following <a href="/users/archivist1@example-dot-com">archivist1@example.com</a>', timestamp: '1' }
     UserFollowEventJob.new(@user.user_key, @another_user.user_key).run
-    @user.events.length.should == 1
-    @user.events.first.should == event
-    @another_user.events.length.should == 1
-    @another_user.events.first.should == event
-    @third_user.events.length.should == 1
-    @third_user.events.first.should == event
+    expect(@user.events.length).to eq(1)
+    expect(@user.events.first).to eq(event)
+    expect(@another_user.events.length).to eq(1)
+    expect(@another_user.events.first).to eq(event)
+    expect(@third_user.events.length).to eq(1)
+    expect(@third_user.events.first).to eq(event)
   end
   it "should log user unfollow events" do
     # UserUnfollow should log the event to the unfollower's dashboard, the unfollowee's dashboard, and followers' dashboards
     @third_user.follow(@user)
     @user.follow(@another_user)
-    @user.events.length.should == 0
-    @another_user.events.length.should == 0
-    @third_user.events.length.should == 0
-    Time.should_receive(:now).at_least(:once).and_return(1)
+    expect(@user.events.length).to eq(0)
+    expect(@another_user.events.length).to eq(0)
+    expect(@third_user.events.length).to eq(0)
+    expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has unfollowed <a href="/users/archivist1@example-dot-com">archivist1@example.com</a>', timestamp: '1' }
     UserUnfollowEventJob.new(@user.user_key, @another_user.user_key).run
-    @user.events.length.should == 1
-    @user.events.first.should == event
-    @another_user.events.length.should == 1
-    @another_user.events.first.should == event
-    @third_user.events.length.should == 1
-    @third_user.events.first.should == event
+    expect(@user.events.length).to eq(1)
+    expect(@user.events.first).to eq(event)
+    expect(@another_user.events.length).to eq(1)
+    expect(@another_user.events.first).to eq(event)
+    expect(@third_user.events.length).to eq(1)
+    expect(@third_user.events.first).to eq(event)
   end
   it "should log content deposit events" do
     # ContentDeposit should log the event to the depositor's profile, followers' dashboards, and the GF
     @another_user.follow(@user)
     @third_user.follow(@user)
-    User.any_instance.stub(:can?).and_return(true)
-    @user.profile_events.length.should == 0
-    @another_user.events.length.should == 0
-    @third_user.events.length.should == 0
-    @gf.events.length.should == 0
-    Time.should_receive(:now).at_least(:once).and_return(1)
+    allow_any_instance_of(User).to receive(:can?).and_return(true)
+    expect(@user.profile_events.length).to eq(0)
+    expect(@another_user.events.length).to eq(0)
+    expect(@third_user.events.length).to eq(0)
+    expect(@gf.events.length).to eq(0)
+    expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = {action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has deposited <a href="/files/123">Hamlet</a>', timestamp: '1' }
     ContentDepositEventJob.new('test:123', @user.user_key).run
-    @user.profile_events.length.should == 1
-    @user.profile_events.first.should == event
-    @another_user.events.length.should == 1
-    @another_user.events.first.should == event
-    @third_user.events.length.should == 1
-    @third_user.events.first.should == event
-    @gf.events.length.should == 1
-    @gf.events.first.should == event
+    expect(@user.profile_events.length).to eq(1)
+    expect(@user.profile_events.first).to eq(event)
+    expect(@another_user.events.length).to eq(1)
+    expect(@another_user.events.first).to eq(event)
+    expect(@third_user.events.length).to eq(1)
+    expect(@third_user.events.first).to eq(event)
+    expect(@gf.events.length).to eq(1)
+    expect(@gf.events.first).to eq(event)
   end
   it "should log content update events" do
     # ContentUpdate should log the event to the depositor's profile, followers' dashboards, and the GF
     @another_user.follow(@user)
     @third_user.follow(@user)
-    User.any_instance.stub(:can?).and_return(true)
-    @user.profile_events.length.should == 0
-    @another_user.events.length.should == 0
-    @third_user.events.length.should == 0
-    @gf.events.length.should == 0
-    Time.should_receive(:now).at_least(:once).and_return(1)
+    allow_any_instance_of(User).to receive(:can?).and_return(true)
+    expect(@user.profile_events.length).to eq(0)
+    expect(@another_user.events.length).to eq(0)
+    expect(@third_user.events.length).to eq(0)
+    expect(@gf.events.length).to eq(0)
+    expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = {action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has updated <a href="/files/123">Hamlet</a>', timestamp: '1' }
     ContentUpdateEventJob.new('test:123', @user.user_key).run
-    @user.profile_events.length.should == 1
-    @user.profile_events.first.should == event
-    @another_user.events.length.should == 1
-    @another_user.events.first.should == event
-    @third_user.events.length.should == 1
-    @third_user.events.first.should == event
-    @gf.events.length.should == 1
-    @gf.events.first.should == event
+    expect(@user.profile_events.length).to eq(1)
+    expect(@user.profile_events.first).to eq(event)
+    expect(@another_user.events.length).to eq(1)
+    expect(@another_user.events.first).to eq(event)
+    expect(@third_user.events.length).to eq(1)
+    expect(@third_user.events.first).to eq(event)
+    expect(@gf.events.length).to eq(1)
+    expect(@gf.events.first).to eq(event)
   end
   it "should log content new version events" do
     # ContentNewVersion should log the event to the depositor's profile, followers' dashboards, and the GF
     @another_user.follow(@user)
     @third_user.follow(@user)
-    User.any_instance.stub(:can?).and_return(true)
-    @user.profile_events.length.should == 0
-    @another_user.events.length.should == 0
-    @third_user.events.length.should == 0
-    @gf.events.length.should == 0
-    Time.should_receive(:now).at_least(:once).and_return(1)
+    allow_any_instance_of(User).to receive(:can?).and_return(true)
+    expect(@user.profile_events.length).to eq(0)
+    expect(@another_user.events.length).to eq(0)
+    expect(@third_user.events.length).to eq(0)
+    expect(@gf.events.length).to eq(0)
+    expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = {action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has added a new version of <a href="/files/123">Hamlet</a>', timestamp: '1' }
     ContentNewVersionEventJob.new('test:123', @user.user_key).run
-    @user.profile_events.length.should == 1
-    @user.profile_events.first.should == event
-    @another_user.events.length.should == 1
-    @another_user.events.first.should == event
-    @third_user.events.length.should == 1
-    @third_user.events.first.should == event
-    @gf.events.length.should == 1
-    @gf.events.first.should == event
+    expect(@user.profile_events.length).to eq(1)
+    expect(@user.profile_events.first).to eq(event)
+    expect(@another_user.events.length).to eq(1)
+    expect(@another_user.events.first).to eq(event)
+    expect(@third_user.events.length).to eq(1)
+    expect(@third_user.events.first).to eq(event)
+    expect(@gf.events.length).to eq(1)
+    expect(@gf.events.first).to eq(event)
   end
   it "should log content restored version events" do
     # ContentRestoredVersion should log the event to the depositor's profile, followers' dashboards, and the GF
     @another_user.follow(@user)
     @third_user.follow(@user)
-    User.any_instance.stub(:can?).and_return(true)
-    @user.profile_events.length.should == 0
-    @another_user.events.length.should == 0
-    @third_user.events.length.should == 0
-    @gf.events.length.should == 0
-    Time.should_receive(:now).at_least(:once).and_return(1)
+    allow_any_instance_of(User).to receive(:can?).and_return(true)
+    expect(@user.profile_events.length).to eq(0)
+    expect(@another_user.events.length).to eq(0)
+    expect(@third_user.events.length).to eq(0)
+    expect(@gf.events.length).to eq(0)
+    expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = {action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has restored a version \'content.0\' of <a href="/files/123">Hamlet</a>', timestamp: '1' }
     ContentRestoredVersionEventJob.new('test:123', @user.user_key, 'content.0').run
-    @user.profile_events.length.should == 1
-    @user.profile_events.first.should == event
-    @another_user.events.length.should == 1
-    @another_user.events.first.should == event
-    @third_user.events.length.should == 1
-    @third_user.events.first.should == event
-    @gf.events.length.should == 1
-    @gf.events.first.should == event
+    expect(@user.profile_events.length).to eq(1)
+    expect(@user.profile_events.first).to eq(event)
+    expect(@another_user.events.length).to eq(1)
+    expect(@another_user.events.first).to eq(event)
+    expect(@third_user.events.length).to eq(1)
+    expect(@third_user.events.first).to eq(event)
+    expect(@gf.events.length).to eq(1)
+    expect(@gf.events.first).to eq(event)
   end
   it "should log content delete events" do
     # ContentDelete should log the event to the depositor's profile and followers' dashboards
     @another_user.follow(@user)
     @third_user.follow(@user)
-    @user.profile_events.length.should == 0
-    @another_user.events.length.should == 0
-    @third_user.events.length.should == 0
-    Time.should_receive(:now).at_least(:once).and_return(1)
+    expect(@user.profile_events.length).to eq(0)
+    expect(@another_user.events.length).to eq(0)
+    expect(@third_user.events.length).to eq(0)
+    expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = {action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has deleted file \'123\'', timestamp: '1' }
     ContentDeleteEventJob.new('test:123', @user.user_key).run
-    @user.profile_events.length.should == 1
-    @user.profile_events.first.should == event
-    @another_user.events.length.should == 1
-    @another_user.events.first.should == event
-    @third_user.events.length.should == 1
-    @third_user.events.first.should == event
+    expect(@user.profile_events.length).to eq(1)
+    expect(@user.profile_events.first).to eq(event)
+    expect(@another_user.events.length).to eq(1)
+    expect(@another_user.events.first).to eq(event)
+    expect(@third_user.events.length).to eq(1)
+    expect(@third_user.events.first).to eq(event)
   end
   it "should not log content-related jobs to followers who lack access" do
     # No Content-related eventjobs should log an event to a follower who does not have access to the GF
     @another_user.follow(@user)
     @third_user.follow(@user)
-    @user.profile_events.length.should == 0
-    @another_user.events.length.should == 0
-    @third_user.events.length.should == 0
-    @gf.events.length.should == 0
+    expect(@user.profile_events.length).to eq(0)
+    expect(@another_user.events.length).to eq(0)
+    expect(@third_user.events.length).to eq(0)
+    expect(@gf.events.length).to eq(0)
     @now = Time.now
-    Time.should_receive(:now).at_least(:once).and_return(@now)
+    expect(Time).to receive(:now).at_least(:once).and_return(@now)
     event = {action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has updated <a href="/files/123">Hamlet</a>', timestamp: @now.to_i.to_s }
     ContentUpdateEventJob.new('test:123', @user.user_key).run
-    @user.profile_events.length.should == 1
-    @user.profile_events.first.should == event
-    @another_user.events.length.should == 0
-    @another_user.events.first.should be_nil
-    @third_user.events.length.should == 0
-    @third_user.events.first.should be_nil
-    @gf.events.length.should == 1
-    @gf.events.first.should == event
+    expect(@user.profile_events.length).to eq(1)
+    expect(@user.profile_events.first).to eq(event)
+    expect(@another_user.events.length).to eq(0)
+    expect(@another_user.events.first).to be_nil
+    expect(@third_user.events.length).to eq(0)
+    expect(@third_user.events.first).to be_nil
+    expect(@gf.events.length).to eq(1)
+    expect(@gf.events.first).to eq(event)
   end
 end
 

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -29,7 +29,7 @@ describe ImportUrlJob do
   subject(:job) { ImportUrlJob.new(generic_file.id) }
 
   it "should have no content at the outset" do
-    generic_file.content.size.should be_nil
+    expect(generic_file.content.size).to be_nil
   end
 
   context "after running the job" do
@@ -46,7 +46,7 @@ describe ImportUrlJob do
     end
 
     it "should create a content datastream" do
-      Net::HTTP.any_instance.should_receive(:request_get).with(file_hash).and_yield(mock_response)
+      expect_any_instance_of(Net::HTTP).to receive(:request_get).with(file_hash).and_yield(mock_response)
       job.run
       expect(generic_file.reload.content.size).to eq 4218
       expect(generic_file.content.dsLabel).to eq file_path

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -21,7 +21,7 @@ describe IngestLocalFileJob do
 
   it "should have attached a file" do
     job.run
-    generic_file.reload.content.size.should == 4218
+    expect(generic_file.reload.content.size).to eq(4218)
   end
 
   describe "virus checking" do

--- a/spec/lib/sufia/breadcrumbs_spec.rb
+++ b/spec/lib/sufia/breadcrumbs_spec.rb
@@ -28,7 +28,7 @@ describe Sufia::Breadcrumbs do
   describe "#default_trail" do
     context "when the user is logged in" do
       before do
-        crumbs.stub(:user_signed_in?) { true }
+        allow(crumbs).to receive(:user_signed_in?) { true }
       end
       specify "the default trail is nil" do
         expect(crumbs.default_trail).to eql([[I18n.t('sufia.dashboard.title'), sufia.dashboard_index_path]])
@@ -36,7 +36,7 @@ describe Sufia::Breadcrumbs do
     end
     context "when there is no user" do
       before do
-        crumbs.stub(:user_signed_in?) { false }
+        allow(crumbs).to receive(:user_signed_in?) { false }
       end
       specify "the default trail is nil" do
         expect(crumbs.default_trail).to be_nil
@@ -57,7 +57,7 @@ describe Sufia::Breadcrumbs do
     context "when coming from the dashboard" do
       before do
         allow(crumbs.request).to receive(:referer).and_return("http://...dashboard/")
-        crumbs.stub(:user_signed_in?) { true }
+        allow(crumbs).to receive(:user_signed_in?) { true }
       end
       specify "the trail goes back to the user's files" do
         allow(crumbs).to receive(:controller_name).and_return("my/files")

--- a/spec/lib/sufia/id_service_spec.rb
+++ b/spec/lib/sufia/id_service_spec.rb
@@ -4,7 +4,7 @@ describe Sufia::IdService do
   describe "mint" do
     subject { Sufia::IdService.mint }
 
-    it { should_not be_empty }
+    it { is_expected.not_to be_empty }
 
     it "should not mint the same id twice in a row" do
       expect(Sufia::IdService.mint).to_not eq subject

--- a/spec/lib/sufia/upload_complete_behavior_spec.rb
+++ b/spec/lib/sufia/upload_complete_behavior_spec.rb
@@ -19,18 +19,18 @@ describe Sufia::FilesController::UploadCompleteBehavior do
   let (:test_id) {"123abc"}
   context "Not overridden" do
     it "respond with the batch edit path" do
-      UploadThing.upload_complete_path(test_id).should == Sufia::Engine.routes.url_helpers.batch_edit_path(test_id)
+      expect(UploadThing.upload_complete_path(test_id)).to eq(Sufia::Engine.routes.url_helpers.batch_edit_path(test_id))
     end
     it "respond with the dashboard path" do
-      UploadThing.destroy_complete_path({}).should ==   Sufia::Engine.routes.url_helpers.dashboard_files_path
+      expect(UploadThing.destroy_complete_path({})).to eq(Sufia::Engine.routes.url_helpers.dashboard_files_path)
     end
   end
   context "overriden path" do
     it "respond with the batch edit path" do
-      UploadThingRedefine.upload_complete_path(test_id).should == "example.com"
+      expect(UploadThingRedefine.upload_complete_path(test_id)).to eq("example.com")
     end
     it "respond with the batch edit path" do
-      UploadThingRedefine.destroy_complete_path(test_id).should == "destroy.com"
+      expect(UploadThingRedefine.destroy_complete_path(test_id)).to eq("destroy.com")
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,30 +1,30 @@
 require 'spec_helper'
 require 'cancan/matchers'
 
-describe Sufia::Ability do
+describe Sufia::Ability, :type => :model do
   describe "a user with no roles" do
     let(:user) { nil }
     subject { Ability.new(user) }
-    it { should_not be_able_to(:create, GenericFile) }
-    it { should_not be_able_to(:create, TinymceAsset) }
-    it { should_not be_able_to(:update, ContentBlock) }
+    it { is_expected.not_to be_able_to(:create, GenericFile) }
+    it { is_expected.not_to be_able_to(:create, TinymceAsset) }
+    it { is_expected.not_to be_able_to(:update, ContentBlock) }
   end
 
   describe "a registered user" do
     let(:user) { FactoryGirl.find_or_create(:archivist) }
     subject { Ability.new(user) }
-    it { should be_able_to(:create, GenericFile) }
-    it { should_not be_able_to(:create, TinymceAsset) }
-    it { should_not be_able_to(:update, ContentBlock) }
+    it { is_expected.to be_able_to(:create, GenericFile) }
+    it { is_expected.not_to be_able_to(:create, TinymceAsset) }
+    it { is_expected.not_to be_able_to(:update, ContentBlock) }
   end
 
   describe "a user in the admin group" do
     let(:user) { FactoryGirl.find_or_create(:archivist) }
-    before { user.stub(groups: ['admin', 'registered']) }
+    before { allow(user).to receive_messages(groups: ['admin', 'registered']) }
     subject { Ability.new(user) }
-    it { should be_able_to(:create, GenericFile) }
-    it { should be_able_to(:create, TinymceAsset) }
-    it { should be_able_to(:update, ContentBlock) }
+    it { is_expected.to be_able_to(:create, GenericFile) }
+    it { is_expected.to be_able_to(:create, TinymceAsset) }
+    it { is_expected.to be_able_to(:update, ContentBlock) }
   end
 
   describe "proxies and transfers" do
@@ -37,38 +37,38 @@ describe Sufia::Ability do
       end
     end
     subject { Ability.new(user) }
-    it { should_not be_able_to(:transfer, file.pid) }
+    it { is_expected.not_to be_able_to(:transfer, file.pid) }
 
     context "with a ProxyDepositRequest for a file they have deposited" do
       subject { Ability.new(sender) }
-      it { should be_able_to(:transfer, file.pid) }
+      it { is_expected.to be_able_to(:transfer, file.pid) }
     end
 
     context "with a ProxyDepositRequest that they receive" do
       let(:request) { ProxyDepositRequest.create!(pid: file.pid, receiving_user: user, sending_user: sender) }
-      it { should be_able_to(:accept, request) }
-      it { should be_able_to(:reject, request) }
-      it { should_not be_able_to(:destroy, request) }
+      it { is_expected.to be_able_to(:accept, request) }
+      it { is_expected.to be_able_to(:reject, request) }
+      it { is_expected.not_to be_able_to(:destroy, request) }
 
       context "and the request has already been accepted" do
         let(:request) { ProxyDepositRequest.create!(pid: file.pid, receiving_user: user, sending_user: sender, status: 'accepted') }
-        it { should_not be_able_to(:accept, request) }
-        it { should_not be_able_to(:reject, request) }
-        it { should_not be_able_to(:destroy, request) }
+        it { is_expected.not_to be_able_to(:accept, request) }
+        it { is_expected.not_to be_able_to(:reject, request) }
+        it { is_expected.not_to be_able_to(:destroy, request) }
       end
     end
 
     context "with a ProxyDepositRequest they are the sender of" do
       let(:request) { ProxyDepositRequest.create!(pid: file.pid, receiving_user: sender, sending_user: user) }
-      it { should_not be_able_to(:accept, request) }
-      it { should_not be_able_to(:reject, request) }
-      it { should be_able_to(:destroy, request) }
+      it { is_expected.not_to be_able_to(:accept, request) }
+      it { is_expected.not_to be_able_to(:reject, request) }
+      it { is_expected.to be_able_to(:destroy, request) }
 
       context "and the request has already been accepted" do
         let(:request) { ProxyDepositRequest.create!(pid: file.pid, receiving_user: sender, sending_user: user, status: 'accepted') }
-        it { should_not be_able_to(:accept, request) }
-        it { should_not be_able_to(:reject, request) }
-        it { should_not be_able_to(:destroy, request) }
+        it { is_expected.not_to be_able_to(:accept, request) }
+        it { is_expected.not_to be_able_to(:reject, request) }
+        it { is_expected.not_to be_able_to(:destroy, request) }
       end
     end
   end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Batch do
+describe Batch, :type => :model do
   before(:all) do
     @user = FactoryGirl.find_or_create(:jill)
     @file = GenericFile.new
@@ -16,22 +16,22 @@ describe Batch do
     @batch.delete
   end
   it "should have rightsMetadata" do
-    @batch.rightsMetadata.should be_instance_of Hydra::Datastream::RightsMetadata
+    expect(@batch.rightsMetadata).to be_instance_of Hydra::Datastream::RightsMetadata
   end
   it "should have dc desc metadata" do
-    @batch.descMetadata.should be_kind_of BatchRdfDatastream
+    expect(@batch.descMetadata).to be_kind_of BatchRdfDatastream
   end
   it "should belong to testuser" do
-    @batch.creator.should == [@user.user_key]
+    expect(@batch.creator).to eq([@user.user_key])
   end
   it "should be titled 'test collection'" do
-    @batch.title.should == ["test collection"]
+    expect(@batch.title).to eq(["test collection"])
   end
   it "should have generic_files defined" do
-    @batch.should respond_to(:generic_files)
+    expect(@batch).to respond_to(:generic_files)
   end
   it "should contain one generic file" do
-    @batch.part.should == [@file.pid]
+    expect(@batch.part).to eq([@file.pid])
   end
   it "should be able to have more than one file" do
     gf = GenericFile.new
@@ -39,28 +39,28 @@ describe Batch do
     gf.save
     @batch.part << gf.pid
     @batch.save
-    @batch.part.should == [@file.pid, gf.pid]
+    expect(@batch.part).to eq([@file.pid, gf.pid])
     gf.delete
   end
   it "should support to_solr" do
-    @batch.to_solr.should_not be_nil
-    @batch.to_solr["batch__part_t"].should be_nil
-    @batch.to_solr["batch__title_t"].should be_nil
-    @batch.to_solr["batch__creator_t"].should be_nil
+    expect(@batch.to_solr).not_to be_nil
+    expect(@batch.to_solr["batch__part_t"]).to be_nil
+    expect(@batch.to_solr["batch__title_t"]).to be_nil
+    expect(@batch.to_solr["batch__creator_t"]).to be_nil
   end
   describe "find_or_create" do
     describe "when the object exists" do
       it "should find batch instead of creating" do
-        Batch.should_receive(:create).never
+        expect(Batch).to receive(:create).never
         @b2 = Batch.find_or_create( @batch.pid)
       end
     end
     describe "when the object does not exist" do
       it "should create" do
-        lambda {Batch.find("batch:123")}.should raise_error(ActiveFedora::ObjectNotFoundError)
-        Batch.should_receive(:create).once.and_return("the batch")
+        expect {Batch.find("batch:123")}.to raise_error(ActiveFedora::ObjectNotFoundError)
+        expect(Batch).to receive(:create).once.and_return("the batch")
         @b2 = Batch.find_or_create( "batch:123")
-        @b2.should == "the batch"
+        expect(@b2).to eq("the batch")
       end
     end
   end

--- a/spec/models/characterization_spec.rb
+++ b/spec/models/characterization_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Sufia::GenericFile::Characterization do
+describe Sufia::GenericFile::Characterization, :type => :model do
   before do
     class TestClass < ActiveFedora::Base
       include Sufia::GenericFile::Characterization

--- a/spec/models/checksum_audit_log_spec.rb
+++ b/spec/models/checksum_audit_log_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ChecksumAuditLog do
+describe ChecksumAuditLog, :type => :model do
   let(:f) do
     GenericFile.new.tap do |gf|
       gf.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Collection do
+describe Collection, :type => :model do
   before do
     @user = FactoryGirl.create(:user)
     @collection = Collection.new(title: "test collection").tap do |c|

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Sufia::Download do
+describe Sufia::Download, :type => :model do
 
   before do
     @download = Sufia::Download

--- a/spec/models/featured_work_list_spec.rb
+++ b/spec/models/featured_work_list_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FeaturedWorkList do
+describe FeaturedWorkList, :type => :model do
   let(:file1) { FactoryGirl.create(:generic_file) }
   let(:file2) { FactoryGirl.create(:generic_file) }
 

--- a/spec/models/featured_work_spec.rb
+++ b/spec/models/featured_work_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FeaturedWork do
+describe FeaturedWork, :type => :model do
   let(:feature) { FeaturedWork.create(generic_file_id:"99") }
 
   it "should have a file" do
@@ -21,7 +21,10 @@ describe FeaturedWork do
   describe "can_create_another?" do
     subject { FeaturedWork }
     context "when none exist" do
-      its(:can_create_another?) { should be true }
+      describe '#can_create_another?' do
+        subject { super().can_create_another? }
+        it { is_expected.to be true }
+      end
     end
     context "when five exist" do
       before do
@@ -29,13 +32,21 @@ describe FeaturedWork do
           FeaturedWork.create(generic_file_id:n.to_s)
         end
       end
-      its(:can_create_another?) { should be false }
+
+      describe '#can_create_another?' do
+        subject { super().can_create_another? }
+        it { is_expected.to be false }
+      end
     end
   end
 
   describe "#order" do
     subject { FeaturedWork.new(order: 5) }
-    its(:order) {should eq 5 }
+
+    describe '#order' do
+      subject { super().order }
+      it {is_expected.to eq 5 }
+    end
   end
 end
 

--- a/spec/models/file_content_datastream_spec.rb
+++ b/spec/models/file_content_datastream_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FileContentDatastream do
+describe FileContentDatastream, :type => :model do
   describe "version control" do
     before do
       f = GenericFile.new
@@ -16,16 +16,16 @@ describe FileContentDatastream do
       @file.content.versions.count == 1
     end
     it "should return the expected version ID" do
-      @file.content.versions.first.versionID.should == "content.0"
+      expect(@file.content.versions.first.versionID).to eq("content.0")
     end
     it "should support latest_version" do
-      @file.content.latest_version.versionID.should == "content.0"
+      expect(@file.content.latest_version.versionID).to eq("content.0")
     end
     it "should return the same version via get_version" do
-      @file.content.get_version("content.0").versionID.should == @file.content.latest_version.versionID
+      expect(@file.content.get_version("content.0").versionID).to eq(@file.content.latest_version.versionID)
     end
     it "should not barf when a garbage ID is provided to get_version"  do
-      @file.content.get_version("foobar").should be_nil
+      expect(@file.content.get_version("foobar")).to be_nil
     end
     describe "add a version" do
       before do
@@ -36,36 +36,36 @@ describe FileContentDatastream do
         @file.content.versions.count == 2
       end
       it "should return the newer version via latest_version" do
-        @file.content.versions.first.versionID.should == "content.1"
+        expect(@file.content.versions.first.versionID).to eq("content.1")
       end
       it "should return the same version via get_version" do
-        @file.content.get_version("content.1").versionID.should == @file.content.latest_version.versionID
+        expect(@file.content.get_version("content.1").versionID).to eq(@file.content.latest_version.versionID)
       end
     end
   end
   describe "extract_metadata" do
     before do
       @subject = FileContentDatastream.new(nil, 'content')
-      @subject.stub(pid: 'my_pid')
-      @subject.stub(dsVersionID: 'content.7')
+      allow(@subject).to receive_messages(pid: 'my_pid')
+      allow(@subject).to receive_messages(dsVersionID: 'content.7')
     end
     it "should return an xml document", unless: $in_travis do
       f = File.new(fixture_path + '/world.png', 'rb')
       @subject.content = f.read
       xml = @subject.extract_metadata
       doc = Nokogiri::XML.parse(xml)
-      doc.root.xpath('//ns:imageWidth/text()', {'ns'=>'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}).inner_text.should == '50'
+      expect(doc.root.xpath('//ns:imageWidth/text()', {'ns'=>'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}).inner_text).to eq('50')
     end
     it "should return expected results when invoked via HTTP", unless: $in_travis do
       f = ActionDispatch::Http::UploadedFile.new(tempfile: File.new(fixture_path + '/world.png'),
                                                  filename: 'world.png')
       content = double("file")
-      content.stub(read: f.read)
-      content.stub(rewind: f.rewind)
-      @subject.stub(:content).and_return(f)
+      allow(content).to receive_messages(read: f.read)
+      allow(content).to receive_messages(rewind: f.rewind)
+      allow(@subject).to receive(:content).and_return(f)
       xml = @subject.extract_metadata
       doc = Nokogiri::XML.parse(xml)
-      doc.root.xpath('//ns:identity/@mimetype', {'ns'=>'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}).first.value.should == 'image/png'
+      expect(doc.root.xpath('//ns:identity/@mimetype', {'ns'=>'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}).first.value).to eq('image/png')
     end
   end
   describe "changed?" do

--- a/spec/models/file_usage_spec.rb
+++ b/spec/models/file_usage_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FileUsage do
+describe FileUsage, :type => :model do
 
   before :all do
     @file = GenericFile.new

--- a/spec/models/fits_datastream_spec.rb
+++ b/spec/models/fits_datastream_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FitsDatastream, unless: $in_travis do
+describe FitsDatastream, type: :model, unless: $in_travis do
   describe "image" do
     before(:all) do
       @file = GenericFile.new

--- a/spec/models/generic_file/reload_on_save_spec.rb
+++ b/spec/models/generic_file/reload_on_save_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe Sufia::GenericFile::ReloadOnSave do
+describe Sufia::GenericFile::ReloadOnSave, :type => :model do
   let(:user) { FactoryGirl.find_or_create(:jill) }
   let(:file) { GenericFile.new.tap { |f| f.apply_depositor_metadata(user); f.save! } }
 
   it 'defaults to not call reload' do
-    file.should_not_receive(:reload)
+    expect(file).not_to receive(:reload)
     file.save
   end
 
   it 'can be set to call reload' do
     file.reload_on_save = true
-    file.should_receive(:reload)
+    expect(file).to receive(:reload)
     file.save
   end
 
   it 'allows reload to be turned off and on' do
     file.reload_on_save = true
-    file.should_receive(:reload).once
+    expect(file).to receive(:reload).once
     file.save
     file.reload_on_save = false
     file.save

--- a/spec/models/generic_file/visibility_spec.rb
+++ b/spec/models/generic_file/visibility_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Sufia::GenericFile do
+describe Sufia::GenericFile, :type => :model do
   module VisibilityOverride
     extend ActiveSupport::Concern
     include Sufia::GenericFile::Permissions

--- a/spec/models/generic_file/web_form_spec.rb
+++ b/spec/models/generic_file/web_form_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
-describe GenericFile do
+describe GenericFile, :type => :model do
   before do
     subject.apply_depositor_metadata('jcoyne')
   end
 
   describe "terms_for_editing" do
     it "should return a list" do
-      subject.terms_for_editing.should == [:resource_type, :title, :creator, :contributor, :description, :tag,
-                    :rights, :publisher, :date_created, :subject, :language, :identifier, :based_near, :related_url]
+      expect(subject.terms_for_editing).to eq([:resource_type, :title, :creator, :contributor, :description, :tag,
+                    :rights, :publisher, :date_created, :subject, :language, :identifier, :based_near, :related_url])
     end
   end
   describe "terms_for_display" do
@@ -22,13 +22,14 @@ describe GenericFile do
 
   describe "accessible_attributes" do
     it "should have a list" do
-      subject.accessible_attributes.should include(:part_of, :resource_type, :title, :creator, :contributor, :description,
+      expect(subject.accessible_attributes).to include(:part_of, :resource_type, :title, :creator, :contributor, :description,
         :tag, :rights, :publisher, :date_created, :subject, :language, :identifier, :based_near, :related_url, :permissions)
     end
 
     it "should sanitize them" do
-      subject.sanitize_attributes({'part_of' => 'A book', 'something_crazy' => "get's thrown out"}).should ==
+      expect(subject.sanitize_attributes({'part_of' => 'A book', 'something_crazy' => "get's thrown out"})).to eq(
         {'part_of' => 'A book'}
+      )
     end
   end
 end

--- a/spec/models/generic_file_rdf_datastream_spec.rb
+++ b/spec/models/generic_file_rdf_datastream_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe GenericFileRdfDatastream do
+describe GenericFileRdfDatastream, :type => :model do
   it "should have bibliographicCitation" do
     subject.bibliographic_citation = "foo"
     expect(subject.bibliographic_citation).to eq ["foo"]

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe GenericFile do
+describe GenericFile, :type => :model do
   let(:user) { FactoryGirl.find_or_create(:jill) }
 
   before(:each) do
@@ -90,176 +90,176 @@ describe GenericFile do
     context "when pdf?" do
       it "should be true for pdf" do
         subject.mime_type = 'application/pdf'
-        subject.should be_pdf
+        expect(subject).to be_pdf
       end
     end
     context "when audio?" do
       it "should be true for wav" do
         subject.mime_type = 'audio/x-wave'
-        subject.should be_audio
+        expect(subject).to be_audio
         subject.mime_type = 'audio/x-wav'
-        subject.should be_audio
+        expect(subject).to be_audio
       end
       it "should be true for mpeg" do
         subject.mime_type = 'audio/mpeg'
-        subject.should be_audio
+        expect(subject).to be_audio
         subject.mime_type = 'audio/mp3'
-        subject.should be_audio
+        expect(subject).to be_audio
       end
       it "should be true for ogg" do
         subject.mime_type = 'audio/ogg'
-        subject.should be_audio
+        expect(subject).to be_audio
       end
     end
     context "when video?" do
       it "should be true for avi" do
         subject.mime_type = 'video/avi'
-        subject.should be_video
+        expect(subject).to be_video
       end
       it "should be true for webm" do
         subject.mime_type = 'video/webm'
-        subject.should be_video
+        expect(subject).to be_video
       end
       it "should be true for mpeg" do
         subject.mime_type = 'video/mp4'
-        subject.should be_video
+        expect(subject).to be_video
         subject.mime_type = 'video/mpeg'
-        subject.should be_video
+        expect(subject).to be_video
       end
       it "should be true for quicktime" do
         subject.mime_type = 'video/quicktime'
-        subject.should be_video
+        expect(subject).to be_video
       end
       it "should be true for mxf" do
         subject.mime_type = 'application/mxf'
-        subject.should be_video
+        expect(subject).to be_video
       end
     end
   end
 
   describe "visibility" do
     it "should not be changed when it's new" do
-      subject.should_not be_visibility_changed
+      expect(subject).not_to be_visibility_changed
     end
     it "should be changed when it has been changed" do
       subject.visibility= 'open'
-      subject.should be_visibility_changed
+      expect(subject).to be_visibility_changed
     end
 
     it "should not be changed when it's set to its previous value" do
       subject.visibility= 'restricted'
-      subject.should_not be_visibility_changed
+      expect(subject).not_to be_visibility_changed
     end
 
   end
 
   describe "attributes" do
     it "should have rightsMetadata" do
-      subject.rightsMetadata.should be_instance_of ParanoidRightsDatastream
+      expect(subject.rightsMetadata).to be_instance_of ParanoidRightsDatastream
     end
     it "should have properties datastream for depositor" do
-      subject.properties.should be_instance_of PropertiesDatastream
+      expect(subject.properties).to be_instance_of PropertiesDatastream
     end
     it "should have apply_depositor_metadata" do
-      subject.rightsMetadata.edit_access.should == ['jcoyne']
-      subject.depositor.should == 'jcoyne'
+      expect(subject.rightsMetadata.edit_access).to eq(['jcoyne'])
+      expect(subject.depositor).to eq('jcoyne')
     end
     it "should have a set of permissions" do
       subject.read_groups=['group1', 'group2']
       subject.edit_users=['user1']
       subject.read_users=['user2', 'user3']
-      subject.permissions.should == [{type: "group", access: "read", name: "group1"},
+      expect(subject.permissions).to eq([{type: "group", access: "read", name: "group1"},
           {type: "group", access: "read", name: "group2"},
           {type: "user", access: "read", name: "user2"},
           {type: "user", access: "read", name: "user3"},
-          {type: "user", access: "edit", name: "user1"}]
+          {type: "user", access: "edit", name: "user1"}])
     end
     describe "updating permissions" do
       it "should create new group permissions" do
         subject.permissions = {new_group_name: {'group1'=>'read'}}
-        subject.permissions.should == [{type: "group", access: "read", name: "group1"},
-                                     {type: "user", access: "edit", name: "jcoyne"}]
+        expect(subject.permissions).to eq([{type: "group", access: "read", name: "group1"},
+                                     {type: "user", access: "edit", name: "jcoyne"}])
       end
       it "should create new user permissions" do
         subject.permissions = {new_user_name: {'user1'=>'read'}}
-        subject.permissions.should == [{type: "user", access: "read", name: "user1"},
-                                     {type: "user", access: "edit", name: "jcoyne"}]
+        expect(subject.permissions).to eq([{type: "user", access: "read", name: "user1"},
+                                     {type: "user", access: "edit", name: "jcoyne"}])
       end
       it "should not replace existing groups" do
         subject.permissions = {new_group_name: {'group1' => 'read'}}
         subject.permissions = {new_group_name: {'group2' => 'read'}}
-        subject.permissions.should == [{type: "group", access: "read", name: "group1"},
+        expect(subject.permissions).to eq([{type: "group", access: "read", name: "group1"},
                                      {type: "group", access: "read", name: "group2"},
-                                     {type: "user", access: "edit", name: "jcoyne"}]
+                                     {type: "user", access: "edit", name: "jcoyne"}])
       end
       it "should not replace existing users" do
         subject.permissions = {new_user_name:{'user1'=>'read'}}
         subject.permissions = {new_user_name:{'user2'=>'read'}}
-        subject.permissions.should == [{type: "user", access: "read", name: "user1"},
+        expect(subject.permissions).to eq([{type: "user", access: "read", name: "user1"},
                                      {type: "user", access: "read", name: "user2"},
-                                     {type: "user", access: "edit", name: "jcoyne"}]
+                                     {type: "user", access: "edit", name: "jcoyne"}])
       end
       it "should update permissions on existing users" do
         subject.permissions = {new_user_name:{'user1'=>'read'}}
         subject.permissions = {user:{'user1'=>'edit'}}
-        subject.permissions.should == [{type: "user", access: "edit", name: "user1"},
-                                     {type: "user", access: "edit", name: "jcoyne"}]
+        expect(subject.permissions).to eq([{type: "user", access: "edit", name: "user1"},
+                                     {type: "user", access: "edit", name: "jcoyne"}])
       end
       it "should update permissions on existing groups" do
         subject.permissions = {new_group_name:{'group1'=>'read'}}
         subject.permissions = {group:{'group1'=>'edit'}}
-        subject.permissions.should == [{type: "group", access: "edit", name: "group1"},
-                                     {type: "user", access: "edit", name: "jcoyne"}]
+        expect(subject.permissions).to eq([{type: "group", access: "edit", name: "group1"},
+                                     {type: "user", access: "edit", name: "jcoyne"}])
       end
     end
     it "should have a characterization datastream" do
-      subject.characterization.should be_kind_of FitsDatastream
+      expect(subject.characterization).to be_kind_of FitsDatastream
     end
     it "should have a dc desc metadata" do
-      subject.descMetadata.should be_kind_of GenericFileRdfDatastream
+      expect(subject.descMetadata).to be_kind_of GenericFileRdfDatastream
     end
     it "should have content datastream" do
       subject.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
-      subject.content.should be_kind_of FileContentDatastream
+      expect(subject.content).to be_kind_of FileContentDatastream
     end
   end
   describe "delegations" do
     it "should delegate methods to properties metadata" do
-      subject.should respond_to(:relative_path)
-      subject.should respond_to(:depositor)
+      expect(subject).to respond_to(:relative_path)
+      expect(subject).to respond_to(:depositor)
     end
     it "should delegate methods to descriptive metadata" do
-      subject.should respond_to(:related_url)
-      subject.should respond_to(:based_near)
-      subject.should respond_to(:part_of)
-      subject.should respond_to(:contributor)
-      subject.should respond_to(:creator)
-      subject.should respond_to(:title)
-      subject.should respond_to(:description)
-      subject.should respond_to(:publisher)
-      subject.should respond_to(:date_created)
-      subject.should respond_to(:date_uploaded)
-      subject.should respond_to(:date_modified)
-      subject.should respond_to(:subject)
-      subject.should respond_to(:language)
-      subject.should respond_to(:rights)
-      subject.should respond_to(:resource_type)
-      subject.should respond_to(:identifier)
+      expect(subject).to respond_to(:related_url)
+      expect(subject).to respond_to(:based_near)
+      expect(subject).to respond_to(:part_of)
+      expect(subject).to respond_to(:contributor)
+      expect(subject).to respond_to(:creator)
+      expect(subject).to respond_to(:title)
+      expect(subject).to respond_to(:description)
+      expect(subject).to respond_to(:publisher)
+      expect(subject).to respond_to(:date_created)
+      expect(subject).to respond_to(:date_uploaded)
+      expect(subject).to respond_to(:date_modified)
+      expect(subject).to respond_to(:subject)
+      expect(subject).to respond_to(:language)
+      expect(subject).to respond_to(:rights)
+      expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:identifier)
     end
     it "should delegate methods to characterization metadata" do
-      subject.should respond_to(:format_label)
-      subject.should respond_to(:mime_type)
-      subject.should respond_to(:file_size)
-      subject.should respond_to(:last_modified)
-      subject.should respond_to(:filename)
-      subject.should respond_to(:original_checksum)
-      subject.should respond_to(:well_formed)
-      subject.should respond_to(:file_title)
-      subject.should respond_to(:file_author)
-      subject.should respond_to(:page_count)
+      expect(subject).to respond_to(:format_label)
+      expect(subject).to respond_to(:mime_type)
+      expect(subject).to respond_to(:file_size)
+      expect(subject).to respond_to(:last_modified)
+      expect(subject).to respond_to(:filename)
+      expect(subject).to respond_to(:original_checksum)
+      expect(subject).to respond_to(:well_formed)
+      expect(subject).to respond_to(:file_title)
+      expect(subject).to respond_to(:file_author)
+      expect(subject).to respond_to(:page_count)
     end
     it "should redefine to_param to make redis keys more recognizable" do
-      subject.to_param.should == subject.noid
+      expect(subject.to_param).to eq(subject.noid)
     end
     describe "that have been saved" do
       # This file has no content, so it doesn't characterize
@@ -278,10 +278,10 @@ describe GenericFile do
       it "should have activity stream-related methods defined" do
         subject.save
         f = subject.reload
-        f.should respond_to(:stream)
-        f.should respond_to(:events)
-        f.should respond_to(:create_event)
-        f.should respond_to(:log_event)
+        expect(f).to respond_to(:stream)
+        expect(f).to respond_to(:events)
+        expect(f).to respond_to(:create_event)
+        expect(f).to respond_to(:log_event)
       end
       it "should be able to set values via delegated methods" do
         subject.related_url = ["http://example.org/"]
@@ -289,23 +289,23 @@ describe GenericFile do
         subject.title = ["New work"]
         subject.save
         f = subject.reload
-        f.related_url.should == ["http://example.org/"]
-        f.creator.should == ["John Doe"]
-        f.title.should == ["New work"]
+        expect(f.related_url).to eq(["http://example.org/"])
+        expect(f.creator).to eq(["John Doe"])
+        expect(f.title).to eq(["New work"])
       end
       it "should be able to be added to w/o unexpected graph behavior" do
         subject.creator = ["John Doe"]
         subject.title = ["New work"]
         subject.save
         f = subject.reload
-        f.creator.should == ["John Doe"]
-        f.title.should == ["New work"]
+        expect(f.creator).to eq(["John Doe"])
+        expect(f.title).to eq(["New work"])
         f.creator = ["Jane Doe"]
         f.title << "Newer work"
         f.save
         f = subject.reload
-        f.creator.should == ["Jane Doe"]
-        f.title.should == ["New work", "Newer work"]
+        expect(f.creator).to eq(["Jane Doe"])
+        expect(f.title).to eq(["New work", "Newer work"])
       end
     end
   end
@@ -361,12 +361,12 @@ describe GenericFile do
   end
   it "should support multi-valued fields in solr" do
     subject.tag = ["tag1", "tag2"]
-    lambda { subject.save }.should_not raise_error
+    expect { subject.save }.not_to raise_error
     subject.delete
   end
   it "should support setting and getting the relative_path value" do
     subject.relative_path = "documents/research/NSF/2010"
-    subject.relative_path.should == "documents/research/NSF/2010"
+    expect(subject.relative_path).to eq("documents/research/NSF/2010")
   end
   describe "create_thumbnail" do
     before do
@@ -378,14 +378,14 @@ describe GenericFile do
     end
     describe "with a video", if: Sufia.config.enable_ffmpeg do
       before do
-        @f.stub(mime_type: 'video/quicktime')  #Would get set by the characterization job
+        allow(@f).to receive_messages(mime_type: 'video/quicktime')  #Would get set by the characterization job
         @f.add_file(File.open("#{fixture_path}/countdown.avi", 'rb'), 'content', 'countdown.avi')
         @f.save
       end
       it "should make a png thumbnail" do
         @f.create_thumbnail
-        @f.thumbnail.content.size.should == 4768 # this is a bad test. I just want to show that it did something.
-        @f.thumbnail.mimeType.should == 'image/png'
+        expect(@f.thumbnail.content.size).to eq(4768) # this is a bad test. I just want to show that it did something.
+        expect(@f.thumbnail.mimeType).to eq('image/png')
       end
     end
   end
@@ -418,33 +418,33 @@ describe GenericFile do
     end
     it "should schedule a audit job for each datastream" do
       s0 = double('zero')
-      AuditJob.should_receive(:new).with(@f.pid, 'descMetadata', "descMetadata.0").and_return(s0)
-      Sufia.queue.should_receive(:push).with(s0)
+      expect(AuditJob).to receive(:new).with(@f.pid, 'descMetadata', "descMetadata.0").and_return(s0)
+      expect(Sufia.queue).to receive(:push).with(s0)
       s1 = double('one')
-      AuditJob.should_receive(:new).with(@f.pid, 'DC', "DC1.0").and_return(s1)
-      Sufia.queue.should_receive(:push).with(s1)
+      expect(AuditJob).to receive(:new).with(@f.pid, 'DC', "DC1.0").and_return(s1)
+      expect(Sufia.queue).to receive(:push).with(s1)
       s2 = double('two')
-      AuditJob.should_receive(:new).with(@f.pid, 'RELS-EXT', "RELS-EXT.0").and_return(s2)
-      Sufia.queue.should_receive(:push).with(s2)
+      expect(AuditJob).to receive(:new).with(@f.pid, 'RELS-EXT', "RELS-EXT.0").and_return(s2)
+      expect(Sufia.queue).to receive(:push).with(s2)
       s3 = double('three')
-      AuditJob.should_receive(:new).with(@f.pid, 'rightsMetadata', "rightsMetadata.0").and_return(s3)
-      Sufia.queue.should_receive(:push).with(s3)
+      expect(AuditJob).to receive(:new).with(@f.pid, 'rightsMetadata', "rightsMetadata.0").and_return(s3)
+      expect(Sufia.queue).to receive(:push).with(s3)
       s4 = double('four')
-      AuditJob.should_receive(:new).with(@f.pid, 'properties', "properties.0").and_return(s4)
-      Sufia.queue.should_receive(:push).with(s4)
+      expect(AuditJob).to receive(:new).with(@f.pid, 'properties', "properties.0").and_return(s4)
+      expect(Sufia.queue).to receive(:push).with(s4)
       s5 = double('five')
-      AuditJob.should_receive(:new).with(@f.pid, 'content', "content.0").and_return(s5)
-      Sufia.queue.should_receive(:push).with(s5)
+      expect(AuditJob).to receive(:new).with(@f.pid, 'content', "content.0").and_return(s5)
+      expect(Sufia.queue).to receive(:push).with(s5)
       @f.audit!
     end
     it "should log a failing audit" do
-      @f.datastreams.each { |ds| ds.stub(:dsChecksumValid).and_return(false) }
-      GenericFile.stub(:run_audit).and_return(double(:respose, pass:1, created_at: '2005-12-20', pid: 'foo:123', dsid: 'foo', version: '1'))
+      @f.datastreams.each { |ds| allow(ds).to receive(:dsChecksumValid).and_return(false) }
+      allow(GenericFile).to receive(:run_audit).and_return(double(:respose, pass:1, created_at: '2005-12-20', pid: 'foo:123', dsid: 'foo', version: '1'))
       @f.audit!
       expect(ChecksumAuditLog.all).to be_all { |cal| cal.pass == 0 }
     end
     it "should log a passing audit" do
-      GenericFile.stub(:run_audit).and_return(double(:respose, pass:1, created_at: '2005-12-20', pid: 'foo:123', dsid: 'foo', version: '1'))
+      allow(GenericFile).to receive(:run_audit).and_return(double(:respose, pass:1, created_at: '2005-12-20', pid: 'foo:123', dsid: 'foo', version: '1'))
       @f.audit!
       expect(ChecksumAuditLog.all).to be_all { |cal| cal.pass == 1 }
     end
@@ -465,22 +465,22 @@ describe GenericFile do
       @new = ChecksumAuditLog.create(pid: @f.pid, dsid: @version.dsid, version: @version.versionID, pass: 0)
     end
     it "should not prune failed audits" do
-      @version.should_receive(:dsChecksumValid).and_return(true)
+      expect(@version).to receive(:dsChecksumValid).and_return(true)
       GenericFile.run_audit(@version)
 
-      @version.should_receive(:dsChecksumValid).and_return(false)
+      expect(@version).to receive(:dsChecksumValid).and_return(false)
       GenericFile.run_audit(@version)
 
-      @version.should_receive(:dsChecksumValid).and_return(false)
+      expect(@version).to receive(:dsChecksumValid).and_return(false)
       GenericFile.run_audit(@version)
 
-      @version.should_receive(:dsChecksumValid).and_return(true)
+      expect(@version).to receive(:dsChecksumValid).and_return(true)
       GenericFile.run_audit(@version)
 
-      @version.should_receive(:dsChecksumValid).and_return(false)
+      expect(@version).to receive(:dsChecksumValid).and_return(false)
       GenericFile.run_audit(@version)
 
-      @f.logs(@version.dsid).map(&:pass).should == [0, 1, 0, 0, 1, 0, 1]
+      expect(@f.logs(@version.dsid).map(&:pass)).to eq([0, 1, 0, 0, 1, 0, 1])
     end
 
   end
@@ -537,15 +537,15 @@ describe GenericFile do
       @new_file.delete
     end
     it "should support the noid method" do
-      @new_file.should respond_to(:noid)
+      expect(@new_file).to respond_to(:noid)
     end
     it "should return the expected identifier" do
-      @new_file.noid.should == '123'
+      expect(@new_file.noid).to eq('123')
     end
     it "should work outside of an instance" do
       new_id = Sufia::IdService.mint
       noid = new_id.split(':').last
-      Sufia::Noid.noidify(new_id).should == noid
+      expect(Sufia::Noid.noidify(new_id)).to eq(noid)
     end
   end
   describe "characterize" do
@@ -553,7 +553,7 @@ describe GenericFile do
       subject.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
       subject.characterize
       doc = Nokogiri::XML.parse(subject.characterization.content)
-      doc.root.xpath('//ns:imageWidth/text()', {'ns'=>'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}).inner_text.should == '50'
+      expect(doc.root.xpath('//ns:imageWidth/text()', {'ns'=>'http://hul.harvard.edu/ois/xml/ns/fits/fits_output'}).inner_text).to eq('50')
     end
     context "after characterization" do
       before(:all) do
@@ -569,25 +569,25 @@ describe GenericFile do
         @myfile.destroy
       end
       it "should return expected results after a save" do
-        @myfile.file_size.should == ['218882']
-        @myfile.original_checksum.should == ['5a2d761cab7c15b2b3bb3465ce64586d']
+        expect(@myfile.file_size).to eq(['218882'])
+        expect(@myfile.original_checksum).to eq(['5a2d761cab7c15b2b3bb3465ce64586d'])
       end
       it "should return a hash of all populated values from the characterization terminology" do
-        @myfile.characterization_terms[:format_label].should == ["Portable Document Format"]
-        @myfile.characterization_terms[:mime_type].should == "application/pdf"
-        @myfile.characterization_terms[:file_size].should == ["218882"]
-        @myfile.characterization_terms[:original_checksum].should == ["5a2d761cab7c15b2b3bb3465ce64586d"]
-        @myfile.characterization_terms.keys.should include(:last_modified)
-        @myfile.characterization_terms.keys.should include(:filename)
+        expect(@myfile.characterization_terms[:format_label]).to eq(["Portable Document Format"])
+        expect(@myfile.characterization_terms[:mime_type]).to eq("application/pdf")
+        expect(@myfile.characterization_terms[:file_size]).to eq(["218882"])
+        expect(@myfile.characterization_terms[:original_checksum]).to eq(["5a2d761cab7c15b2b3bb3465ce64586d"])
+        expect(@myfile.characterization_terms.keys).to include(:last_modified)
+        expect(@myfile.characterization_terms.keys).to include(:filename)
       end
       it "should append metadata from the characterization" do
-        @myfile.title.should include("Microsoft Word - sample.pdf.docx")
-        @myfile.filename[0].should == @myfile.label
+        expect(@myfile.title).to include("Microsoft Word - sample.pdf.docx")
+        expect(@myfile.filename[0]).to eq(@myfile.label)
       end
       it "should append each term only once" do
         @myfile.append_metadata
-        @myfile.format_label.should == ["Portable Document Format"]
-        @myfile.title.should include("Microsoft Word - sample.pdf.docx")
+        expect(@myfile.format_label).to eq(["Portable Document Format"])
+        expect(@myfile.title).to include("Microsoft Word - sample.pdf.docx")
       end
       it 'includes extracted full-text content' do
         expect(@myfile.full_text.content).to eq("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nMicrosoft Word - sample.pdf.docx\n\n\n \n \n\n \n\n \n\n \n\nThis PDF file was created using CutePDF. \n\nwww.cutepdf.com")
@@ -597,7 +597,7 @@ describe GenericFile do
   describe "label" do
     it "should set the inner label" do
       subject.label = "My New Label"
-      subject.inner_object.label.should == "My New Label"
+      expect(subject.inner_object.label).to eq("My New Label")
     end
   end
   context "with rightsMetadata" do
@@ -608,27 +608,27 @@ describe GenericFile do
       m
     end
     it "should have read groups accessor" do
-      subject.read_groups.should == ['group-6', 'group-7']
+      expect(subject.read_groups).to eq(['group-6', 'group-7'])
     end
     it "should have read groups string accessor" do
-      subject.read_groups_string.should == 'group-6, group-7'
+      expect(subject.read_groups_string).to eq('group-6, group-7')
     end
     it "should have read groups writer" do
       subject.read_groups = ['group-2', 'group-3']
-      subject.rightsMetadata.groups.should == {'group-2' => 'read', 'group-3'=>'read', 'group-8' => 'edit'}
-      subject.rightsMetadata.users.should == {"person1"=>"read","person2"=>"read", 'jcoyne' => 'edit'}
+      expect(subject.rightsMetadata.groups).to eq({'group-2' => 'read', 'group-3'=>'read', 'group-8' => 'edit'})
+      expect(subject.rightsMetadata.users).to eq({"person1"=>"read","person2"=>"read", 'jcoyne' => 'edit'})
     end
 
     it "should have read groups string writer" do
       subject.read_groups_string = 'umg/up.dlt.staff, group-3'
-      subject.rightsMetadata.groups.should == {'umg/up.dlt.staff' => 'read', 'group-3'=>'read', 'group-8' => 'edit'}
-      subject.rightsMetadata.users.should == {"person1"=>"read","person2"=>"read", 'jcoyne' => 'edit'}
+      expect(subject.rightsMetadata.groups).to eq({'umg/up.dlt.staff' => 'read', 'group-3'=>'read', 'group-8' => 'edit'})
+      expect(subject.rightsMetadata.users).to eq({"person1"=>"read","person2"=>"read", 'jcoyne' => 'edit'})
     end
     it "should only revoke eligible groups" do
       subject.set_read_groups(['group-2', 'group-3'], ['group-6'])
       # 'group-7' is not eligible to be revoked
-      subject.rightsMetadata.groups.should == {'group-2' => 'read', 'group-3'=>'read', 'group-7' => 'read', 'group-8' => 'edit'}
-      subject.rightsMetadata.users.should == {"person1"=>"read","person2"=>"read", 'jcoyne' => 'edit'}
+      expect(subject.rightsMetadata.groups).to eq({'group-2' => 'read', 'group-3'=>'read', 'group-7' => 'read', 'group-8' => 'edit'})
+      expect(subject.rightsMetadata.users).to eq({"person1"=>"read","person2"=>"read", 'jcoyne' => 'edit'})
     end
   end
   describe "permissions validation" do
@@ -668,66 +668,66 @@ describe GenericFile do
       end
       it "should work via permissions=()" do
         @file.permissions = {user: {'mjg36' => 'read'}}
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_users)
-        @file.errors[:edit_users].should include('Depositor must have edit access')
+        expect(@file.errors).to include(:edit_users)
+        expect(@file.errors[:edit_users]).to include('Depositor must have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_attributes" do
         # automatically triggers save
-        lambda { @file.update_attributes(read_users_string: 'mjg36') }.should_not raise_error
+        expect { @file.update_attributes(read_users_string: 'mjg36') }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_users)
-        @file.errors[:edit_users].should include('Depositor must have edit access')
+        expect(@file.errors).to include(:edit_users)
+        expect(@file.errors[:edit_users]).to include('Depositor must have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_indexed_attributes" do
         @rightsmd.update_indexed_attributes([:edit_access, :person] => '')
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_users)
-        @file.errors[:edit_users].should include('Depositor must have edit access')
+        expect(@file.errors).to include(:edit_users)
+        expect(@file.errors[:edit_users]).to include('Depositor must have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via permissions()" do
         @rightsmd.permissions({person: "mjg36"}, "read")
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_users)
-        @file.errors[:edit_users].should include('Depositor must have edit access')
+        expect(@file.errors).to include(:edit_users)
+        expect(@file.errors[:edit_users]).to include('Depositor must have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_permissions()" do
         @rightsmd.update_permissions({"person" => {"mjg36" => "read"}})
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_users)
-        @file.errors[:edit_users].should include('Depositor must have edit access')
+        expect(@file.errors).to include(:edit_users)
+        expect(@file.errors[:edit_users]).to include('Depositor must have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via content=()" do
         @rightsmd.content=(@rights_xml)
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_users)
-        @file.errors[:edit_users].should include('Depositor must have edit access')
+        expect(@file.errors).to include(:edit_users)
+        expect(@file.errors[:edit_users]).to include('Depositor must have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via ng_xml=()" do
         @rightsmd.ng_xml=(Nokogiri::XML::Document.parse(@rights_xml))
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_users)
-        @file.errors[:edit_users].should include('Depositor must have edit access')
+        expect(@file.errors).to include(:edit_users)
+        expect(@file.errors[:edit_users]).to include('Depositor must have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_values()" do
         @rightsmd.update_values([:edit_access, :person] => '')
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_users)
-        @file.errors[:edit_users].should include('Depositor must have edit access')
+        expect(@file.errors).to include(:edit_users)
+        expect(@file.errors[:edit_users]).to include('Depositor must have edit access')
         expect(@file).to_not be_valid
       end
     end
@@ -768,66 +768,66 @@ describe GenericFile do
       end
       it "should work via permissions=()" do
         @file.permissions = {group: {'public' => 'edit'}}
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Public cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Public cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_attributes" do
         # automatically triggers save
-        lambda { @file.update_attributes(edit_groups_string: 'public') }.should_not raise_error
+        expect { @file.update_attributes(edit_groups_string: 'public') }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Public cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Public cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_indexed_attributes" do
         @rightsmd.update_indexed_attributes([:edit_access, :group] => 'public')
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Public cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Public cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via permissions()" do
         @rightsmd.permissions({group: "public"}, "edit")
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Public cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Public cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_permissions()" do
         @rightsmd.update_permissions({"group" => {"public" => "edit"}})
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Public cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Public cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via content=()" do
         @rightsmd.content=(@rights_xml)
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Public cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Public cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via ng_xml=()" do
         @rightsmd.ng_xml=(Nokogiri::XML::Document.parse(@rights_xml))
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Public cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Public cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_values()" do
         @rightsmd.update_values([:edit_access, :group] => 'public')
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Public cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Public cannot have edit access')
         expect(@file).to_not be_valid
       end
     end
@@ -868,66 +868,66 @@ describe GenericFile do
       end
       it "should work via permissions=()" do
         @file.permissions = {group: {'registered' => 'edit'}}
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Registered cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Registered cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_attributes" do
         # automatically triggers save
-        lambda { @file.update_attributes(edit_groups_string: 'registered') }.should_not raise_error
+        expect { @file.update_attributes(edit_groups_string: 'registered') }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Registered cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Registered cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_indexed_attributes" do
         @rightsmd.update_indexed_attributes([:edit_access, :group] => 'registered')
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Registered cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Registered cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via permissions()" do
         @rightsmd.permissions({group: "registered"}, "edit")
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Registered cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Registered cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_permissions()" do
         @rightsmd.update_permissions({"group" => {"registered" => "edit"}})
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Registered cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Registered cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via content=()" do
         @rightsmd.content=(@rights_xml)
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Registered cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Registered cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via ng_xml=()" do
         @rightsmd.ng_xml=(Nokogiri::XML::Document.parse(@rights_xml))
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Registered cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Registered cannot have edit access')
         expect(@file).to_not be_valid
       end
       it "should work via update_values()" do
         @rightsmd.update_values([:edit_access, :group] => 'registered')
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to be_new_record
-        @file.errors.should include(:edit_groups)
-        @file.errors[:edit_groups].should include('Registered cannot have edit access')
+        expect(@file.errors).to include(:edit_groups)
+        expect(@file.errors[:edit_groups]).to include('Registered cannot have edit access')
         expect(@file).to_not be_valid
       end
     end
@@ -970,58 +970,58 @@ describe GenericFile do
       end
       it "should work via permissions=()" do
         @file.permissions = {group: {'registered' => 'read'}}
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to_not be_new_record
-        @file.errors.should be_empty
+        expect(@file.errors).to be_empty
         expect(@file).to be_valid
       end
       it "should work via update_attributes" do
         # automatically triggers save
-        lambda { @file.update_attributes(read_groups_string: 'registered') }.should_not raise_error
+        expect { @file.update_attributes(read_groups_string: 'registered') }.not_to raise_error
         expect(@file).to_not be_new_record
-        @file.errors.should be_empty
+        expect(@file.errors).to be_empty
         expect(@file).to be_valid
       end
       it "should work via update_indexed_attributes" do
         @rightsmd.update_indexed_attributes([:read_access, :group] => 'registered')
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to_not be_new_record
-        @file.errors.should be_empty
+        expect(@file.errors).to be_empty
         expect(@file).to be_valid
       end
       it "should work via permissions()" do
         @rightsmd.permissions({group: "registered"}, "read")
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to_not be_new_record
-        @file.errors.should be_empty
+        expect(@file.errors).to be_empty
         expect(@file).to be_valid
       end
       it "should work via update_permissions()" do
         @rightsmd.update_permissions({"group" => {"registered" => "read"}})
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to_not be_new_record
-        @file.errors.should be_empty
+        expect(@file.errors).to be_empty
         expect(@file).to be_valid
       end
       it "should work via content=()" do
         @rightsmd.content=(@rights_xml)
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to_not be_new_record
-        @file.errors.should be_empty
+        expect(@file.errors).to be_empty
         expect(@file).to be_valid
       end
       it "should work via ng_xml=()" do
         @rightsmd.ng_xml=(Nokogiri::XML::Document.parse(@rights_xml))
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to_not be_new_record
-        @file.errors.should be_empty
+        expect(@file.errors).to be_empty
         expect(@file).to be_valid
       end
       it "should work via update_values()" do
         @rightsmd.update_values([:read_access, :group] => 'registered')
-        lambda { @file.save }.should_not raise_error
+        expect { @file.save }.not_to raise_error
         expect(@file).to_not be_new_record
-        @file.errors.should be_empty
+        expect(@file.errors).to be_empty
         expect(@file).to be_valid
       end
     end
@@ -1036,7 +1036,7 @@ describe GenericFile do
         allow(Sufia::GenericFile::Actor).to receive(:virus_check).and_raise(Sufia::VirusFoundError, "A virus was found in #{f.path}: EL CRAPO VIRUS")
         subject.add_file(f, 'content', 'small_file.txt')
         subject.save
-        subject.should_not be_persisted
+        expect(subject).not_to be_persisted
         expect(subject.errors.messages).to eq(base: ["A virus was found in #{f.path}: EL CRAPO VIRUS"])
       end
       it "does not save a new version of a GenericFile" do
@@ -1045,7 +1045,7 @@ describe GenericFile do
         allow(Sufia::GenericFile::Actor).to receive(:virus_check).and_raise(Sufia::VirusFoundError)
         subject.add_file(File.new(fixture_path + '/sufia_generic_stub.txt') , 'content', 'sufia_generic_stub.txt')
         subject.save
-        subject.reload.content.content.should == "small\n"
+        expect(subject.reload.content.content).to eq("small\n")
       end
     end
   end
@@ -1077,12 +1077,12 @@ describe GenericFile do
   describe "public?" do
     context "when read group is set to public" do
       before { subject.read_groups = ['public'] }
-      it { should be_public }
+      it { is_expected.to be_public }
     end
 
     context "when read group is not set to public" do
       before { subject.read_groups = ['foo'] }
-      it { should_not be_public }
+      it { is_expected.not_to be_public }
     end
   end
 end

--- a/spec/models/geo_names_resource_spec.rb
+++ b/spec/models/geo_names_resource_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe GeoNamesResource do
+describe GeoNamesResource, :type => :model do
 
   it "should find locations" do
     hits = GeoNamesResource.find_location("State")
-    hits.should_not be_nil
+    expect(hits).not_to be_nil
   end
 end
 

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe LocalAuthority do
+describe LocalAuthority, :type => :model do
 
   def harvest_nt
     LocalAuthority.harvest_rdf("genres", [fixture_path + '/genreForms.nt'])
@@ -24,22 +24,22 @@ describe LocalAuthority do
   
   it "should harvest an ntriples RDF vocab" do
     harvest_nt
-    LocalAuthority.count.should == 1
-    LocalAuthorityEntry.count.should == 6
+    expect(LocalAuthority.count).to eq(1)
+    expect(LocalAuthorityEntry.count).to eq(6)
   end
   it "should harvest an RDF/XML vocab (w/ an alt predicate)" do
     LocalAuthority.harvest_rdf("langs", [fixture_path + '/lexvo.rdf'],
                                format: 'rdfxml',
                                predicate: RDF::URI("http://www.w3.org/2008/05/skos#prefLabel"))
-    LocalAuthority.count.should == 1
-    LocalAuthorityEntry.count.should == 35
+    expect(LocalAuthority.count).to eq(1)
+    expect(LocalAuthorityEntry.count).to eq(35)
   end
   it "should harvest TSV vocabs" do
     harvest_tsv
-    LocalAuthority.count.should == 1
+    expect(LocalAuthority.count).to eq(1)
     auth = LocalAuthority.where(name: "geo").first
     expect(LocalAuthorityEntry.where(local_authority_id: auth.id).first.uri).to start_with('http://sws.geonames.org/')
-    LocalAuthorityEntry.count.should == 149
+    expect(LocalAuthorityEntry.count).to eq(149)
   end
   
   describe "when vocabs are harvested" do
@@ -53,22 +53,22 @@ describe LocalAuthority do
     end
 
     it "should not have any initial domain terms" do
-      DomainTerm.count.should == 0
+      expect(DomainTerm.count).to eq(0)
     end
 
     it "should not harvest an RDF vocab twice" do
       harvest_nt
-      LocalAuthority.count.should == num_auths
-      LocalAuthorityEntry.count.should == num_entries
+      expect(LocalAuthority.count).to eq(num_auths)
+      expect(LocalAuthorityEntry.count).to eq(num_entries)
     end
     it "should not harvest a TSV vocab twice" do
       harvest_tsv
-      LocalAuthority.count.should == num_auths
-      LocalAuthorityEntry.count.should == num_entries
+      expect(LocalAuthority.count).to eq(num_auths)
+      expect(LocalAuthorityEntry.count).to eq(num_entries)
     end
     it "should register a vocab" do
       LocalAuthority.register_vocabulary(MyTestRdfDatastream, "geographic", "geo")
-      DomainTerm.count.should == 1
+      expect(DomainTerm.count).to eq(1)
     end
     
     describe "when vocabs are registered" do
@@ -79,23 +79,23 @@ describe LocalAuthority do
       end
 
       it "should have some doamin terms" do
-        DomainTerm.count.should == 2
+        expect(DomainTerm.count).to eq(2)
       end
       
       it "should return nil for empty queries" do
-        LocalAuthority.entries_by_term("my_test", "geographic", "").should be_nil
+        expect(LocalAuthority.entries_by_term("my_test", "geographic", "")).to be_nil
       end
       it "should return an empty array for unregistered models" do
-        LocalAuthority.entries_by_term("my_foobar", "geographic", "E").should == []
+        expect(LocalAuthority.entries_by_term("my_foobar", "geographic", "E")).to eq([])
       end
       it "should return an empty array for unregistered terms" do
-        LocalAuthority.entries_by_term("my_test", "foobar", "E").should == []
+        expect(LocalAuthority.entries_by_term("my_test", "foobar", "E")).to eq([])
       end
       it "should return entries by term" do
         term = DomainTerm.where(model: "my_tests", term: "genre").first
         authorities = term.local_authorities.collect(&:id).uniq
         hits = LocalAuthorityEntry.where("local_authority_id in (?)", authorities).where("label like ?", "A%").select("label, uri").limit(25)
-        LocalAuthority.entries_by_term("my_tests", "genre", "A").count.should == 6
+        expect(LocalAuthority.entries_by_term("my_tests", "genre", "A").count).to eq(6)
       end
    
     end

--- a/spec/models/pageview_spec.rb
+++ b/spec/models/pageview_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Sufia::Pageview do
+describe Sufia::Pageview, :type => :model do
   before do
     @pageview = Sufia::Pageview
   end

--- a/spec/models/properties_datastream_spec.rb
+++ b/spec/models/properties_datastream_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe PropertiesDatastream do
+describe PropertiesDatastream, :type => :model do
   describe "import_url" do
     before do
       subject.import_url = 'http://example.com/somefile.txt'

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe ProxyDepositRequest do
-  let (:sender) { FactoryGirl.find_or_create(:jill) }
-  let (:receiver) { FactoryGirl.find_or_create(:archivist) }
-  let (:receiver2) { FactoryGirl.find_or_create(:curator) }
-  let (:file) do
+describe ProxyDepositRequest, type: :model do
+  let(:sender) { FactoryGirl.find_or_create(:jill) }
+  let(:receiver) { FactoryGirl.find_or_create(:archivist) }
+  let(:receiver2) { FactoryGirl.find_or_create(:curator) }
+  let(:file) do
     GenericFile.new.tap do |f|
       f.title = ["Test file"]
       f.apply_depositor_metadata(sender.user_key)
@@ -12,35 +12,40 @@ describe ProxyDepositRequest do
     end
   end
 
+  subject do
+    ProxyDepositRequest.new(pid: file.pid, sending_user: sender,
+      receiving_user: receiver, sender_comment: "please take this")
+  end
+
   after do
     subject.destroy if subject.persisted?
   end
 
-  subject { ProxyDepositRequest.new(pid: file.pid, sending_user: sender, receiving_user: receiver, sender_comment: "please take this") }
+  its(:status) { is_expected.to eq 'pending' }
+  it { is_expected.to be_pending }
+  its(:fulfillment_date) { is_expected.to be_nil }
+  its(:sender_comment) { is_expected.to eq 'please take this' }
 
-  its(:status) {should == 'pending'}
-  it {should be_pending}
-  its(:fulfillment_date) {should be_nil}
-  its(:sender_comment) {should == 'please take this'}
-
-  it "should have a title for the file" do
-    subject.title.should == 'Test file'
+  it "has a title for the file" do
+    expect(subject.title).to eq('Test file')
   end
 
   context "After approval" do
     before do
       subject.transfer!
     end
-    its(:status) {should == 'accepted'}
-    its(:fulfillment_date) {should_not be_nil}
-    its(:deleted_file?) {should eq false}
+
+    its(:status) { is_expected.to eq 'accepted' }
+    its(:fulfillment_date) { is_expected.not_to be_nil }
+    its(:deleted_file?) { is_expected.to be false }
 
     describe "and the file is deleted" do
       before do
         file.destroy
       end
-      its(:title) {should == 'file not found'}
-      its(:deleted_file?) {should eq true}
+
+      its(:title) { is_expected.to eq 'file not found' }
+      its(:deleted_file?) { is_expected.to be true }
     end
   end
 
@@ -48,52 +53,54 @@ describe ProxyDepositRequest do
     before do
       subject.reject!('a comment')
     end
-    its(:status) {should == 'rejected'}
-    its(:fulfillment_date) {should_not be_nil}
-    its(:receiver_comment) {should == 'a comment'}
+
+    its(:status) { is_expected.to eq 'rejected' }
+    its(:fulfillment_date) { is_expected.not_to be_nil }
+    its(:receiver_comment) { is_expected.to eq 'a comment' }
   end
 
   context "After cancel" do
     before do
       subject.cancel!
     end
-    its(:status) {should == 'canceled'}
-    its(:fulfillment_date) {should_not be_nil}
-  end
 
-  describe "transfer" do
-    context "when the transfer_to user isn't found" do
-      it "should be an error" do
+    its(:status) { is_expected.to eq 'canceled' }
+    its(:fulfillment_date) { is_expected.not_to be_nil }
+   end
+
+  describe 'transfer' do
+    context 'when the transfer_to user is not found' do
+      it 'raises an error' do
         subject.transfer_to = 'dave'
-        subject.should_not be_valid
-        subject.errors[:transfer_to].should == ["must be an existing user"]
+        expect(subject).not_to be_valid
+        expect(subject.errors[:transfer_to]).to eq(['must be an existing user'])
       end
     end
 
-    context "when the transfer_to user is found" do
-      it "should create a transfer_request" do
+    context 'when the transfer_to user is found' do
+      it 'creates a transfer_request' do
         subject.transfer_to = receiver.user_key
         subject.save!
         proxy_request = receiver.proxy_deposit_requests.first
-        proxy_request.pid.should == file.pid
-        proxy_request.sending_user.should == sender
+        expect(proxy_request.pid).to eq(file.pid)
+        expect(proxy_request.sending_user).to eq(sender)
       end
     end
 
     context 'when the receiving user is the sending user' do
-      it 'should be an error' do
+      it 'raises an error' do
         subject.transfer_to = sender.user_key
-        subject.should_not be_valid
-        subject.errors[:sending_user].should == ['must specify another user to receive the file']
+        expect(subject).not_to be_valid
+        expect(subject.errors[:sending_user]).to eq(['must specify another user to receive the file'])
       end
     end
 
     context 'when the file is already being transferred' do
-      it 'should be an error' do
+      it 'raises an error' do
         subject.save!
-        subject2 = ProxyDepositRequest.new(pid: file.pid, sending_user: sender, receiving_user: receiver2, sender_comment: "please take this")
-        subject2.should_not be_valid
-        subject2.errors[:open_transfer].should == ['must close open transfer on the file before creating a new one']
+        subject2 = ProxyDepositRequest.new(pid: file.pid, sending_user: sender, receiving_user: receiver2, sender_comment: 'please take this')
+        expect(subject2).not_to be_valid
+        expect(subject2.errors[:open_transfer]).to eq(['must close open transfer on the file before creating a new one'])
       end
     end
   end

--- a/spec/models/single_use_link_spec.rb
+++ b/spec/models/single_use_link_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SingleUseLink do
+describe SingleUseLink, :type => :model do
   before(:all) do
     @file = GenericFile.new
     @file.apply_depositor_metadata('mjg36')
@@ -16,22 +16,22 @@ describe SingleUseLink do
   describe "create" do
      before do
       @now = DateTime.now
-      DateTime.stub(:now).and_return(@now)
+      allow(DateTime).to receive(:now).and_return(@now)
       @hash = "sha2hash#{@now.to_f.to_s}"
-      Digest::SHA2.should_receive(:new).and_return(@hash)
+      expect(Digest::SHA2).to receive(:new).and_return(@hash)
      end
      it "should create show link" do
       su = SingleUseLink.create itemId: file.pid, path: Sufia::Engine.routes.url_helpers.generic_file_path(file.pid)
-      su.downloadKey.should == @hash
-      su.itemId.should == file.pid
-      su.path.should == Sufia::Engine.routes.url_helpers.generic_file_path(file.pid)
+      expect(su.downloadKey).to eq(@hash)
+      expect(su.itemId).to eq(file.pid)
+      expect(su.path).to eq(Sufia::Engine.routes.url_helpers.generic_file_path(file.pid))
       su.delete
      end
      it "should create show download link" do
       su = SingleUseLink.create itemId: file.pid, path: Sufia::Engine.routes.url_helpers.download_path(file.pid)
-      su.downloadKey.should == @hash
-      su.itemId.should == file.pid
-      su.path.should == Sufia::Engine.routes.url_helpers.download_path(file.pid)
+      expect(su.downloadKey).to eq(@hash)
+      expect(su.itemId).to eq(file.pid)
+      expect(su.path).to eq(Sufia::Engine.routes.url_helpers.download_path(file.pid))
       su.delete
      end
   end
@@ -42,15 +42,15 @@ describe SingleUseLink do
        end
        it "should retrieve link" do
           link = SingleUseLink.where(downloadKey: 'sha2hashb').first
-          link.itemId.should == file.pid
+          expect(link.itemId).to eq(file.pid)
        end
        it "should retrieve link with find_by" do
           link = SingleUseLink.find_by_downloadKey('sha2hashb')
-          link.itemId.should == file.pid
+          expect(link.itemId).to eq(file.pid)
        end
        it "should expire link" do
           link = SingleUseLink.where(downloadKey: 'sha2hashb').first
-          link.expired?.should == false
+          expect(link.expired?).to eq(false)
        end
      end
      describe "expired" do
@@ -62,7 +62,7 @@ describe SingleUseLink do
 
        it "should expire link" do
           link = SingleUseLink.where(downloadKey: 'sha2hashb').first
-          link.expired?.should == true
+          expect(link.expired?).to eq(true)
        end
      end
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SolrDocument do
+describe SolrDocument, :type => :model do
 
   describe "date_uploaded" do
     before do

--- a/spec/models/trophy_spec.rb
+++ b/spec/models/trophy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Trophy do
+describe Trophy, :type => :model do
    before(:all) do
     @trophy = Trophy.create(user_id:99,generic_file_id:"99")
   end
@@ -9,17 +9,17 @@ describe Trophy do
   end
 
   it "should have a user" do
-     @trophy.should respond_to(:user_id)
-     @trophy.user_id.should == 99
+     expect(@trophy).to respond_to(:user_id)
+     expect(@trophy.user_id).to eq(99)
   end
   it "should have a file" do
-     @trophy.should respond_to(:generic_file_id)
-     @trophy.generic_file_id.should == "99"
+     expect(@trophy).to respond_to(:generic_file_id)
+     expect(@trophy.generic_file_id).to eq("99")
   end
 
   it "should not allow six trophies" do
      (1..6).each {|n| Trophy.create(user_id:120,generic_file_id:n.to_s)}
-     Trophy.where(user_id:120).count.should == 5
+     expect(Trophy.where(user_id:120).count).to eq(5)
      Trophy.where(user_id:120).map(&:delete)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe User do
+describe User, :type => :model do
   before(:all) do
     @user = FactoryGirl.find_or_create(:jill)
     @another_user = FactoryGirl.find_or_create(:archivist)
@@ -10,31 +10,31 @@ describe User do
     @another_user.delete
   end
   it "should have an email" do
-    @user.user_key.should == "jilluser@example.com"
+    expect(@user.user_key).to eq("jilluser@example.com")
   end
   it "should have activity stream-related methods defined" do
-    @user.should respond_to(:stream)
-    @user.should respond_to(:events)
-    @user.should respond_to(:profile_events)
-    @user.should respond_to(:create_event)
-    @user.should respond_to(:log_event)
-    @user.should respond_to(:log_profile_event)
+    expect(@user).to respond_to(:stream)
+    expect(@user).to respond_to(:events)
+    expect(@user).to respond_to(:profile_events)
+    expect(@user).to respond_to(:create_event)
+    expect(@user).to respond_to(:log_event)
+    expect(@user).to respond_to(:log_profile_event)
   end
   it "should have social attributes" do
-    @user.should respond_to(:twitter_handle)
-    @user.should respond_to(:facebook_handle)
-    @user.should respond_to(:googleplus_handle)
-    @user.should respond_to(:linkedin_handle)
+    expect(@user).to respond_to(:twitter_handle)
+    expect(@user).to respond_to(:facebook_handle)
+    expect(@user).to respond_to(:googleplus_handle)
+    expect(@user).to respond_to(:linkedin_handle)
   end
   it "should redefine to_param to make redis keys more recognizable (and useable within Rails URLs)" do
-    @user.to_param.should == "jilluser@example-dot-com"
+    expect(@user.to_param).to eq("jilluser@example-dot-com")
   end
   it "should have a cancan ability defined" do
-    @user.should respond_to(:can?)
+    expect(@user).to respond_to(:can?)
   end
   it "should not have any followers" do
-    @user.followers_count.should == 0
-    @another_user.follow_count.should == 0
+    expect(@user.followers_count).to eq(0)
+    expect(@another_user.follow_count).to eq(0)
   end
   describe "follow/unfollow" do
     before(:all) do

--- a/spec/routing/featured_works_route_spec.rb
+++ b/spec/routing/featured_works_route_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "file routes" do
+describe "file routes", :type => :routing do
   routes { Sufia::Engine.routes }
   it 'should create a featured_work' do
     expect(post: '/files/1/featured_work').to route_to(controller: 'featured_works', action: 'create', id: '1')

--- a/spec/routing/ownership_transfers_route_spec.rb
+++ b/spec/routing/ownership_transfers_route_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "proxy deposit and transfers routing" do
+describe "proxy deposit and transfers routing", :type => :routing do
   routes { Sufia::Engine.routes }
 
   it "lists transfers" do

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -1,146 +1,146 @@
 require 'spec_helper'
 
-describe 'Routes' do
+describe 'Routes', :type => :routing do
   routes { Sufia::Engine.routes }
 
   describe 'Homepage' do
     it 'should route the root url to the homepage controller' do
-      { get: '/' }.should route_to(controller: 'homepage', action: 'index')
+      expect({ get: '/' }).to route_to(controller: 'homepage', action: 'index')
     end
   end
 
   describe 'GenericFile' do
     it 'should route to citation' do
-      { get: '/files/1/citation' }.should route_to(controller: 'generic_files', action: 'citation', id: '1')
+      expect({ get: '/files/1/citation' }).to route_to(controller: 'generic_files', action: 'citation', id: '1')
     end
 
     it 'should route to stats' do
-      { get: '/files/1/stats' }.should route_to(controller: 'generic_files', action: 'stats', id: '1')
+      expect({ get: '/files/1/stats' }).to route_to(controller: 'generic_files', action: 'stats', id: '1')
     end
 
     it 'should route to audit' do
-      { post: '/files/7/audit' }.should route_to(controller: 'generic_files', action: 'audit', id: '7')
+      expect({ post: '/files/7/audit' }).to route_to(controller: 'generic_files', action: 'audit', id: '7')
     end
 
     it 'should route to create' do
-      { post: '/files' }.should route_to(controller: 'generic_files', action: 'create')
+      expect({ post: '/files' }).to route_to(controller: 'generic_files', action: 'create')
     end
 
     it 'should route to new' do
-      { get: '/files/new' }.should route_to(controller: 'generic_files', action: 'new')
+      expect({ get: '/files/new' }).to route_to(controller: 'generic_files', action: 'new')
     end
 
     it 'should route to edit' do
-      { get: '/files/3/edit' }.should route_to(controller: 'generic_files', action: 'edit', id: '3')
+      expect({ get: '/files/3/edit' }).to route_to(controller: 'generic_files', action: 'edit', id: '3')
     end
 
     it "should route to show" do
-      { get: '/files/4' }.should route_to(controller: 'generic_files', action: 'show', id: '4')
+      expect({ get: '/files/4' }).to route_to(controller: 'generic_files', action: 'show', id: '4')
     end
 
     it "should route to update" do
-      { put: '/files/5' }.should route_to(controller: 'generic_files', action: 'update', id: '5')
+      expect({ put: '/files/5' }).to route_to(controller: 'generic_files', action: 'update', id: '5')
     end
 
     it "should route to destroy" do
-      { delete: '/files/6' }.should route_to(controller: 'generic_files', action: 'destroy', id: '6')
+      expect({ delete: '/files/6' }).to route_to(controller: 'generic_files', action: 'destroy', id: '6')
     end
 
     it "should *not* route to index" do
-      { get: '/files' }.should_not route_to(controller: 'generic_files', action: 'index')
+      expect({ get: '/files' }).not_to route_to(controller: 'generic_files', action: 'index')
     end
   end
 
   describe 'Batch' do
     it "should route to edit" do
-      { get: '/batches/1/edit' }.should route_to(controller: 'batch', action: 'edit', id: '1')
+      expect({ get: '/batches/1/edit' }).to route_to(controller: 'batch', action: 'edit', id: '1')
     end
 
     it "should route to update" do
-      { post: '/batches/2' }.should route_to(controller: 'batch', action: 'update', id: '2')
+      expect({ post: '/batches/2' }).to route_to(controller: 'batch', action: 'update', id: '2')
     end
   end
 
   describe 'Download' do
     it "should route to show" do
-      { get: '/downloads/9' }.should route_to(controller: 'downloads', action: 'show', id: '9')
+      expect({ get: '/downloads/9' }).to route_to(controller: 'downloads', action: 'show', id: '9')
     end
   end
 
   describe 'Dashboard' do
     it "should route to dashboard" do
-      { get: '/dashboard' }.should route_to(controller: 'dashboard', action: 'index')
+      expect({ get: '/dashboard' }).to route_to(controller: 'dashboard', action: 'index')
     end
 
       it "should route to dashboard activity" do
-      { get: '/dashboard/activity' }.should route_to(controller: 'dashboard', action: 'activity')
+      expect({ get: '/dashboard/activity' }).to route_to(controller: 'dashboard', action: 'activity')
     end
 
     it "should route to my files tab" do
-      { get: '/dashboard/files' }.should route_to(controller: 'my/files', action: 'index')
+      expect({ get: '/dashboard/files' }).to route_to(controller: 'my/files', action: 'index')
     end
 
     it "should route to my collections tab" do
-      { get: '/dashboard/collections' }.should route_to(controller: 'my/collections', action: 'index')
+      expect({ get: '/dashboard/collections' }).to route_to(controller: 'my/collections', action: 'index')
     end
 
     it "should route to my highlighted tab" do
-      { get: '/dashboard/highlights' }.should route_to(controller: 'my/highlights', action: 'index')
+      expect({ get: '/dashboard/highlights' }).to route_to(controller: 'my/highlights', action: 'index')
     end
 
     it "should route to my shared tab" do
-      { get: '/dashboard/shares' }.should route_to(controller: 'my/shares', action: 'index')
+      expect({ get: '/dashboard/shares' }).to route_to(controller: 'my/shares', action: 'index')
     end
   end
 
   describe 'Advanced Search' do
     it "should route to search" do
-      { get: '/search' }.should route_to(controller: 'advanced', action: 'index')
+      expect({ get: '/search' }).to route_to(controller: 'advanced', action: 'index')
     end
   end
 
   describe 'Authorities' do
     it "should route to query" do
-      { get: '/authorities/subject/bio' }.should route_to(controller: 'authorities', action: 'query', model: 'subject', term: 'bio')
+      expect({ get: '/authorities/subject/bio' }).to route_to(controller: 'authorities', action: 'query', model: 'subject', term: 'bio')
     end
   end
 
   describe 'Users' do
     it 'should route to user trophies' do
-      { post: '/users/bob135/trophy' }.should route_to(controller: 'users', action: 'toggle_trophy', id: 'bob135')
+      expect({ post: '/users/bob135/trophy' }).to route_to(controller: 'users', action: 'toggle_trophy', id: 'bob135')
     end
     it 'should route to user profile' do
-      { get: '/users/bob135' }.should route_to(controller: 'users', action: 'show', id: 'bob135')
+      expect({ get: '/users/bob135' }).to route_to(controller: 'users', action: 'show', id: 'bob135')
     end
 
     it "should route to edit profile" do
-      { get: '/users/bob135/edit' }.should route_to(controller: 'users', action: 'edit', id: 'bob135')
+      expect({ get: '/users/bob135/edit' }).to route_to(controller: 'users', action: 'edit', id: 'bob135')
     end
 
     it "should route to update profile" do
-      { put: '/users/bob135' }.should route_to(controller: 'users', action: 'update', id: 'bob135')
+      expect({ put: '/users/bob135' }).to route_to(controller: 'users', action: 'update', id: 'bob135')
     end
 
     it "should route to user follow" do
-      { post: '/users/bob135/follow' }.should route_to(controller: 'users', action: 'follow', id: 'bob135')
+      expect({ post: '/users/bob135/follow' }).to route_to(controller: 'users', action: 'follow', id: 'bob135')
     end
 
     it "should route to user unfollow" do
-      { post: '/users/bob135/unfollow' }.should route_to(controller: 'users', action: 'unfollow', id: 'bob135')
+      expect({ post: '/users/bob135/unfollow' }).to route_to(controller: 'users', action: 'unfollow', id: 'bob135')
     end
   end
 
   describe "Directory" do
     it "should route to user" do
-      { get: '/directory/user/xxx666' }.should route_to(controller: 'directory', action: 'user', uid: 'xxx666')
+      expect({ get: '/directory/user/xxx666' }).to route_to(controller: 'directory', action: 'user', uid: 'xxx666')
     end
 
     it "should route to user attribute" do
-      { get: '/directory/user/zzz777/email' }.should route_to(controller: 'directory', action: 'user_attribute', uid: 'zzz777', attribute: 'email')
+      expect({ get: '/directory/user/zzz777/email' }).to route_to(controller: 'directory', action: 'user_attribute', uid: 'zzz777', attribute: 'email')
     end
 
     it "should route to group and allow periods" do
-      { get: '/directory/group/all.staff' }.should route_to(controller: 'directory', action: 'group', cn: 'all.staff')
+      expect({ get: '/directory/group/all.staff' }).to route_to(controller: 'directory', action: 'group', cn: 'all.staff')
     end
   end
 
@@ -161,50 +161,50 @@ describe 'Routes' do
 
   describe "Contact Form" do
     it "should route to new" do
-      { get: '/contact' }.should route_to(controller: 'contact_form', action: 'new')
+      expect({ get: '/contact' }).to route_to(controller: 'contact_form', action: 'new')
     end
 
     it "should route to create" do
-      { post: '/contact' }.should route_to(controller: 'contact_form', action: 'create')
+      expect({ post: '/contact' }).to route_to(controller: 'contact_form', action: 'create')
     end
   end
 
   describe "Dynamically edited pages" do
     it "should route to about" do
-      { get: '/about' }.should route_to(controller: 'pages', action: 'show', id: 'about_page')
+      expect({ get: '/about' }).to route_to(controller: 'pages', action: 'show', id: 'about_page')
     end
   end
 
   describe "Static Pages" do
     it "should route to help" do
-      { get: '/help' }.should route_to(controller: 'static', action: 'help')
+      expect({ get: '/help' }).to route_to(controller: 'static', action: 'help')
     end
 
     it "should route to terms" do
-      { get: '/terms' }.should route_to(controller: 'static', action: 'terms')
+      expect({ get: '/terms' }).to route_to(controller: 'static', action: 'terms')
     end
 
     it "should route to zotero" do
-      { get: '/zotero' }.should route_to(controller: 'static', action: 'zotero')
+      expect({ get: '/zotero' }).to route_to(controller: 'static', action: 'zotero')
     end
 
     it "should route to mendeley" do
-      { get: '/mendeley' }.should route_to(controller: 'static', action: 'mendeley')
+      expect({ get: '/mendeley' }).to route_to(controller: 'static', action: 'mendeley')
     end
 
     it "should route to versions" do
-      { get: '/versions' }.should route_to(controller: 'static', action: 'versions')
+      expect({ get: '/versions' }).to route_to(controller: 'static', action: 'versions')
     end
 
     it "should *not* route a bogus static page" do
-      { get: '/awesome' }.should_not route_to(controller: 'static', action: 'awesome')
+      expect({ get: '/awesome' }).not_to route_to(controller: 'static', action: 'awesome')
     end
   end
 
   describe "Catch-all" do
     it "should route non-existent routes to errors" do
       pending "The default route is turned off in testing, so that errors are raised"
-      { get: '/awesome' }.should route_to(controller: 'errors', action: 'routing', error: 'awesome')
+      expect({ get: '/awesome' }).to route_to(controller: 'errors', action: 'routing', error: 'awesome')
     end
   end
 end

--- a/spec/services/noid_spec.rb
+++ b/spec/services/noid_spec.rb
@@ -6,11 +6,11 @@ describe Sufia::Noid do
 
     context "when the passed in pid doesn't have a namespace" do
       let(:id) { 'abc123' }
-      it { should eq 'sufia:abc123' }
+      it { is_expected.to eq 'sufia:abc123' }
     end
     context "when the passed in pid has a namespace" do
       let(:id) { 'ksl:abc123' }
-      it { should eq 'ksl:abc123' }
+      it { is_expected.to eq 'ksl:abc123' }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,10 @@ module EngineRoutes
 end
 
 RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = File.expand_path("../fixtures", __FILE__)
 

--- a/spec/support/locations.rb
+++ b/spec/support/locations.rb
@@ -2,7 +2,7 @@ module Locations
   def go_to_dashboard
     visit '/dashboard'
     # causes selenium to wait until text appears on the page
-    page.should have_content('My Dashboard')
+    expect(page).to have_content('My Dashboard')
   end
 
   def go_to_dashboard_files
@@ -12,17 +12,17 @@ module Locations
 
   def go_to_dashboard_collections
     visit '/dashboard/collections'
-    page.should have_content('My Collections')
+    expect(page).to have_content('My Collections')
   end
 
   def go_to_dashboard_shares
     visit '/dashboard/shares'
-    page.should have_content('Files Shared with Me')
+    expect(page).to have_content('Files Shared with Me')
   end
 
   def go_to_dashboard_highlights
     visit '/dashboard/highlights'
-    page.should have_content('My Highlights')
+    expect(page).to have_content('My Highlights')
   end
 
   def go_to_user_profile

--- a/spec/views/batch/edit.html.erb_spec.rb
+++ b/spec/views/batch/edit.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'batch/edit.html.erb' do
+describe 'batch/edit.html.erb', :type => :view do
   let( :batch ) {
     stub_model(Batch, id: '123')
   }

--- a/spec/views/batch_edits/check_all_spec.rb
+++ b/spec/views/batch_edits/check_all_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Check All' do
+describe 'Check All', :type => :view do
   before (:all) do
     @document_list = ['a','b','c']
     @batch_size_on_other_page = 0
@@ -11,14 +11,14 @@ describe 'Check All' do
     allow(controller).to receive(:controller_name).and_return('batch_edits')
     controller.prepend_view_path "app/views/batch_edits"
     html = render partial: 'batch_edits/check_all'
-    html.should have_selector("li[data-behavior='batch-edit-select-abc']")
+    expect(html).to have_selector("li[data-behavior='batch-edit-select-abc']")
   end
 
   it 'should render actions for my items' do
     allow(controller).to receive(:controller_name).and_return('my')
     controller.prepend_view_path "app/views/my"
     html = render partial: 'batch_edits/check_all'
-    html.should have_selector("li[data-behavior='batch-edit-select-none']")
-    html.should have_selector("li[data-behavior='batch-edit-select-page']")
+    expect(html).to have_selector("li[data-behavior='batch-edit-select-none']")
+    expect(html).to have_selector("li[data-behavior='batch-edit-select-page']")
   end
 end

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'catalog/index.html.erb' do
+describe 'catalog/index.html.erb', :type => :view do
   before do
     allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
     stub_template 'catalog/_search_sidebar.html.erb' => ''

--- a/spec/views/catalog/sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/catalog/sort_and_per_page.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'catalog/_sort_and_per_page.html.erb' do
+describe 'catalog/_sort_and_per_page.html.erb', :type => :view do
   before do
     allow(controller).to receive(:current_user).and_return(stub_model(User))
     allow_any_instance_of(Ability).to receive(:can?).and_return(true)

--- a/spec/views/collections/_form.html.erb_spec.rb
+++ b/spec/views/collections/_form.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'collections/_form.html.erb' do
+describe 'collections/_form.html.erb', :type => :view do
   describe 'when the collection edit form is rendered' do
     let(:collection) { Collection.new({title: 'the title', description: 'the description',
                                        creator: 'the creator'})}

--- a/spec/views/collections/_show_descriptions.html.erb_spec.rb
+++ b/spec/views/collections/_show_descriptions.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'collections/_show_descriptions.html.erb' do
+describe 'collections/_show_descriptions.html.erb', :type => :view do
   context 'displaying a custom collection' do
     before do
       @collection = mock_model(Collection)

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "dashboard/index.html.erb" do
+describe "dashboard/index.html.erb", :type => :view do
 
   before do
     @user = mock_model(User, name: "Charles Francis Xavier", user_key: "charles")

--- a/spec/views/generic_file/edit.html.erb_spec.rb
+++ b/spec/views/generic_file/edit.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'generic_files/edit.html.erb' do
+describe 'generic_files/edit.html.erb', :type => :view do
   describe 'when the file has two or more resource types' do
     let(:generic_file) {
       content = double('content', versions: [], mimeType: 'application/pdf')

--- a/spec/views/generic_file/show.html.erb_spec.rb
+++ b/spec/views/generic_file/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'generic_files/show.html.erb' do
+describe 'generic_files/show.html.erb', :type => :view do
   let(:depositor) {
     stub_model(User,
       user_key: 'bob',

--- a/spec/views/generic_file/stats.html.erb_spec.rb
+++ b/spec/views/generic_file/stats.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'generic_files/stats.html.erb' do
+describe 'generic_files/stats.html.erb', :type => :view do
   describe 'usage statistics' do
     let(:generic_file) {
       stub_model(GenericFile, noid: '123',

--- a/spec/views/my/facet.html.erb_spec.rb
+++ b/spec/views/my/facet.html.erb_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 # Note: this is a direct copy of the corresponding test in Blacklight
 # with changes for "views/my" instead of "views/catalog"
 
-describe "my/facet.html.erb" do
+describe "my/facet.html.erb", :type => :view do
   let(:display_facet) { double }
   let(:blacklight_config) { Blacklight::Configuration.new }
   before do
     blacklight_config.add_facet_field "xyz", label: "Facet title"
-    view.stub(:blacklight_config).and_return(blacklight_config)
+    allow(view).to receive(:blacklight_config).and_return(blacklight_config)
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
     stub_template "my/_facet_pagination.html.erb" => "pagination"
     assign :facet, blacklight_config.facet_fields["xyz"]

--- a/spec/views/users/_follower_modal.html.erb_spec.rb
+++ b/spec/views/users/_follower_modal.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'users/_follower_modal.html.erb' do
+describe 'users/_follower_modal.html.erb', :type => :view do
   let(:user) { FactoryGirl.create(:user, display_name: "Frank") }
 
   before do

--- a/spec/views/users/_following_modal.html.erb_spec.rb
+++ b/spec/views/users/_following_modal.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'users/_following_modal.html.erb' do
+describe 'users/_following_modal.html.erb', :type => :view do
   let(:user) { FactoryGirl.create(:user, display_name: "Frank") }
 
   before do

--- a/spec/views/users/_notify_number.html.erb_spec.rb
+++ b/spec/views/users/_notify_number.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'users/_notify_number.html.erb' do
+describe 'users/_notify_number.html.erb', :type => :view do
 
   it "should draw user list" do
     assign :notify_number, 8

--- a/spec/views/users/_user_util_links.html.erb_spec.rb
+++ b/spec/views/users/_user_util_links.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '/_user_util_links.html.erb' do
+describe '/_user_util_links.html.erb', :type => :view do
 
   let(:join_date) { 5.days.ago }
   before do

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe 'users/index.html.erb' do
+describe 'users/index.html.erb', :type => :view do
 
   let(:join_date) { 5.days.ago }
   before do
     users = []
     (1..25).each  {|i| users << stub_model(User, name: "name#{i}", user_key: "user#{i}", created_at: join_date)}
-    User.stub_chain(:all).and_return(users)
+    allow(User).to receive_message_chain(:all).and_return(users)
     relation = User.all
     allow(relation).to receive(:limit_value).and_return(10)
     allow(relation).to receive(:current_page).and_return(1)

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'users/show.html.erb' do
+describe 'users/show.html.erb', :type => :view do
 
   let(:join_date) { 5.days.ago }
   before do
@@ -26,7 +26,7 @@ describe 'users/show.html.erb' do
 
   it "should have the vitals" do
     render
-    rendered.should match /Joined on #{join_date.strftime("%b %d, %Y")}/
+    expect(rendered).to match /Joined on #{join_date.strftime("%b %d, %Y")}/
   end
 
   context "with trophy" do


### PR DESCRIPTION
This conversion is done by Transpec 2.3.7 with the following command:
    transpec
- 626 conversions
  from: obj.should
    to: expect(obj).to
- 306 conversions
  from: == expected
    to: eq(expected)
- 53 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 36 conversions
  from: lambda { }.should_not
    to: expect { }.not_to
- 31 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 30 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 26 conversions
  from: describe 'some controller' { }
    to: describe 'some controller', :type => :controller { }
- 26 conversions
  from: it { should ... }
    to: it { is_expected.to ... }
- 25 conversions
  from: describe 'some model' { }
    to: describe 'some model', :type => :model { }
- 21 conversions
  from: it { should_not ... }
    to: it { is_expected.not_to ... }
- 20 conversions
  from: Klass.any_instance.stub(:message)
    to: allow_any_instance_of(Klass).to receive(:message)
- 17 conversions
  from: describe 'some view' { }
    to: describe 'some view', :type => :view { }
- 16 conversions
  from: its(:attr) { }
    to: describe '#attr' do subject { super().attr }; it { } end
- 14 conversions
  from: describe 'some feature' { }
    to: describe 'some feature', :type => :feature { }
- 7 conversions
  from: describe 'some helper' { }
    to: describe 'some helper', :type => :helper { }
- 7 conversions
  from: lambda { }.should
    to: expect { }.to
- 7 conversions
  from: obj.stub(:message => value)
    to: allow(obj).to receive_messages(:message => value)
- 6 conversions
  from: Klass.any_instance.should_receive(:message)
    to: expect_any_instance_of(Klass).to receive(:message)
- 3 conversions
  from: describe 'some routing' { }
    to: describe 'some routing', :type => :routing { }
- 2 conversions
  from: obj.unstub(:message)
    to: allow(obj).to receive(:message).and_call_original
- 1 conversion
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)
- 1 conversion
  from: obj.stub_chain(:message1, :message2)
    to: allow(obj).to receive_message_chain(:message1, :message2)

For more details: https://github.com/yujinakayama/transpec#supported-conversions
