### PR TITLE
Sufia should not override EngineCart's tasks.

### DIFF
--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,0 +1,1 @@
+gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'

--- a/tasks/sufia-dev.rake
+++ b/tasks/sufia-dev.rake
@@ -15,19 +15,3 @@ task ci: ['engine_cart:generate', 'jetty:clean', 'sufia:jetty:config'] do
   end
   raise "test failures: #{error}" if error
 end
-
-EXTRA_GEMS =<<EOF
-gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'
-EOF
-
-namespace :engine_cart do
-  desc 'Regenerate embedded app for testing'
-  task regenerate: ['engine_cart:clean', 'engine_cart:generate']
-
-  # we're adding some extra stuff into the gemfile beyond what engine_cart gives us by default
-  task :inject_gemfile_extras do
-    open(File.expand_path('Gemfile', EngineCart.destination), 'a') do |f|
-      f.write EXTRA_GEMS
-    end
-  end
-end


### PR DESCRIPTION
At some point, the regenerate and inject_gemfile_extras tasks were not in EngineCart, so we put them in Sufia. Now they're in EngineCart as of 0.5.0, so I'm removing them from Sufia since they are extraneous concerns.