### PR TITLE
Permit the parameters that allow you to remove a permission

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'
 gem 'sufia-models', path: './sufia-models'
 gem 'slop', '~> 3.6.0' # This just helps us generate a valid Gemfile.lock when Rails 4.2 is installed (which requires byebug which has a dependency on slop)
 
+gem 'hydra-editor', github: 'projecthydra-labs/hydra-editor'
+
 group :development, :test do
   gem "simplecov", require: false
   gem 'byebug' unless ENV['CI']

--- a/app/assets/javascripts/sufia/permissions.js
+++ b/app/assets/javascripts/sufia/permissions.js
@@ -136,28 +136,24 @@ Blacklight.onLoad(function() {
       return $('#file_permissions').parent().children().size() - 1;
   }
 
-  $('.remove_perm').on('click', function() {
-     var top = $(this).parent().parent();
-     top.addClass('hidden'); // do not show the block
-     addDestroyField(top);
-     showPermissionNote();
-     return false;
+  $('.remove_perm').on('click', function(evt) {
+       evt.preventDefault();
+       var top = $(this).parent().parent();
+       top.addClass('hidden'); // do not show the block
+       addDestroyField(top, $(this).attr('data-index'));
+       showPermissionNote();
   });
 
   function showPermissionNote() {
      $('#save_perm_note').removeClass('hidden');
   }
 
-  function addDestroyField(element) {
+  function addDestroyField(element, index) {
       $('<input>').attr({
           type: 'hidden',
-          name: 'generic_file[permissions_attributes][' + indexOf(element) + '][_destroy]',
+          name: 'generic_file[permissions_attributes][' + index + '][_destroy]',
           value: 'true'
       }).appendTo(element);
-  }
-
-  function indexOf(element) {
-      return $('#file_permissions').parent().children().index(element) - 1;
   }
 
 });

--- a/app/forms/sufia/forms/generic_file_edit_form.rb
+++ b/app/forms/sufia/forms/generic_file_edit_form.rb
@@ -2,15 +2,8 @@ module Sufia
   module Forms
     class GenericFileEditForm < GenericFilePresenter
       include HydraEditor::Form
+      include HydraEditor::Form::Permissions
       self.required_fields = [:title, :creator, :tag, :rights]
-
-      # This is required so that fields_for will draw a nested form.
-      # See ActionView::Helpers#nested_attributes_association?
-      #   https://github.com/rails/rails/blob/a04c0619617118433db6e01b67d5d082eaaa0189/actionview/lib/action_view/helpers/form_helper.rb#L1890
-      def permissions_attributes= attributes
-        model.permissions_attributes= attributes
-      end
-
     end
   end
 end

--- a/app/views/generic_files/_permission_form.html.erb
+++ b/app/views/generic_files/_permission_form.html.erb
@@ -108,7 +108,7 @@
         <div class="col-sm-8">
           <%= permission_fields.select :access, Sufia.config.permission_levels, {}, class: 'form-control select_perm' %>
         </div>
-        <button class="btn close remove_perm">X</button>
+        <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">X</button>
       </td>
     </tr>
   <% end %>

--- a/spec/forms/generic_file_edit_form_spec.rb
+++ b/spec/forms/generic_file_edit_form_spec.rb
@@ -15,12 +15,14 @@ describe Sufia::Forms::GenericFileEditForm do
   end
 
   describe ".model_attributes" do
-    let(:params) { ActionController::Parameters.new(title: ['foo'], description: [''])}
+    let(:params) { ActionController::Parameters.new(title: ['foo'], description: [''], "permissions_attributes"=>{"2"=>{"access"=>"edit", "_destroy"=>"true", "id"=>"a987551e-b87f-427a-8721-3e5942273125"}})}
     subject { described_class.model_attributes(params) }
 
     it "should only change title" do
       expect(subject['title']).to eq ["foo"]
       expect(subject['description']).to be_empty
+      expect(subject['permissions_attributes']).to eq("2" => {"access"=>"edit", "id"=>"a987551e-b87f-427a-8721-3e5942273125", "_destroy"=>"true"})
     end
   end
+
 end

--- a/spec/views/generic_file/_permission_form.html.erb_spec.rb
+++ b/spec/views/generic_file/_permission_form.html.erb_spec.rb
@@ -7,17 +7,39 @@ describe 'generic_files/_permission_form.html.erb', :type => :view do
         resource_type: ['Dataset'])
   }
 
-  before do
-    allow(controller).to receive(:current_user).and_return(stub_model(User))
-    allow(generic_file).to receive(:permissions).and_return([])
-    form_for(generic_file, url: '/update') do |f|
-      @f = f
+  let(:form) do
+    form_for(generic_file, url: '/update') do |gf_form|
+      return gf_form
     end
   end
 
-  it "should draw the permissions form without error" do
-    render 'generic_files/permission_form.html.erb', f: @f
-    expect(rendered).to have_css("input#new_user_name_skel")
+  before do
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    allow(generic_file).to receive(:permissions).and_return(permissions)
+    allow(view).to receive(:f).and_return(form)
+    render
+  end
+
+  context "without additional users" do
+    let(:permissions) { [] }
+
+    it "should draw the permissions form without error" do
+      expect(rendered).to have_css("input#new_user_name_skel")
+      expect(rendered).not_to have_css("button.remove_perm")
+    end
+  end
+
+  context "with additional users" do
+    let(:depositor_permission) { Hydra::AccessControls::Permission.new(id: '123', name: 'bob', type: 'person', access: 'edit') }
+    let(:public_permission) { Hydra::AccessControls::Permission.new(id: '124', name: 'public', type: 'group', access: 'read') }
+    let(:other_permission) { Hydra::AccessControls::Permission.new(id: '125', name: 'joe@example.com', type: 'person', access: 'edit') }
+    let(:permissions) { [ depositor_permission, public_permission, other_permission] }
+
+    it "should draw the permissions form without error" do
+      expect(rendered).to have_css("input#new_user_name_skel")
+      expect(rendered).to have_css("button.remove_perm", count: 1) # depositor and public should be filtered out
+      expect(rendered).to have_css("button.remove_perm[data-index='2']")
+    end
   end
 
 end


### PR DESCRIPTION
Previously, attempting to remove a permission would fail because
permissions_attributes id and _destroy were not permitted