### PR TITLE
Moves GenericFile::Content behaviors out of GenericFile::Metadata

### DIFF
--- a/sufia-models/app/models/concerns/sufia/generic_file.rb
+++ b/sufia-models/app/models/concerns/sufia/generic_file.rb
@@ -15,6 +15,7 @@ module Sufia
     include Sufia::GenericFile::Trophies
     include Sufia::GenericFile::Featured
     include Sufia::GenericFile::Metadata
+    include Sufia::GenericFile::Content
     include Sufia::GenericFile::Versions
     include Sufia::GenericFile::VirusCheck
     include Sufia::GenericFile::FullTextIndexing

--- a/sufia-models/app/models/concerns/sufia/generic_file/content.rb
+++ b/sufia-models/app/models/concerns/sufia/generic_file/content.rb
@@ -1,0 +1,13 @@
+module Sufia
+  module GenericFile
+    module Content
+      extend ActiveSupport::Concern
+
+      included do
+        contains "content", class_name: 'FileContentDatastream'
+        contains "thumbnail"
+      end
+
+    end
+  end
+end

--- a/sufia-models/app/models/concerns/sufia/generic_file/metadata.rb
+++ b/sufia-models/app/models/concerns/sufia/generic_file/metadata.rb
@@ -4,8 +4,6 @@ module Sufia
       extend ActiveSupport::Concern
 
       included do
-        contains "content", class_name: 'FileContentDatastream'
-        contains "thumbnail"
 
         property :label, predicate: ::RDF::DC.title, multiple: false
 


### PR DESCRIPTION
Moves GenericFile::Content behaviors out of GenericFile::Metadata and into a separate module
