### PR TITLE
Updating to use the new blacklight partial instead of defining in-line

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,34 +1,7 @@
-<div id="sidebar" class="col-md-3">
+<div id="sidebar" class="col-md-3 col-sm-4">
   <%= render 'search_sidebar' %>
 </div>
 
-<div id="content" class="col-md-9">
-
-
-  <h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
-
-  <% @page_title = t('blacklight.search.title', :application_name => application_name) %>
-
-
-  <% content_for(:head) do -%>
-      <%= render_opensearch_response_metadata %>
-      <%= auto_discovery_link_tag(:rss, url_for(params.merge(:format => 'rss')), :title => t('blacklight.search.rss_feed') ) %>
-      <%= auto_discovery_link_tag(:atom, url_for(params.merge(:format => 'atom')), :title => t('blacklight.search.atom_feed') ) %>
-  <% end -%>
-
-
-  <%= render 'search_header' %>
-
-  <h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
-
-  <%- if @response.empty? %>
-      <%= render "zero_results" %>
-  <%- elsif render_grouped_response? %>
-      <%= render_grouped_document_index %>
-  <%- else %>
-      <%= render_document_index %>
-  <%- end %>
-
-  <%= render 'results_pagination' %>
-
+<div id="content" class="col-md-9 col-sm-8">
+    <%= render 'search_results' %>
 </div>


### PR DESCRIPTION
Using the new blacklight partial (https://github.com/projectblacklight/blacklight/blob/master/app/views/catalog/_search_results.html.erb) instead of overriding the entire contents to change the zero response.