### PR TITLE
AuditJob and ChecksumAuditLog updated to account for changes in Fedora 4.

### DIFF
--- a/spec/jobs/audit_job_spec.rb
+++ b/spec/jobs/audit_job_spec.rb
@@ -5,9 +5,35 @@ describe AuditJob do
     @user = FactoryGirl.find_or_create(:jill)
     @inbox = @user.mailbox.inbox
     @file = GenericFile.new
+    @file.add_file(File.open(fixture_path + '/world.png'), 'content', 'world.png')
     @file.apply_depositor_metadata(@user)
     @file.save
   end
+
+  describe "audit on content" do
+    it "should pass" do
+      content_uri = @file.content.uri
+      job = AuditJob.new(@file.id, 'content', content_uri)
+      expect(job.run).to eq(true)
+    end
+  end
+
+  describe "audit on a version of the content" do
+    it "should pass" do
+      version_uri = @file.content.versions[0]
+      job = AuditJob.new(@file.id, 'content', version_uri)
+      expect(job.run).to eq(true)
+    end
+  end
+
+  describe "audit on an invalid version of the content" do
+    it "should fail" do
+      bad_version_uri = @file.content.versions[0] + "bogus"
+      job = AuditJob.new(@file.id, 'content', bad_version_uri)
+      expect(job.run).to eq(false)
+    end
+  end
+
   describe "passing audit" do
     it "should not send passing mail" do
       skip "skipping audit for now"

--- a/sufia-models/app/jobs/audit_job.rb
+++ b/sufia-models/app/jobs/audit_job.rb
@@ -6,44 +6,41 @@ class AuditJob < ActiveFedoraPidBasedJob
   PASS = 'Passing Audit Run'
   FAIL = 'Failing Audit Run'
 
-  attr_accessor :pid, :datastream_id, :version_id
+  attr_accessor :uri, :pid, :path
 
-  def initialize(pid, datastream_id, version_id)
-    super(pid)
-    self.datastream_id = datastream_id
-    self.version_id = version_id
+  # URI of the resource to audit.
+  # This URI could include the actual resource (e.g. content) and the version to audit:
+  #     http://localhost:8983/fedora/rest/test/a/b/c/abcxyz/content/fcr:versions/version1
+  # but it could also just be:
+  #     http://localhost:8983/fedora/rest/test/a/b/c/abcxyz/content
+  def initialize(id, path, uri)
+    super(uri)
+    self.pid = id
+    self.path = path
+    self.uri = uri
   end
 
   def run
-    if generic_file
-      datastream = generic_file.datastreams[datastream_id]
-      if datastream
-        version =  datastream.versions.select { |v| v.versionID == version_id}.first
-        log = run_audit(version)
-
-        # look up the user for sending the message to
-        login = generic_file.depositor
-        if login
-          user = User.find_by_user_key(login)
-          ActiveFedora::Base.logger.warn "User '#{login}' not found" unless user
-          job_user = User.audituser()
-          # send the user a message about the failing audit
-          unless (log.pass == 1)
-            message = "The audit run at #{log.created_at} for #{log.pid}:#{log.dsid}:#{log.version} was #{log.pass == 1 ? 'passing' : 'failing'}."
-            subject = (log.pass == 1 ? PASS : FAIL)
-            job_user.send_message(user, message, subject)
-          end 
-        end
-      else
-        ActiveFedora::Base.logger.warn "No datastream for audit!!!!! pid: #{pid} dsid: #{datastream_id}"
-      end
-    else
-      ActiveFedora::Base.logger.warn "No generic file for data stream audit!!!!! pid: #{pid} dsid: #{datastream_id}"
+    fixity_ok = false
+    log = run_audit(pid, path, uri)
+    fixity_ok = (log.pass == 1)
+    unless fixity_ok
+      # send the user a message about the failing audit
+      login = generic_file.depositor
+      user = User.find_by_user_key(login)
+      ActiveFedora::Base.logger.warn "User '#{login}' not found" unless user
+      job_user = User.audituser()
+      file_title = generic_file.title.first
+      message = "The audit run at #{log.created_at} for #{file_title} (#{uri}) failed."
+      subject = FAIL
+      job_user.send_message(user, message, subject)
     end
+    fixity_ok
   end
 
   private
-  def run_audit(version)
-    object.class.run_audit(version)
+  def run_audit(id, path, uri)
+    object.class.run_audit(id, path, uri)
   end
+
 end

--- a/sufia-models/app/models/checksum_audit_log.rb
+++ b/sufia-models/app/models/checksum_audit_log.rb
@@ -1,16 +1,15 @@
 class ChecksumAuditLog < ActiveRecord::Base
 
-  def ChecksumAuditLog.get_audit_log(version)
-    ChecksumAuditLog.find_or_create_by_pid_and_dsid_and_version(pid: version.pid,
-                                                                dsid: version.dsid,
-                                                                version: version.versionID)
+  def ChecksumAuditLog.get_audit_log(id, path, version_uri)
+    ChecksumAuditLog.find_or_create_by(pid: id, dsid: path, version: version_uri)
   end
 
-  def ChecksumAuditLog.prune_history(version)
-    ## Check to see if there are previous passing logs that we can delete
-    # we want to keep the first passing event after a failure, the most current passing event, and all failures so that this table doesn't grow too large
+  def ChecksumAuditLog.prune_history(id, path)
+    # Check to see if there are previous passing logs that we can delete
+    # we want to keep the first passing event after a failure, the most current passing event, 
+    # and all failures so that this table doesn't grow too large
     # Simple way (a little naieve): if the last 2 were passing, delete the first one
-    logs = GenericFile.load_instance_from_solr(version.pid).logs(version.dsid)
+    logs = GenericFile.load_instance_from_solr(id).logs(path)
     list = logs.limit(2)
     if list.size > 1 && (list[0].pass == 1) && (list[1].pass == 1)
       list[0].destroy


### PR DESCRIPTION
 Audit_job and checksum_audit_logs updated to account for changes in Fedora 4.

In ChecksumAuditLog we are saving the full URI of the resource that was audited. This URI could be http://xyz/content or http://xyz/content/fcr:versions/versionX. The MySQL table checksum_audit_logs remains unchanged. Later on we could update the table with a new column name if we want to.

AuditJob was also refactored to receive the URI of the resource to audit. AuditJob does not searches for the datastream to audit since the URI gives a full path to it (as indicated in the previous paragraph.)
