### PR TITLE
README: update Sufia version in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you have questions or need help, please email [the Hydra community developmen
 ### Add gems to Gemfile
 
 ```
-gem 'sufia', '~> 4.0.0'
+gem 'sufia', '~> 4.2.0'
 gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'  # required to handle pagination properly in dashboard. See https://github.com/amatsuda/kaminari/pull/322
 ```
 


### PR DESCRIPTION
I noticed the README is still pointing at Sufia 4.0.0; figured this should point at the latest release. Spent a little time scratching my head when I ran into the asset precompilation issue that was fixed in 4.0.1, until I realized I'd installed an outdated version.
