### PR TITLE
Adds production block to generated redis config.

### DIFF
--- a/sufia-models/lib/generators/sufia/models/templates/config/redis.yml
+++ b/sufia-models/lib/generators/sufia/models/templates/config/redis.yml
@@ -4,3 +4,6 @@ development:
 test:
   host: localhost
   port: 6379
+production:
+  host: localhost
+  port: 6379


### PR DESCRIPTION
Our other config files (see: fedora, solr, database) include blocks for development, test, and production.  So too should the redis config that Sufia generates, else you get possibly misleading error messages, like:
```
RAILS_ENV=production bundle exec rake db:migrate
rake aborted!
NoMethodError: undefined method <top (required)>'
```