### PR TITLE
Remove arrow in relevance sorting label

### DIFF
--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -304,7 +304,7 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance \u25BC"
+    config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance"
     config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
     config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"

--- a/spec/views/catalog/sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/catalog/sort_and_per_page.html.erb_spec.rb
@@ -15,13 +15,17 @@ describe 'catalog/_sort_and_per_page.html.erb', :type => :view do
     allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
   end
 
-
-
   it 'appears on page without error' do
     render
     page = Capybara::Node::Simple.new(rendered)
     expect(page).to have_selector('span.page_entries', count: 1)
     expect(rendered).to include("<strong>4</strong> - <strong>6</strong> of <strong>20</strong>")
+  end
+  
+  it 'displays the relevance option for sorting' do
+    render
+    page = Capybara::Node::Simple.new(rendered)
+    expect(rendered).to include("<li><a href=\"/catalog?sort=score+desc%2C+date_uploaded_dtsi+desc\">relevance</a></li>")
   end
 
 end


### PR DESCRIPTION
Fixes issue reporting in #914 by updating the catalog_controller generator to match the current one in Blacklight.