### PR TITLE
Styles count for views and downloads, refs #9672

### DIFF
--- a/app/assets/stylesheets/sufia/_dashboard.scss
+++ b/app/assets/stylesheets/sufia/_dashboard.scss
@@ -18,6 +18,16 @@
     background-color: $badge-background-color;
     color: $badge-font-color;
   }
+  .badge-optional {
+    background-color: $badge-optional-background-color;
+    border-radius: 2px;
+    color: $badge-font-color;
+    padding: 0 .25em;
+  }
+  .views-downloads-dashboard {
+    list-style-type: none;
+    padding-left: 0;
+  }
   .panel-default > .panel-heading {
     background-color: $panel-background-color;
   }

--- a/app/assets/stylesheets/sufia/_settings.scss
+++ b/app/assets/stylesheets/sufia/_settings.scss
@@ -23,6 +23,7 @@ $teal: #2CAEB7;
 $vermilion: #F30;
 
 $badge-background-color: $highlight-yellow;
+$badge-optional-background-color: $gray-medium;
 $badge-font-color: $classic-white;
 $content-wrapper-background-color: $cream-light;
 $dashboard-background-color: $classic-white;

--- a/app/views/dashboard/_index_partials/_stats.html.erb
+++ b/app/views/dashboard/_index_partials/_stats.html.erb
@@ -8,9 +8,9 @@
 
       <td>
         <%= t("sufia.dashboard.stats.files") %>
-        <ul>
-          <li> <%= pluralize(@user.total_file_views, t("sufia.dashboard.stats.file_views")) %> </li>
-          <li> <%= pluralize(@user.total_file_downloads, t("sufia.dashboard.stats.file_downloads")) %> </li>
+        <ul class="views-downloads-dashboard">
+          <li><span class="badge-optional"><%= @user.total_file_views %></span> <%= t("sufia.dashboard.stats.file_views").pluralize(@user.total_file_views) %></li>
+          <li><span class="badge-optional"><%= @user.total_file_downloads %></span> <%= t("sufia.dashboard.stats.file_downloads").pluralize(@user.total_file_downloads) %></li>
         </ul>
       </td>
     </tr>

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -64,8 +64,8 @@ describe "dashboard/index.html.erb", :type => :view do
       expect(@sidebar).to include '<span class="badge">2</span>'
       expect(@sidebar).to include '<span class="badge">15</span>'
       expect(@sidebar).to include '<span class="badge">3</span>'
-      expect(@sidebar).to include '1 View'
-      expect(@sidebar).to include '3 Downloads'
+      expect(@sidebar).to include '<span class="badge-optional">1</span> View'
+      expect(@sidebar).to include '<span class="badge-optional">3</span> Downloads'
     end
 
     it "should show the statistics before the profile" do


### PR DESCRIPTION
Getting capybara error for something that my work didn't change.

 1) Browse files when not logged in should allow you to click next
     Failure/Error: expect(page).to have_css "a.btn-link", text:"« Previous", wait: Capybara.default_wait_time*4
       expected to find css "a.btn-link" with text "« Previous" but there were no matches. Also found "Next »", "Next »", which matched the selector but not all filters.
     # ./spec/features/browse_files_spec.rb:52:in `block (3 levels) in <top (required)>'
