### PR TITLE
User stats should have its own generator.

### DIFF
--- a/sufia-models/lib/generators/sufia/models/cached_stats_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/cached_stats_generator.rb
@@ -2,12 +2,10 @@ require_relative 'abstract_migration_generator'
 
 class Sufia::Models::CachedStatsGenerator < Sufia::Models::AbstractMigrationGenerator
   source_root File.expand_path('../templates', __FILE__)
-  argument :model_name, type: :string , default: "user"
 
   desc """
 This generator adds the ability to cache usage stats to your application:
  1. Creates several database migrations if they do not exist in /db/migrate
- 2. Adds stats methods to the user model
        """
 
   def banner
@@ -18,22 +16,9 @@ This generator adds the ability to cache usage stats to your application:
   def copy_migrations
     [
       'create_file_view_stats.rb',
-      'create_file_download_stats.rb',
-      'create_user_stats.rb'
+      'create_file_download_stats.rb'
     ].each do |file|
       better_migration_template file
-    end
-  end
-
-  def add_stats_mixin_to_user_model
-    file_path = "app/models/#{model_name.underscore}.rb"
-
-    if File.exists?(file_path)
-      inject_into_file file_path, after: /include Sufia\:\:User.*$/ do
-        "\n include Sufia::UserUsageStats"
-      end
-    else
-      puts "     \e[31mFailure\e[0m  Sufia requires a user object. This generators assumes that the model is defined in the file #{file_path}, which does not exist.  If you used a different name, please re-run the generator and provide that name as an argument. Such as \b  rails -g sufia client"
     end
   end
 end

--- a/sufia-models/lib/generators/sufia/models/install_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/install_generator.rb
@@ -15,6 +15,7 @@ This generator makes the following changes to your application:
  8. Runs proxies generator
  9. Runs cached stats generator
 10. Runs ORCID field generator
+11. Runs user stats generator
        """
   def banner
     say_status("warning", "GENERATING SUFIA MODELS", :yellow)
@@ -96,5 +97,10 @@ This generator makes the following changes to your application:
   # Adds orcid field to user model
   def orcid_field
     generate 'sufia:models:orcid_field'
+  end
+
+  # Adds user stats-related migration & methods
+  def user_stats
+    generate 'sufia:models:user_stats'
   end
 end

--- a/sufia-models/lib/generators/sufia/models/user_stats_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/user_stats_generator.rb
@@ -1,0 +1,31 @@
+require_relative 'abstract_migration_generator'
+
+class Sufia::Models::UserStatsGenerator < Sufia::Models::AbstractMigrationGenerator
+  source_root File.expand_path('../templates', __FILE__)
+  argument :model_name, type: :string , default: "user"
+
+  desc """
+This generator adds usage stats methods to the user model in your application:
+       """
+
+  def banner
+    say_status("warning", "ADDING USER STATS-RELATED ABILITIES TO SUFIA MODELS", :yellow)
+  end
+
+  # Setup the database migrations
+  def copy_migrations
+    better_migration_template 'create_user_stats.rb'
+  end
+
+  def add_stats_mixin_to_user_model
+    file_path = "app/models/#{model_name.underscore}.rb"
+
+    if File.exists?(file_path)
+      inject_into_file file_path, after: /include Sufia\:\:User.*$/ do
+        "\n  include Sufia::UserUsageStats"
+      end
+    else
+      puts "     \e[31mFailure\e[0m  Sufia requires a user object. This generator assumes that the model is defined in the file #{file_path}, which does not exist.  If you used a different name, please re-run the generator and provide that name as an argument. Such as \b  rails g sufia:models:user_stats client"
+    end
+  end
+end


### PR DESCRIPTION
The 4.2.0 release already uses the cached_stats generator, so we should not add to it lest we break/complicate the upgrade path.  This takes the modifications to that generator and breaks them out into their own generator, which will enable adopters to upgrade cleanly from 4.2 to 4.3.
