### PR TITLE
Adding select2 name look up to permissions form for GenericFile and Batch

### DIFF
--- a/app/assets/javascripts/sufia/permissions.js
+++ b/app/assets/javascripts/sufia/permissions.js
@@ -9,33 +9,9 @@
    */
 
 Blacklight.onLoad(function() {
-  // input for uids -  attach function to verify uid
-  $('#new_user_name_skel').on('blur', function() {
-      // clear out any existing messages
-      $('#directory_user_result').html('');
-      var un = $('#new_user_name_skel').val();
-      var perm = $('#new_user_permission_skel').val();
-      if ( $.trim(un).length == 0 ) {
-        return;
-      }
-      $.ajax( {
-        url: "/directory/user/" + un,
-        success: function( data ) {
-          if (data != null) {
-            if (!data.length) {
-              $('#directory_user_result').html('User id ('+un+ ') does not exist.');
-              $('#new_user_name_skel').select();
-              $('#new_user_permission_skel').val('none');
-              return;
-            }
-            else {
-              $('#new_user_permission_skel').focus();
-            }
-          }
-        }
-      });
 
-  });
+  // Attach the user search select2 box to the permission form
+  $("#new_user_name_skel").userSearch();
 
   // add button for new user
   $('#add_new_user_skel').on('click', function() {

--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -164,6 +164,13 @@ module Sufia
       end
     end
 
+    def user_display_name_and_key(user_key)
+      user = ::User.find_by_user_key(user_key)
+      return user_key if user.nil?
+
+      user.respond_to?(:name) ? "#{user.name} (#{user_key})" : user_key
+    end
+
     private
 
     def search_action_for_dashboard

--- a/app/views/generic_files/_permission_form.html.erb
+++ b/app/views/generic_files/_permission_form.html.erb
@@ -53,12 +53,10 @@
   <div class="form-group">
     <div id="new-user">
       <p class="col-sm-12">Enter <%=t('sufia.account_label') %> (one at a time)</p>
-      <p class="sr-only">Use the add button to give access to one <%=t('sufia.account_label') %> at a time (it will be added to the list below).</p>
+      <p class="sr-only">Use the add button to give access to one <%=t('sufia.account_label') %> at a time (it will be added to the list below).  Select the user, by name or <%=t('sufia.account_label') %>. Then select the access level you wish to grant and click on Add this <%= t('sufia.account_label') %> to complete adding the permission.</p>
       <div class="col-sm-5">
-        <div class="input-group">
-          <label for="new_user_name_skel" class="sr-only"><%= t('sufia.account_label') %> (without the <%= t('sufia.directory.suffix') %> part)</label>
-          <%= text_field_tag 'new_user_name_skel', nil, class: "form-control" %><span class="input-group-addon"><%=t('sufia.directory.suffix') %></span>
-        </div>
+        <label for="new_user_name_skel" class="sr-only"><%= t('sufia.account_label') %> (without the <%= t('sufia.directory.suffix') %> part)</label>
+        <%= text_field_tag 'new_user_name_skel', nil %>
       </div>
       <div class="col-sm-4">
         <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
@@ -116,7 +114,7 @@
     <% next if permission[:name].downcase == 'registered' %>
     <% next if permission[:name].downcase == depositor %>
     <tr>
-      <td><%= label_tag "generic_file[permissions][#{permission[:type]}][#{permission[:name]}]", permission[:name], class: "control-label" %></td>
+      <td><%= label_tag "generic_file[permissions][#{permission[:type]}][#{permission[:name]}]", user_display_name_and_key(permission[:name]), class: "control-label" %></td>
       <td>
         <div class="col-sm-8">
           <%= select_tag "generic_file[permissions][#{permission[:type]}][#{permission[:name]}]", options_for_select(Sufia.config.permission_levels, permission[:access]), class: 'form-control select_perm' %>

--- a/spec/views/generic_file/_permission_form.html.erb_spec.rb
+++ b/spec/views/generic_file/_permission_form.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'generic_files/_permission_form.html.erb', :type => :view do
+  let(:gf) {
+    stub_model(GenericFile, noid: '123',
+        depositor: 'bob',
+        resource_type: ['Dataset'])
+  }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+  end
+
+  it "should draw the permissions form without error" do
+    render partial: 'generic_files/permission_form.html.erb',  locals: {gf: gf}
+    expect(rendered).to have_css("input#new_user_name_skel")
+  end
+
+end


### PR DESCRIPTION
This allows a user to look up the permission by name or by user_key (email), and additionally shows the user name and user_key once the permission is added.
