### PR TITLE
Removed a rescue block

### DIFF
--- a/app/controllers/concerns/sufia/files_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller_behavior.rb
@@ -133,10 +133,6 @@ module Sufia
       else
         render action: 'edit'
       end
-    rescue => error
-      flash[:error] = error.message
-      logger.error "GenericFilesController::update rescued #{error.class}\n\t#{error.message}\n #{error.backtrace.join("\n")}\n\n"
-      render action: 'edit'
     end
 
     protected


### PR DESCRIPTION
Reasoning:
  * It was an untyped, so it's hard to say which conditions might be
expected. This means it was obfuscating errors we should be solving like #846
  * It was untested
  * It didn't work. It didn't set the correct ivars to render the edit view