### PR TITLE
Ensure we return only GenericFile objects

### DIFF
--- a/app/controllers/concerns/sufia/homepage_controller.rb
+++ b/app/controllers/concerns/sufia/homepage_controller.rb
@@ -35,7 +35,7 @@ module Sufia::HomepageController
   # @param user_parameters the current user-subitted parameters
   def only_generic_files(solr_parameters, user_parameters)
     solr_parameters[:fq] ||= []
-    solr_parameters[:fq] << "#{Solrizer.solr_name("has_model", :symbol)}:\"info:fedora/afmodel:GenericFile\""
+    solr_parameters[:fq] << "#{Solrizer.solr_name("has_model", :symbol)}:\"GenericFile\""
   end
 
 end

--- a/spec/controllers/homepage_controller_spec.rb
+++ b/spec/controllers/homepage_controller_spec.rb
@@ -4,8 +4,7 @@ describe HomepageController, :type => :controller do
   routes { Rails.application.class.routes }
 
   describe "#index" do
-    before :all do
-      GenericFile.delete_all
+    before do
       @gf1 = GenericFile.new(title:['Test Document PDF'], filename:['test.pdf'], tag:['rocks'], read_groups:['public'])
       @gf1.apply_depositor_metadata('mjg36')
       @gf1.save
@@ -42,7 +41,14 @@ describe HomepageController, :type => :controller do
       expect(response).to be_success
       titles = assigns(:recent_documents).map {|d| d['title_tesim'][0]}
       expect(titles).to_not include('Test Private Document')
-    end    
+    end
+
+    it "should include only GenericFile objects in recent documents" do
+      get :index
+      assigns(:recent_documents).each do |doc|
+        expect(doc[Solrizer.solr_name("has_model", :symbol)]).to eql ["GenericFile"]
+      end
+    end 
 
     context "with a document not created this second" do
       before do
@@ -65,6 +71,8 @@ describe HomepageController, :type => :controller do
         create_times = assigns(:recent_documents).map{|d| d['system_create_dtsi']}
         expect(create_times).to eq create_times.sort.reverse
       end
+
+
     end
 
     context "with featured works" do


### PR DESCRIPTION
The model name in Solr for GenericFile changed in Fedora4, but wasn’t previously tested.
