### PR TITLE
Versions returns uris and not labels

### DIFF
--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -449,7 +449,7 @@ describe GenericFilesController do
               expect(restored_file.content.mime_type).to eql(file1_type)
               expect(restored_file.content.original_name).to eql(file1)
               expect(restored_file.content.versions.count).to eq 2
-              expect(restored_file.content.versions[1]).to eql(latest_version)
+              expect(restored_file.content.versions[1]).to end_with(latest_version)
               expect(restored_file.content.version_committer(version1)).to eql(first_user.user_key)
             end
           end

--- a/spec/models/file_content_datastream_spec.rb
+++ b/spec/models/file_content_datastream_spec.rb
@@ -16,13 +16,13 @@ describe FileContentDatastream, :type => :model do
       expect(@file.content.versions).to be_kind_of(Array)
       expect(@file.content.versions.count).to eql(1)
     end
-    it "should return a label for the version" do
-      expect(@file.content.versions.first.to_s).to eql(version1)
+    it "should return a uri for the version" do
+      expect(@file.content.versions.first).to end_with(version1)
     end
     context "with the latest version" do
       let(:latest_version) { @file.content.versions.last }
       it "should return the latest version" do
-        expect(@file.content.latest_version.to_s).to eql(version1)
+        expect(@file.content.latest_version).to eql(version1)
       end
     end
     describe "add a version" do

--- a/sufia-models/lib/sufia/models/file_content/versions.rb
+++ b/sufia-models/lib/sufia/models/file_content/versions.rb
@@ -7,12 +7,16 @@ module Sufia
         has_many_versions
       end
 
+      def version_label uri
+        uri.split("/").last
+      end
+
       def latest_version
-        versions.last
+        version_label(versions.last) unless versions.empty?
       end
 
       def version_committer(version)
-        vc = VersionCommitter.where(version_id: version.to_s)
+        vc = VersionCommitter.where(version_id: version_label(version))
         return vc.empty? ? nil : vc.first.committer_login
       end
 


### PR DESCRIPTION
Changes to ActiveFedora's versions method requires interpreting labels from the uri that corresponds to the version.
