### PR TITLE
Change the way we log depositor change events

### DIFF
--- a/spec/jobs/event_jobs_spec.rb
+++ b/spec/jobs/event_jobs_spec.rb
@@ -86,6 +86,22 @@ describe 'event jobs' do
     expect(@gf.events.length).to eq(1)
     expect(@gf.events.first).to eq(event)
   end
+  it "logs content depositor change events" do
+    # ContentDepositorChange should log the event to the proxy depositor's profile, the depositor's dashboard, followers' dashboards, and the GF
+    @third_user.follow(@another_user)
+    allow_any_instance_of(User).to receive(:can?).and_return(true)
+    allow(Time).to receive(:now).at_least(:once).and_return(1)
+    event = {action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has transferred <a href="/files/123">Hamlet</a> to user <a href="/users/archivist1@example-dot-com">archivist1@example.com</a>', timestamp: '1' }
+    ContentDepositorChangeEventJob.new('test:123', @another_user.user_key).run
+    expect(@user.profile_events.length).to eq(1)
+    expect(@user.profile_events.first).to eq(event)
+    expect(@another_user.events.length).to eq(1)
+    expect(@another_user.events.first).to eq(event)
+    expect(@third_user.events.length).to eq(1)
+    expect(@third_user.events.first).to eq(event)
+    expect(@gf.events.length).to eq(1)
+    expect(@gf.events.first).to eq(event)
+  end
   it "should log content update events" do
     # ContentUpdate should log the event to the depositor's profile, followers' dashboards, and the GF
     @another_user.follow(@user)
@@ -188,4 +204,3 @@ describe 'event jobs' do
     expect(@gf.events.first).to eq(event)
   end
 end
-


### PR DESCRIPTION
We had a ticket in ScholarSphere to make this change many months ago but it was never prioritized. Now that proxies and transfers have moved into Sufia, I thought it might be a good time to put this into place. In short, we want depositor change events to be logged publicly for the proxy depositor (who initiated the change) but logged to the dashboard of the depositor as a sort of notification, and we log the event only to the followers of the depositor, who now 'owns' the deposit, rather than the proxy depositor's followers
