### PR TITLE
Fixes bug in BatchUpdateJob::update_file by changing how params used to ...

### DIFF
--- a/spec/controllers/batch_controller_spec.rb
+++ b/spec/controllers/batch_controller_spec.rb
@@ -33,10 +33,9 @@ describe BatchController do
       end
 
       it "should set the groups" do
-        post :update, id: batch, "generic_file"=>{"permissions"=>{"group"=>{"public"=>"1", "registered"=>"2"}}}
+        post :update, id: batch, "generic_file"=>{"permissions_attributes"=>[{"type" => "group", "name" => "public", "access" => "read"}]}
         file.reload
-        expect(file.read_groups).to be_empty
-        expect(file.edit_groups).to be_empty
+        expect(file.read_groups).to include "public"
         expect(response).to redirect_to routes.url_helpers.dashboard_files_path
       end
 

--- a/sufia-models/app/jobs/batch_update_job.rb
+++ b/sufia-models/app/jobs/batch_update_job.rb
@@ -42,7 +42,9 @@ class BatchUpdateJob
       return
     end
     gf.title = [title[gf.id]] if title[gf.id]
-    gf.attributes=file_attributes
+    gf.permissions_attributes = file_attributes['permissions_attributes'] if file_attributes['permissions_attributes']
+    gf.read_users_string = file_attributes['read_users_string'] if file_attributes['read_users_string']
+    gf.read_groups_string = file_attributes['read_groups_string'] if file_attributes['read_groups_string']
     gf.visibility= visibility
 
     save_tries = 0


### PR DESCRIPTION
...set permissions, conforming to the new way of using #permissions_attributes= instad of #attributes=
