### PR TITLE
Remove nested anchor tag

### DIFF
--- a/app/views/homepage/_featured.html.erb
+++ b/app/views/homepage/_featured.html.erb
@@ -2,9 +2,7 @@
 <li class="featured-item" data-id="<%= solr_document.id %>">
   <div class="main row">
     <div class="col-sm-3">
-      <%= link_to sufia.generic_file_path(solr_document), "aria-hidden" => true do %>
-        <%= render_thumbnail_tag solr_document, {width: 90} %>
-      <% end %>
+      <%= render_thumbnail_tag solr_document, { width: 90 } %>
     </div>
     <div class="col-sm-9">
       <%= render partial: 'homepage/featured_fields', locals: {featured: solr_document} %>


### PR DESCRIPTION
Previously was generating HTML like this:
```html
<a aria-hidden="true" href="/files/d5a64948-966c-497e-830d-87f01887cbe1">
  <a data-context-href="/catalog/d5a64948-966c-497e-830d-87f01887cbe1/track?search_id=21"
      href="/files/d5a64948-966c-497e-830d-87f01887cbe1">
    <img alt="D5a64948 966c 497e 830d 87f01887cbe1?datastream id=thumbnail"
        src="/downloads/d5a64948-966c-497e-830d-87f01887cbe1?datastream_id=thumbnail"
        width="90" />
  </a>
</a>
```
This pull request removes the outer anchor. Fixes https://scm.dlt.psu.edu/issues/9648 (authentication required)