### PR TITLE
Adding an overall timeout for the derivatives and a task timeout for ind...

### DIFF
--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -171,4 +171,22 @@ describe CreateDerivativesJob do
       end
     end
   end
+  context "with timeout set very small" do
+    let(:mime_type) { 'audio/wav' }
+    let(:file_name) { 'piano_note.wav' }
+    before do
+      @generic_file.add_file(File.open(fixture_path + '/' + file_name), path: 'content', original_name: file_name, mime_type: mime_type)
+      allow_any_instance_of(GenericFile).to receive(:mime_type).and_return(mime_type)
+      @generic_file.save!
+      @current_timeout = Sufia.config.derivatives_timeout
+      Sufia.config.derivatives_timeout = 0.0001
+    end
+    after do
+      Sufia.config.derivatives_timeout = @current_timeout
+    end
+
+    it "gets a timeout" do
+      expect { subject.run }.to raise_error Hydra::Derivatives::TimeoutError
+    end
+  end
 end

--- a/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
@@ -116,7 +116,7 @@ Sufia.config do |config|
   # config.fits_path = "fits.sh"
 
   # Specify how many seconds back from the current time that we should show by default of the user's activity on the user's dashboard
-  # config.activity_to_show_default_seconds_since_now = 24*60*60
+  # config.activity_to_show_default_seconds_since_now = 24.hours
 
   # Specify a date you wish to start collecting Google Analytic statistics for.
   # Leaving it blank will set the start date to when ever the file was uploaded by
@@ -127,6 +127,15 @@ Sufia.config do |config|
   # config.translate_uri_to_id = lambda { |uri| uri.to_s.split('/')[-1] }
   # config.translate_id_to_uri = lambda { |id|
   #      "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{Sufia::Noid.treeify(id)}" }
+
+  # Sometimes the derivatives jobs get into a bad state and run for eternity
+  # Setting the timeout allows for you to give the jobs a specific amount of time before they must complete
+  # config.derivatives_timeout = 20.minutes
+
+  # Hydra derivatives also allows for setting individual timeouts on each derivative process (creating an thumbnail, converting to a web format, ...)
+  # This values will get copied to each task timeout available in Hydra Derivatives if those values are not individually set
+  # config.derivatives_task_timeout = 10.minutes
+
 
   # If browse-everything has been configured, load the configs.  Otherwise, set to nil.
   begin

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -28,7 +28,9 @@ module Sufia
       config.analytics = false
       config.queue = Sufia::Resque::Queue
       config.max_notifications_for_dashboard = 5
-      config.activity_to_show_default_seconds_since_now = 24*60*60
+      config.activity_to_show_default_seconds_since_now = 24.hours
+      config.derivatives_timeout = 20.minutes
+      config.derivatives_task_timeout = 10.minutes
 
       # Defaulting analytic start date to when ever the file was uploaded by leaving it blank
       config.analytic_start_date = nil
@@ -69,6 +71,11 @@ module Sufia
           Hydra::Derivatives.temp_file_base = c.temp_file_base
           Hydra::Derivatives.fits_path      = c.fits_path
           Hydra::Derivatives.enable_ffmpeg  = c.enable_ffmpeg
+
+          # set all the derivatives timeouts based the overall timeout unless they were already set
+          Hydra::Derivatives::Document.timeout ||= c.derivatives_task_timeout
+          Hydra::Derivatives::Audio.timeout ||= c.derivatives_task_timeout
+          Hydra::Derivatives::Video::Processor.timeout ||= c.derivatives_task_timeout
 
           ActiveFedora::Base.translate_uri_to_id = c.translate_uri_to_id
           ActiveFedora::Base.translate_id_to_uri = c.translate_id_to_uri


### PR DESCRIPTION
...ividual derivative tasks so that the entire derivatives process does not take longer a certain amount of time, and each task can be set enmass instead of needing to be configured individually

In ScholarSphere we are seeing derivatives jobs just hang on the queue.  It may be related to deployment, or stopping and starting the jobs queue, but the jobs should not run forever.  It causes other jobs to back up behind.  This sets a overall timeout for creating any derivatives and include configuring an over all timeout for derivative tasks.  

Part of the reason I am doing this at this level is there is no timeout in derivatives for images.  Yesterday an image file hung on the queue for more than an hour before I found it and killed it.  When I reran it it took less than a minute to run.  