### PR TITLE
Added autocommit to solr config

### DIFF
--- a/sufia-models/lib/generators/sufia/models/templates/config/solrconfig.xml
+++ b/sufia-models/lib/generators/sufia/models/templates/config/solrconfig.xml
@@ -18,6 +18,52 @@
 
   <dataDir>${solr.data.dir:}</dataDir>
 
+  <!-- The default high-performance update handler -->
+  <updateHandler class="solr.DirectUpdateHandler2">
+
+    <!-- Enables a transaction log, used for real-time get, durability, and
+         and solr cloud replica recovery.  The log can grow as big as
+         uncommitted changes to the index, so use of a hard autoCommit
+         is recommended (see below).
+         "dir" - the target directory for transaction logs, defaults to the
+                solr data directory.  -->
+    <updateLog>
+      <str name="dir">${solr.ulog.dir:}</str>
+    </updateLog>
+
+    <!-- AutoCommit
+         Perform a hard commit automatically under certain conditions.
+         Instead of enabling autoCommit, consider using "commitWithin"
+         when adding documents.
+         http://wiki.apache.org/solr/UpdateXmlMessages
+         maxDocs - Maximum number of documents to add since the last
+                   commit before automatically triggering a new commit.
+         maxTime - Maximum amount of time in ms that is allowed to pass
+                   since a document was added before automatically
+                   triggering a new commit.
+         openSearcher - if false, the commit causes recent index changes
+           to be flushed to stable storage, but does not cause a new
+           searcher to be opened to make those changes visible.
+         If the updateLog is enabled, then it's highly recommended to
+         have some sort of hard autoCommit to limit the log size.
+      -->
+     <autoCommit>
+       <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
+       <openSearcher>false</openSearcher>
+     </autoCommit>
+
+    <!-- softAutoCommit is like autoCommit except it causes a
+         'soft' commit which only ensures that changes are visible
+         but does not ensure that data is synced to disk.  This is
+         faster and more near-realtime friendly than a hard commit.
+      -->
+
+     <autoSoftCommit>
+       <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+     </autoSoftCommit>
+
+  </updateHandler>
+
   <requestHandler name="search" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these
          will be overridden by parameters in the request


### PR DESCRIPTION
So you won't lose the docs when you restart Solr
Changes from
https://github.com/projecthydra/active_fedora/commit/c9733e3015710cbbc6c73fa4a85b5c59f35fd773#diff-a34e883c5c6fbed341364fc259dc854cR19
Fixes #889