### PR TITLE
Rake task for deleting empty batches

### DIFF
--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -7,6 +7,7 @@ require File.expand_path('../locations', __FILE__)
 require File.expand_path('../poltergeist', __FILE__)
 require File.expand_path('../cleaner', __FILE__)
 require File.expand_path('../statistic_helper', __FILE__)
+require File.expand_path('../rake_output', __FILE__)
 
 RSpec.configure do |config|
   config.include Features::SessionHelpers, type: :feature

--- a/spec/support/rake_output.rb
+++ b/spec/support/rake_output.rb
@@ -1,0 +1,20 @@
+module RakeOutput
+
+  # saves original $stdout in variable
+  # set $stdout as local instance of StringIO
+  # yields to code execution
+  # returns the local instance of StringIO
+  # resets $stdout to original value
+  def capture_stdout
+    out = StringIO.new
+    $stdout = out
+    yield
+    return out.string
+  ensure
+    $stdout = STDOUT
+  end
+
+  RSpec.configure do |config|
+    config.include RakeOutput
+  end
+end

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'rake'
+
+describe "Rake tasks" do
+
+  describe "sufia:empty_batches" do
+    before do
+      load File.expand_path("../../../sufia-models/lib/tasks/batch_cleanup.rake", __FILE__)
+      Rake::Task.define_task(:environment)
+    end
+    after { Rake::Task["sufia:empty_batches"].reenable }
+    subject { capture_stdout { Rake::Task["sufia:empty_batches"].invoke } }
+    
+    context "without an empty batch" do
+      it { is_expected.to be_empty }
+    end
+    
+    context "with an empty batch" do
+      before { Batch.create("empty-batch") }
+      it { is_expected.to start_with("empty-batch contains no files - to delete, rerun with the remove option") }
+      
+      describe "removing the empty batch" do
+        subject { capture_stdout { Rake::Task["sufia:empty_batches"].invoke("remove") } }
+        it { is_expected.to start_with("empty-batch contains no files - deleted") }
+      end
+    end
+  end
+
+end

--- a/sufia-models/lib/tasks/batch_cleanup.rake
+++ b/sufia-models/lib/tasks/batch_cleanup.rake
@@ -1,0 +1,19 @@
+namespace :sufia do
+
+  desc "Reports on and optionally removes empty batches that contain no associated files"
+  task :empty_batches, [:remove] => :environment do |t, args|
+    option = args.to_hash.fetch(:remove, "keep")
+    Batch.all.each do |batch|
+      if batch.generic_files.empty?
+        print "#{batch.id} contains no files - "
+        if option == "remove"
+          batch.destroy
+          puts "deleted"
+        else
+          puts "to delete, rerun with the remove option: rake sufia:empty_batches[remove]"
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Addresses #915. While it's unlikely that users will find batches without any associated files, it can happen and a simple, default task for locating and deleting them is provided.