### PR TITLE
Blacklight's generator doesn't use a hashrocket

### DIFF
--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -77,7 +77,7 @@ module Sufia
 
     # The engine routes have to come after the devise routes so that /users/sign_in will work
     def inject_routes
-      gsub_file 'config/routes.rb', 'root :to => "catalog#index"', ''
+      gsub_file 'config/routes.rb', 'root to: "catalog#index"', ''
 
       routing_code = "\n  Hydra::BatchEdit.add_routes(self)\n" +
         "  # This must be the very last route in the file because it has a catch-all route for 404 errors.


### PR DESCRIPTION
This was breaking `rake engine_cart:generate` because Blacklight's original root path wasn't getting removed. The tests would then fail because there were two root paths.