### PR TITLE
Replaces tables for description list and adds CSS column-count, refs #91...

### DIFF
--- a/app/assets/stylesheets/sufia.css.scss
+++ b/app/assets/stylesheets/sufia.css.scss
@@ -18,7 +18,7 @@
 @import 'sufia/settings', 'sufia/header', 'sufia/styles', 'sufia/file-listing',
         'sufia/collections', 'sufia/batch-edit', 'sufia/dashboard', 'sufia/home-page',
         'sufia/featured', 'sufia/tagcloud', 'sufia/usage-stats', 'sufia/catalog', 'sufia/buttons',
-        'sufia/tinymce', 'sufia/proxy-rights';
+        'sufia/tinymce', 'sufia/proxy-rights', 'sufia/file-show';
 @import 'hydra-editor/multi_value_fields';
 
 #browse-everything {

--- a/app/assets/stylesheets/sufia/_collections.scss
+++ b/app/assets/stylesheets/sufia/_collections.scss
@@ -1,4 +1,4 @@
-.collection_description {
+.collection_description, .genericfile_description {
   color: #333;
   font-family: 'Lato', Verdana, Arail, Helvetica, sans-serif;
   font-size: 1.15em;

--- a/app/assets/stylesheets/sufia/_file-show.scss
+++ b/app/assets/stylesheets/sufia/_file-show.scss
@@ -1,0 +1,24 @@
+.file-show-term {
+  border-top: 2px solid $heading-border-color;
+  padding-top: 1em;
+  dt {
+    color: $file-show-term-color;
+  }
+  dd {
+    padding-bottom: .35em;
+    word-wrap: break-word;
+  }
+}
+
+.file-show-term dt::after {
+  content: ':';
+}
+
+.file-show-descriptions, .file-show-details {
+  -moz-column-count: 2;
+  -webkit-column-count: 2;
+  column-count: 2;
+  -moz-column-width: 20em;
+  -webkit-column-width: 20em;
+  column-width: 20em;
+}

--- a/app/assets/stylesheets/sufia/_settings.scss
+++ b/app/assets/stylesheets/sufia/_settings.scss
@@ -74,3 +74,7 @@ $view-select-border-color: $blue-medium-bright;
 $view-select-text-color: $classic-white;
 $view-select-background-hover: $classic-white;
 $view-select-text-hover: $blue-medium-bright;
+
+// File Show Page
+$file-show-term-color: $gray-dark;
+$heading-border-color: $gray-light;

--- a/app/views/generic_files/_show_descriptions.html.erb
+++ b/app/views/generic_files/_show_descriptions.html.erb
@@ -1,12 +1,7 @@
-
-<h2 class="non lower">Descriptions</h2>
-<table class="table table-striped"><!-- class="verticalheadings"> -->
-  <tbody>
+<h2>Descriptions</h2>
+<dl class="dl-horizontal file-show-term file-show-descriptions">
   <% present_terms(@presenter,@presenter.terms - [:title, :description]) do |r, term| %>
-      <tr>
-        <th><%= r.label(term) %></th>
-        <td><%= r.value(term) %></td>
-      </tr>
+  <dt><%= r.label(term) %></dt>
+      <dd><%= r.value(term) %></dd>
   <% end %>
-  </tbody>
-</table> <!-- /verticalheadings -->
+</dl>

--- a/app/views/generic_files/_show_details.html.erb
+++ b/app/views/generic_files/_show_details.html.erb
@@ -1,69 +1,45 @@
-    <h2 class="non lower">File Details</h2>
-    <table class="table table-striped">
-      <tbody>
-        <tr>
-          <th>Depositor</th>
-          <td itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person"><span itemprop="name"><%= link_to_profile @generic_file.depositor %></span></td>
-        </tr>
-        <tr>
-          <th>Date Uploaded</th>
-          <td itemprop="datePublished">
-            <%= @generic_file.date_uploaded %>
-          </td>
-        </tr>
-        <tr>
-          <th>Date Modified</th>
-          <td itemprop="dateModified">
-            <%= @generic_file.date_modified %>
-          </td>
-        </tr>
-        <tr>
-          <th>Audit Status</th>
-          <td><%= @audit_status %></td>
-        </tr>
-<% unless @generic_file.related_files.empty? %>
-        <tr>
-          <th>Related Files</th>
-          <td>
-              <div class="related-files">
-                  <dl><dt>
-	              <% @generic_file.related_files.each do |f| %>
-	                <dd><%= link_to(f.label, sufia.generic_file_url(f)) %></dd>
-	              <% end %>
-                  </dt></dl>
-              </div>
-          </td>
-        </tr>
-<% end %>
-<tr>
-          <th>Characterization</th>
-          <td>
-            <%= "not yet characterized" if @generic_file.characterization_terms.values.flatten.map(&:empty?).reduce(true) { |sum, value| sum && value } %>
-            <% @generic_file.characterization_terms.each_pair do |term, values| %>
-            <div>
-              <% label = term.to_s %>
-              <% if label == "format_label" %>
-                 <% label = "File Format"  %>
-                 <% values = @generic_file.file_format %>
-              <% end %>
-              <% label = label.humanize %>
-              <% if values.is_a? Array %>
-                <% length = values.length %>
-                <% length = Sufia.config.fits_message_length-1  if term == :status_message && values.length > Sufia.config.fits_message_length-1  %>
-                <% values[0..length].each_with_index do |value, idx| %>
+<h2>File Details</h2>
+<dl class="dl-horizontal file-show-term file-show-details">
+  <dt>Depositor</dt>
+  <dd itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person"><span itemprop="name"><%= link_to_profile @generic_file.depositor %></span></dd>
+  <dt>Date Uploaded</dt>
+  <dd itemprop="datePublished"><%= @generic_file.date_uploaded %></dd>
+  <dt>Date Modified</dt>
+  <dd itemprop="dateModified"><%= @generic_file.date_modified %></dd>
+  <dt>Audit Status</dt>
+  <dd><%= @audit_status %></dd>
+  <% unless @generic_file.related_files.empty? %>
+  <dt>Related Files</dt>
+      <% @generic_file.related_files.each do |f| %>
+          <dd><%= link_to(f.label, sufia.generic_file_url(f)) %></dd>
+      <% end %>
+  <% end %>
+  <dt>Characterization</dt>
+  <dd>
+    <%= "not yet characterized" if @generic_file.characterization_terms.values.flatten.map(&:empty?).reduce(true) { |sum, value| sum && value } %>
+    <% @generic_file.characterization_terms.each_pair do |term, values| %>
+        <div>
+          <% label = term.to_s %>
+          <% if label == "format_label" %>
+              <% label = "File Format"  %>
+              <% values = @generic_file.file_format %>
+          <% end %>
+          <% label = label.humanize %>
+          <% if values.is_a? Array %>
+              <% length = values.length %>
+              <% length = Sufia.config.fits_message_length-1  if term == :status_message && values.length > Sufia.config.fits_message_length-1  %>
+              <% values[0..length].each_with_index do |value, idx| %>
                   <% next if value.empty? %>
                   <%= "#{label}: #{value.truncate(250)}" %>
                   <%= "<br />".html_safe unless idx == length %>
-                <% end %>
-                <% if length != values.length %>
-                   <%= render partial: "generic_files/extra_fields_modal", locals: {name: term, values: values, start: Sufia.config.fits_message_length}%>
-                <% end %>
-              <% else %>
-                <%= "#{label}: #{values.truncate(250)}" %><br />
               <% end %>
-            </div>
-            <% end %>
-          </td>
-        </tr>
-      </tbody>
-    </table> <!-- /verticalheadings -->
+              <% if length != values.length %>
+                  <%= render partial: "generic_files/extra_fields_modal", locals: {name: term, values: values, start: Sufia.config.fits_message_length}%>
+              <% end %>
+          <% else %>
+              <%= "#{label}: #{values.truncate(250)}" %><br />
+          <% end %>
+        </div>
+    <% end %>
+  </dd>
+</dl>


### PR DESCRIPTION
...33  Adds the ability for the metadata to flow into two columns when the viewport allows. Moves metadata out of a table layout and into description lists.


![screen shot 2015-02-25 at 11 33 09 am](https://cloud.githubusercontent.com/assets/4163828/6374981/3bfffc9c-bce2-11e4-8798-3c19073484b5.png)

![screen shot 2015-02-25 at 11 33 31 am](https://cloud.githubusercontent.com/assets/4163828/6374989/436c7c8a-bce2-11e4-8e3a-a1eb76aa09df.png)

![screen shot 2015-02-25 at 11 33 50 am](https://cloud.githubusercontent.com/assets/4163828/6375004/4e6a849c-bce2-11e4-800e-91c02c64fe63.png)
