### PR TITLE
Makes sure resource type is not a require field in GenericFile edit form...

### DIFF
--- a/app/views/records/edit_fields/_resource_type.html.erb
+++ b/app/views/records/edit_fields/_resource_type.html.erb
@@ -1,2 +1,2 @@
 <%= f.input :resource_type, as: :select_with_help, collection: Sufia.config.resource_types,
-    input_html: { class: 'form-control', multiple: true, required: true } %>
+    input_html: { class: 'form-control', multiple: true } %>

--- a/spec/inputs/select_with_help_input_spec.rb
+++ b/spec/inputs/select_with_help_input_spec.rb
@@ -14,3 +14,18 @@ describe 'SelectWithHelpInput', type: :input do
   end
 end
 
+describe 'SelectWithHelpInput File Edit', type: :input do
+  let(:user) { FactoryGirl.find_or_create(:jill) }
+  let(:file) { GenericFile.create(batch: Batch.create, label: 'f1') { |f| f.apply_depositor_metadata(user) } }
+  let(:form) { Sufia::Forms::GenericFileEditForm.new(file) }
+  let(:base_options) { { as: :select_with_help, collection: Sufia.config.resource_types,
+                         input_html: { class: 'form-control', multiple: true } } }
+  let(:options) { base_options }
+
+  subject { input_for form, :resource_type, options }
+
+  it "should not be required by default" do
+      expect(subject).to have_selector 'select'
+      expect(subject).not_to match /required/
+  end
+end


### PR DESCRIPTION
Batch edit was fixed in a previous commit (https://github.com/projecthydra/sufia/commit/e8eb8b0039ce52d090a4e973f584c26b204a96c9) but File Edit was still making the resource type a required field. This PR fixes the issue in File Edit. 