### PR TITLE
Users controller should not call an undefined method. Fixes #532.

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -172,7 +172,7 @@ describe UsersController, :type => :controller do
       s1 = double('one')
       expect(UserEditProfileEventJob).to receive(:new).with(@user.user_key).and_return(s1)
       expect(Sufia.queue).to receive(:push).with(s1).once
-      expect_any_instance_of(User).to receive(:populate_attributes).once
+      expect_any_instance_of(User).to receive(:populate_attributes).once.and_call_original
       post :update, id: @user.user_key, user: { update_directory: 'true' }
       expect(response).to redirect_to(@routes.url_helpers.profile_path(@user.to_param))
       expect(flash[:notice]).to include("Your profile has been updated")

--- a/sufia-models/app/models/concerns/sufia/user.rb
+++ b/sufia-models/app/models/concerns/sufia/user.rb
@@ -54,6 +54,11 @@ module Sufia::User
     { id: user_key, text: display_name ? "#{display_name} (#{user_key})" : user_key }
   end
 
+  # Populate user instance with attributes from remote system (e.g., LDAP)
+  # There is no default implementation -- override this in your application
+  def populate_attributes
+  end
+
   def email_address
     self.email
   end


### PR DESCRIPTION
The default implementation is to return nil -- downstream implementations should populate user attributes in implementation- or organization-specific ways. E.g., ScholarSphere uses campus LDAP for this.