### PR TITLE
Moving alerts above the tabs so that it is not replicated on each tab. f...

### DIFF
--- a/app/views/generic_files/_browse_everything.html.erb
+++ b/app/views/generic_files/_browse_everything.html.erb
@@ -1,5 +1,4 @@
 <%= render partial: 'generic_files/upload/agreement' %>
-<%= render partial: 'generic_files/upload/alerts' %>
 <div class="well">
   <%= form_tag(sufia.generic_files_path, id: 'browse_everything_form', method: 'post') do %>
       <%= render partial: 'generic_files/upload/tos_checkbox' %>

--- a/app/views/generic_files/_local_file_import.html.erb
+++ b/app/views/generic_files/_local_file_import.html.erb
@@ -1,3 +1,2 @@
 <%= render partial: 'generic_files/upload/agreement' %>
-<%= render partial: 'generic_files/upload/alerts' %>
 <%= render partial: 'generic_files/upload/local_file_import_chooser' %>

--- a/app/views/generic_files/_multiple_upload.html.erb
+++ b/app/views/generic_files/_multiple_upload.html.erb
@@ -1,4 +1,3 @@
 <%= render partial: 'generic_files/upload/agreement' %>
-<%= render partial: 'generic_files/upload/alerts' %>
 <%= render partial: 'generic_files/upload/form' %>
 <%= render partial: 'generic_files/upload/script_templates' %>

--- a/app/views/generic_files/new.html.erb
+++ b/app/views/generic_files/new.html.erb
@@ -1,4 +1,5 @@
 <h2>Upload</h2>
+<%= render partial: 'generic_files/upload/alerts' %>
 <%# using partials rather than inlining, so implementers can add or change stuff on this page without much duplication %>
 <ul class="nav nav-tabs" role="tablist" title="Data Source Selectors" id="upload_tabs">
   <li class="active" id="computer_tab" title="<%= t('sufia.upload.my_computer.sr_tab_label')+' '+ t('sufia.upload.my_computer.tab_label') %>"><a role="tab" href="#local" data-toggle="tab"><i class="glyphicon glyphicon-folder-open" aria-hidden="true"></i> <%= t('sufia.upload.my_computer.tab_label')%></a></li>


### PR DESCRIPTION
...ixes #929

The alert proxy was not made well for multiple uses, sine it included IDs.  There were two ways to fix this issue, what I did or change the partial to remove the ids and update the javascript not to rely on the ids.

I discussed the new positioning with @mtribone and he did not think it was a bad idea, since all other flash messages show at the top of the page.

![screen shot 2015-02-26 at 7 33 11 am](https://cloud.githubusercontent.com/assets/1599081/6391965/ce445970-bd89-11e4-9b65-c9142bbaf8b6.png)
