### PR TITLE
Make sure versions are sorted by the created field

### DIFF
--- a/app/presenters/sufia/version_list_presenter.rb
+++ b/app/presenters/sufia/version_list_presenter.rb
@@ -9,7 +9,7 @@ module Sufia
     private
 
       def wrapped_list
-        @wrapped_list ||= @raw_list.map { |v| Sufia::VersionPresenter.new(v) }.sort(&:date).tap { |l| l.first.try(:current!) }
+        @wrapped_list ||= @raw_list.map { |v| Sufia::VersionPresenter.new(v) }.sort { |a,b| b.version.created <=> a.version.created }.tap { |l| l.first.try(:current!) }
       end
   end
 end

--- a/spec/presenters/sufia/version_list_presenter_spec.rb
+++ b/spec/presenters/sufia/version_list_presenter_spec.rb
@@ -9,14 +9,24 @@ describe Sufia::VersionListPresenter, :no_clean do
     end
   end
 
-  subject { Sufia::VersionListPresenter.new([resource_version]) }
+  let(:resource_version2) do
+    ActiveFedora::VersionsGraph::ResourceVersion.new.tap do |v|
+      v.uri = 'http://example.com/version2'
+      v.label = 'version2'
+      v.created = '2014-12-19T02:03:18.296Z'
+    end
+  end
+
+  subject { Sufia::VersionListPresenter.new([resource_version, resource_version2]) }
 
   describe "#each" do
     it "should yield version_presenters" do
+      versions_descending = []
       subject.each do |v|
         expect(v).to be_kind_of Sufia::VersionPresenter
-        expect(v.label).to eq 'version1'
+        versions_descending.push(v.label)
       end
+      expect(versions_descending).to eq ['version2', 'version1']
     end
   end
 end


### PR DESCRIPTION
Code was still sorting by the old (date) field but the test failed to catch the error because there was only one item on the list used during the test.