### PR TITLE
Resource type should not be required

### DIFF
--- a/app/views/batch/_metadata.html.erb
+++ b/app/views/batch/_metadata.html.erb
@@ -28,14 +28,14 @@
       <div class="col-sm-6">
       <h3>Applies to all files just uploaded</h3>
       <%= f.input :resource_type, as: :select_with_help, collection: Sufia.config.resource_types,
-          input_html: { class: 'form-control', multiple: true, required: true } %>
+          input_html: { class: 'form-control', multiple: true } %>
 
-      <%= f.input :tag, as: :multi_value_with_help, input_html: { required: true } %>
+      <%= f.input :tag, as: :multi_value_with_help %>
 
-      <%= f.input :creator, as: :multi_value_with_help, input_html: { required: true } %>
+      <%= f.input :creator, as: :multi_value_with_help %>
 
       <%= f.input :rights, as: :select_with_modal_help, collection: Sufia.config.cc_licenses,
-          input_html: { class: 'form-control', multiple: true, required: true } %>
+          input_html: { class: 'form-control', multiple: true } %>
 
       <%= render "generic_files/rights_modal" %>
 

--- a/spec/inputs/select_with_help_input_spec.rb
+++ b/spec/inputs/select_with_help_input_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'SelectWithHelpInput', type: :input do
+  subject { input_for form, :resource_type, options }
+  let(:file) { GenericFile.new }
+  let(:form) { Sufia::Forms::BatchEditForm.new(file) }
+  let(:base_options) { { as: :select_with_help, collection: Sufia.config.resource_types,
+                         input_html: { class: 'form-control', multiple: true } } }
+  let(:options) { base_options }
+
+  it "should not be required by default" do
+      expect(subject).to have_selector 'select'
+      expect(subject).not_to match /required/
+  end
+end
+


### PR DESCRIPTION
It was not required in previous versions of Sufia, so this ensures the behavior doesn't change unnecessarily.