### PR TITLE
Point at updated Hydra components

### DIFF
--- a/app/inputs/select_with_modal_help_input.rb
+++ b/app/inputs/select_with_modal_help_input.rb
@@ -14,7 +14,7 @@ class SelectWithModalHelpInput < MultiValueWithHelpInput
       end
     end
 
-    def build_text_field(value)
+    def build_field(value, index)
       html_options = input_html_options.dup
 
       if @rendered_first_element

--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '~> 4.0', '< 5.0.0'
   spec.add_dependency 'activeresource', "~> 4.0" # No longer a dependency of rails 4.0
 
-  spec.add_dependency "hydra-head", "~> 9.0.0.rc2"
-  spec.add_dependency "active-fedora", "~> 9.0.0.rc2"
+  spec.add_dependency "hydra-head", "~> 9.0.0.rc3"
+  spec.add_dependency "active-fedora", "~> 9.0.0.rc3"
   spec.add_dependency "hydra-collections", "~> 4.0.0.rc2"
   spec.add_dependency 'hydra-derivatives', '~> 1.0.0.rc1'
   spec.add_dependency 'nest', '~> 1.1'

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -28,14 +28,14 @@ Gem::Specification.new do |gem|
   # declare a dependency on) sass-rails
   gem.add_dependency 'sass-rails'
 
-  gem.add_dependency 'hydra-batch-edit', '>= 1.1.1', '< 2.0.0'
+  gem.add_dependency 'hydra-batch-edit', '~> 1.1'
   gem.add_dependency 'browse-everything', '~> 0.4'
   gem.add_dependency 'daemons', '~> 1.1'
   gem.add_dependency 'mail_form'
   gem.add_dependency 'rails_autolink', '~> 1.1'
   gem.add_dependency 'yaml_db', '~> 0.2'
   gem.add_dependency 'font-awesome-rails'
-  gem.add_dependency 'hydra-editor', '~> 1.0.0.rc2'
+  gem.add_dependency 'hydra-editor', '~> 1.0.0.rc3'
   gem.add_dependency 'blacklight-gallery'
   gem.add_dependency 'breadcrumbs_on_rails', '~>2.3.0'
   gem.add_dependency 'select2-rails'

--- a/tasks/sufia-dev.rake
+++ b/tasks/sufia-dev.rake
@@ -3,7 +3,6 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 require 'jettywrapper'
-Jettywrapper.hydra_jetty_version = "v8.1.1"
 
 require 'engine_cart/rake_task'
 


### PR DESCRIPTION
Including hydra-head, active-fedora, and hydra-editor. This also picks up jettywrapper 2.0.0 via hydra-head, which pulls in the latest hydra-jetty (with fcr4).