### PR TITLE
Upgrade to Bootstrap 3.2 way of doing media elements.

### DIFF
--- a/app/assets/stylesheets/sufia/_file-listing.scss
+++ b/app/assets/stylesheets/sufia/_file-listing.scss
@@ -41,7 +41,6 @@ h4 .small {
 }
 
 .file_listing_thumbnail {
-  @extend .media-object;
   width: 64px;
 }
 

--- a/app/views/collections/_show_document_list_row.html.erb
+++ b/app/views/collections/_show_document_list_row.html.erb
@@ -11,7 +11,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to sufia.generic_file_path(document), class: "pull-left" do %>
+      <%= link_to sufia.generic_file_path(document), class: "media-left" do %>
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">

--- a/app/views/my/_index_partials/_list_files.html.erb
+++ b/app/views/my/_index_partials/_list_files.html.erb
@@ -13,7 +13,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to sufia.generic_file_path(document), class: "pull-left", "aria-hidden" => true do %>
+      <%= link_to sufia.generic_file_path(document), class: "media-left", "aria-hidden" => true do %>
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
       <% end %>
       <div class="media-body">


### PR DESCRIPTION
the "media-object" class is removed in Bootstrap 3. Attempting to extend
the nonexistent class raises an error in sass-rails 3.0 (Rails 4.2)
Fixes #813
See http://getbootstrap.com/components/#media