### PR TITLE
Delay creation of batch until the user actually submits files. 

### DIFF
--- a/app/controllers/concerns/sufia/files_controller/browse_everything.rb
+++ b/app/controllers/concerns/sufia/files_controller/browse_everything.rb
@@ -13,6 +13,7 @@ module Sufia::FilesController
     protected
 
       def create_from_browse_everything(params)
+        Batch.find_or_create(params[:batch_id])        
         params[:selected_files].each_pair do |index, file_info| 
           next if file_info.blank? || file_info["url"].blank?
           create_file_from_url(file_info["url"], file_info["file_name"])
@@ -22,7 +23,7 @@ module Sufia::FilesController
       
       # Generic utility for creating GenericFile from a URL
       # Used in to import files using URLs from a file picker like browse_everything 
-      def create_file_from_url(url, file_name, batch_id=nil)
+      def create_file_from_url(url, file_name)
         generic_file = ::GenericFile.new(import_url: url, label: file_name).tap do |gf|
           actor = Sufia::GenericFile::Actor.new(gf, current_user)
           actor.create_metadata(params[:batch_id])

--- a/app/controllers/concerns/sufia/files_controller/local_ingest_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller/local_ingest_behavior.rb
@@ -44,6 +44,7 @@ module Sufia
           files << filename
         end
       end
+      Batch.find_or_create(params[:batch_id]) unless files.empty?
       files.each do |filename|
         ingest_one(filename, has_directories)
       end

--- a/app/controllers/concerns/sufia/files_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller_behavior.rb
@@ -48,7 +48,7 @@ module Sufia
 
     # routed to /files/new
     def new
-      @batch_id = Batch.create.id
+      @batch_id = Sufia::IdService.mint
     end
 
     # routed to /files/:id/edit
@@ -211,6 +211,9 @@ module Sufia
     end
 
     def process_file(file)
+
+      Batch.find_or_create(params[:batch_id])
+
       update_metadata_from_upload_screen
       actor.create_metadata(params[:batch_id])
       if actor.create_content(file, file.original_filename, file_path, file.content_type)

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -563,4 +563,27 @@ describe GenericFilesController do
       expect(user.mailbox.inbox[0].messages[0].subject).to eq "Test subject"
     end
   end
+
+  describe "batch creation" do
+    context "when uploading a file" do 
+      let(:batch_id) { Sufia::IdService.mint }
+      let(:file1) { fixture_file_upload('/world.png','image/png') }
+      let(:file2) { fixture_file_upload('/image.jpg','image/png') }
+
+      it "should not create the batch on HTTP GET " do
+        expect(Batch).to_not receive(:create)
+        xhr :get, :new 
+        expect(response).to be_success
+      end
+
+      it "should create the batch on HTTP POST with multiple files" do
+        expect(GenericFile).to receive(:new).twice
+        expect(Batch).to receive(:find_or_create).twice
+        xhr :post, :create, files: [file1], Filename: 'The world 1', batch_id: batch_id, on_behalf_of: 'carolyn', terms_of_service: '1'
+        expect(response).to be_success
+        xhr :post, :create, files: [file2], Filename: 'An image', batch_id: batch_id, on_behalf_of: 'carolyn', terms_of_service: '1'
+        expect(response).to be_success
+      end
+    end  
+  end
 end


### PR DESCRIPTION
This will reduce the number of orphan batches created since we won't create a new batch when the user issues an HTTP GET on the page, rather we will wait until the user issues an HTTP POST to the page which is more inline with the way HTTP calls are expected to behave.