### PR TITLE
removing collapse that makes the edit detail not display.

### DIFF
--- a/app/assets/stylesheets/sufia/_batch-edit.scss
+++ b/app/assets/stylesheets/sufia/_batch-edit.scss
@@ -19,3 +19,6 @@
   padding-top: 5px;
 }
 
+.expanded-details {
+  display: none;
+}

--- a/app/views/batch_edits/edit.html.erb
+++ b/app/views/batch_edits/edit.html.erb
@@ -19,13 +19,13 @@
           <div class="row">
             <!-- look into dashboard_actions.js -->
             <div class="col-sm-2 col-sm-offset-1">
-              <a class="accordion-toggle grey glyphicon-chevron-right-helper" data-toggle="collapse" data-parent="#row_<%= term.to_s %>" href="#" id="expand_link_<%=term.to_s%>">
+              <a class="accordion-toggle grey glyphicon-chevron-right-helper" data-parent="#row_<%= term.to_s %>" href="#" id="expand_link_<%=term.to_s%>">
                 <%= get_label(term) %>
               </a>
               <a href="#collapse_<%=term.to_s%>" class="small" id="chevron_link_<%=term.to_s%>"><span id="expand_<%=term.to_s%>" class="glyphicon glyphicon-chevron-right"></span></a>
             </div>
             <div id="detail_<%= term.to_s %>" class="col-sm-6">
-              <div class="accordion-body collapse expanded-details scrolly">
+              <div class="accordion-body expanded-details scrolly">
                 <%= form_for @generic_file, url: batch_edits_path, method: :put, remote: true, html: { id: "form_#{term.to_s}", class: "ajax-form"} do |f| %>
                   <%= hidden_field_tag('update_type', 'update') %>
                   <%= hidden_field_tag('key', term.to_s) %>


### PR DESCRIPTION
We are mixing jquery slide toggle and bootstrap collapse and getting nothing.  Changed to use only slide toggle since that is what is being used in the dashboard.