### PR TITLE
Remove blank strings from files and collections

### DIFF
--- a/app/controllers/concerns/sufia/collections_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/collections_controller_behavior.rb
@@ -44,10 +44,12 @@ module Sufia
     end
 
     def collection_params
-      params.require(:collection).permit(:title, :description, :members, part_of: [],
-        contributor: [], creator: [], publisher: [], date_created: [], subject: [],
-        language: [], rights: [], resource_type: [], identifier: [], based_near: [],
-        tag: [], related_url: [])
+      form_class.model_attributes(
+        params.require(:collection).permit(:title, :description, :members, part_of: [],
+          contributor: [], creator: [], publisher: [], date_created: [], subject: [],
+          language: [], rights: [], resource_type: [], identifier: [], based_near: [],
+          tag: [], related_url: [])
+      )
     end
 
     def query_collection_members

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -30,6 +30,15 @@ describe CollectionsController do
       }.to change{ Collection.count }.by(1)
     end
 
+    it "should remove blank strings from params before creating Collection" do
+      expect {
+        post :create, collection: {
+          title: "My First Collection ", creator: [""] }
+      }.to change{ Collection.count }.by(1)
+      expect(assigns[:collection].title).to eq("My First Collection ")
+      expect(assigns[:collection].creator).to eq([])
+    end
+
     it "should create a Collection with files I can access" do
       @asset1 = GenericFile.new(title: ["First of the Assets"])
       @asset1.apply_depositor_metadata(user.user_key)
@@ -113,6 +122,14 @@ describe CollectionsController do
         collection.reload
         expect(collection.creator).to eq ['Emily']
       end
+
+      it "should remove blank strings from params before updating Collection metadata" do
+        put :update, id: collection, collection: {
+          title: "My Next Collection ", creator: [""] }
+        expect(assigns[:collection].title).to eq("My Next Collection ")
+        expect(assigns[:collection].creator).to eq([])
+      end
+
     end
   end
 

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -44,7 +44,7 @@ describe GenericFilesController do
         it "spawns a content deposit event job" do
           expect_any_instance_of(Sufia::GenericFile::Actor).to receive(:create_content).with(file, 'world.png', 'content', 'image/png').and_return(true)
           xhr :post, :create, files: [file], 'Filename' => 'The world', batch_id: batch_id, permission: {group: { public: 'read' } }, terms_of_service: '1'
-          expect(response.body).to eq '[{"name":null,"size":"","url":"/files/test123","thumbnail_url":"test123","delete_url":"deleteme","delete_type":"DELETE"}]'
+          expect(response.body).to eq '[{"name":null,"size":null,"url":"/files/test123","thumbnail_url":"test123","delete_url":"deleteme","delete_type":"DELETE"}]'
           expect(flash[:error]).to be_nil
         end
 

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -8,6 +8,14 @@ describe GenericFile, :type => :model do
     @file.apply_depositor_metadata(user.user_key)
   end
 
+  context "when it is initialized" do
+    it "has empty arrays for all the properties" do
+      subject.attributes.each do |k,v|
+        expect(Array(v)).to eq([])
+      end
+    end
+  end
+
   describe "created for someone (proxy)" do
     before do
       @transfer_to = FactoryGirl.find_or_create(:jill)

--- a/sufia-models/app/models/datastreams/fits_datastream.rb
+++ b/sufia-models/app/models/datastreams/fits_datastream.rb
@@ -144,42 +144,7 @@ class FitsDatastream < ActiveFedora::OmDatastream
     http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd",
                version: "0.6.0",
                timestamp: "1/25/12 11:04 AM") {
-        xml.identification {
-          xml.identity(format: '', mimetype: '',
-                       toolname: 'FITS', toolversion: '') {
-            xml.tool(toolname: '', toolversion: '')
-            xml.version(toolname: '', toolversion: '')
-            xml.externalIdentifier(toolname: '', toolversion: '')
-          }
-        }
-        xml.fileinfo {
-          xml.size(toolname: '', toolversion: '')
-          xml.creatingApplicatioName(toolname: '', toolversion: '',
-                                     status: '')
-          xml.lastmodified(toolname: '', toolversion: '', status: '')
-          xml.filepath(toolname: '', toolversion: '', status: '')
-          xml.filename(toolname: '', toolversion: '', status: '')
-          xml.md5checksum(toolname: '', toolversion: '', status: '')
-          xml.fslastmodified(toolname: '', toolversion: '', status: '')
-        }
-        xml.filestatus {
-          xml.tag! "well-formed", toolname: '', toolversion: '', status: ''
-          xml.valid(toolname: '', toolversion: '', status: '')
-        }
-        xml.metadata {
-          xml.document {
-            xml.title(toolname: '', toolversion: '', status: '')
-            xml.author(toolname: '', toolversion: '', status: '')
-            xml.pageCount(toolname: '', toolversion: '')
-            xml.isTagged(toolname: '', toolversion: '')
-            xml.hasOutline(toolname: '', toolversion: '')
-            xml.hasAnnotations(toolname: '', toolversion: '')
-            xml.isRightsManaged(toolname: '', toolversion: '',
-                                status: '')
-            xml.isProtected(toolname: '', toolversion: '')
-            xml.hasForms(toolname: '', toolversion: '', status: '')
-          }
-        }
+        xml.identification { xml.identity(toolname: 'FITS') }
       }
     end
     builder.doc


### PR DESCRIPTION
Currently blank strings are saved in place of empty arrays for null values as described in  #941 

Problems with `Collection` were only fixed in Sufia and not hydra-collections, because Sufia defines its own `collection_params` method and because `model_attributes` is available to remove the blank strings.

I'm not sure that the fix for `GenericFile` blanks removal is correct. I don't fully understand what the implications of removing a part of the `xml_template` from `FitsDatastream` are, but many terms were already missing from it so I just removed the rest of them. I couldn't pass few of the tests before and after the change because of incompatibilities with ImageMagic and ffmpeg but the numbers remained constant.

Closes #941