### PR TITLE
Remove deprecation warnings

### DIFF
--- a/app/controllers/concerns/sufia/catalog.rb
+++ b/app/controllers/concerns/sufia/catalog.rb
@@ -2,7 +2,7 @@ module Sufia
   module Catalog
     extend ActiveSupport::Concern
     included do
-      self.solr_search_params_logic += [:only_generic_files_and_collections]
+      self.search_params_logic += [:only_generic_files_and_collections]
     end
 
     protected

--- a/app/controllers/concerns/sufia/catalog.rb
+++ b/app/controllers/concerns/sufia/catalog.rb
@@ -4,15 +4,5 @@ module Sufia
     included do
       self.search_params_logic += [:only_generic_files_and_collections]
     end
-
-    protected
-
-      # Limits search results just to GenericFiles and collections
-      # @param solr_parameters the current solr parameters
-      # @param user_parameters the current user-subitted parameters
-      def only_generic_files_and_collections(solr_parameters, user_parameters)
-        solr_parameters[:fq] ||= []
-        solr_parameters[:fq] << "#{Solrizer.solr_name("has_model", :symbol)}:(\"GenericFile\" \"Collection\")"
-      end
   end
 end

--- a/app/controllers/concerns/sufia/collections_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/collections_controller_behavior.rb
@@ -4,16 +4,13 @@ module Sufia
     include Hydra::CollectionsControllerBehavior
 
     included do
-      include Blacklight::Catalog::SearchContext
-      include BlacklightAdvancedSearch::ParseBasicQ
-      include BlacklightAdvancedSearch::Controller
       include Sufia::Breadcrumbs
 
       before_filter :filter_docs_with_read_access!, except: :show
       before_filter :has_access?, except: :show
       before_filter :build_breadcrumbs, only: [:edit, :show]
 
-      self.search_params_logic += [:add_access_controls_to_solr_params]
+      self.search_params_logic += [:add_access_controls_to_solr_params, :add_advanced_parse_q_to_solr]
 
       layout "sufia-one-column"
     end
@@ -58,7 +55,7 @@ module Sufia
 
     def query_collection_members
       flash[:notice]=nil if flash[:notice] == "Select something first"
-      query = params[:cq]
+      params[:q] = params[:cq]
       super
     end
 

--- a/app/controllers/concerns/sufia/collections_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/collections_controller_behavior.rb
@@ -43,6 +43,10 @@ module Sufia
       Sufia::CollectionPresenter
     end
 
+    def collection_member_search_builder_class
+      Sufia::SearchBuilder
+    end
+
     def collection_params
       form_class.model_attributes(
         params.require(:collection).permit(:title, :description, :members, part_of: [],

--- a/app/controllers/concerns/sufia/collections_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/collections_controller_behavior.rb
@@ -13,7 +13,7 @@ module Sufia
       before_filter :has_access?, except: :show
       before_filter :build_breadcrumbs, only: [:edit, :show]
 
-      self.solr_search_params_logic += [:add_access_controls_to_solr_params]
+      self.search_params_logic += [:add_access_controls_to_solr_params]
 
       layout "sufia-one-column"
     end

--- a/app/controllers/concerns/sufia/homepage_controller.rb
+++ b/app/controllers/concerns/sufia/homepage_controller.rb
@@ -9,7 +9,7 @@ module Sufia::HomepageController
     include Blacklight::SearchHelper
     include Hydra::Controller::SearchBuilder
 
-    self.search_params_logic += [:only_generic_files, :add_access_controls_to_solr_params]
+    self.search_params_logic += [:show_only_generic_files, :add_access_controls_to_solr_params]
     layout 'homepage'
   end
 
@@ -25,19 +25,11 @@ module Sufia::HomepageController
 
   def recent
     # grab any recent documents
-    (_, @recent_documents) = get_search_results(q: '', sort:sort_field, rows: 4)
+    (_, @recent_documents) = search_results({q: '', sort:sort_field, rows: 4}, search_params_logic)
   end
 
   def sort_field
     "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)} desc"
-  end
-
-  # Limits search results just to GenericFiles
-  # @param solr_parameters the current solr parameters
-  # @param user_parameters the current user-subitted parameters
-  def only_generic_files(solr_parameters, user_parameters)
-    solr_parameters[:fq] ||= []
-    solr_parameters[:fq] << "#{Solrizer.solr_name("has_model", :symbol)}:\"GenericFile\""
   end
 
 end

--- a/app/controllers/concerns/sufia/homepage_controller.rb
+++ b/app/controllers/concerns/sufia/homepage_controller.rb
@@ -6,10 +6,10 @@ module Sufia::HomepageController
     include Hydra::Controller::ControllerBehavior
     include Blacklight::Catalog::SearchContext
     include Sufia::Controller
-    include Blacklight::SolrHelper
+    include Blacklight::SearchHelper
     include Hydra::Controller::SearchBuilder
 
-    self.solr_search_params_logic += [:only_generic_files, :add_access_controls_to_solr_params]
+    self.search_params_logic += [:only_generic_files, :add_access_controls_to_solr_params]
     layout 'homepage'
   end
 

--- a/app/controllers/concerns/sufia/my_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/my_controller_behavior.rb
@@ -11,17 +11,13 @@ module Sufia
       include Blacklight::Configurable
 
       self.copy_blacklight_config_from(CatalogController)
-
-      include BlacklightAdvancedSearch::ParseBasicQ
-      include BlacklightAdvancedSearch::Controller
       
       before_filter :authenticate_user!
       before_filter :enforce_show_permissions, only: :show
       before_filter :enforce_viewing_context_for_show_requests, only: :show
       before_filter :find_collections, only: :index
 
-      # This applies appropriate access controls to all solr queries (the internal method of this is overidden bellow to only include edit files)
-      self.search_params_logic += [:add_access_controls_to_solr_params]
+      self.search_params_logic += [:add_access_controls_to_solr_params, :add_advanced_parse_q_to_solr]
 
       layout 'sufia-dashboard'
     end

--- a/app/controllers/concerns/sufia/my_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/my_controller_behavior.rb
@@ -33,7 +33,7 @@ module Sufia
     end
 
     def index
-      (@response, @document_list) = get_search_results
+      (@response, @document_list) = search_results(params, search_params_logic)
       @user = current_user
       @events = @user.events(100)
       @last_event_timestamp = @user.events.first[:timestamp].to_i || 0 rescue 0
@@ -63,20 +63,6 @@ module Sufia
     # show only files with edit permissions in lib/hydra/access_controls_enforcement.rb apply_gated_discovery
     def discovery_permissions
       ["edit"]
-    end
-
-    def show_only_files_deposited_by_current_user solr_parameters, user_parameters
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] += [
-        ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user.user_key)
-      ]
-    end
-
-    def show_only_generic_files solr_parameters, user_parameters
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] += [
-        ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::GenericFile.to_class_uri)
-      ]
     end
 
   end

--- a/app/controllers/concerns/sufia/my_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/my_controller_behavior.rb
@@ -21,7 +21,7 @@ module Sufia
       before_filter :find_collections, only: :index
 
       # This applies appropriate access controls to all solr queries (the internal method of this is overidden bellow to only include edit files)
-      self.solr_search_params_logic += [:add_access_controls_to_solr_params]
+      self.search_params_logic += [:add_access_controls_to_solr_params]
 
       layout 'sufia-dashboard'
     end

--- a/app/controllers/my/collections_controller.rb
+++ b/app/controllers/my/collections_controller.rb
@@ -1,7 +1,7 @@
 module My
   class CollectionsController < MyController
 
-    self.solr_search_params_logic += [
+    self.search_params_logic += [
       :show_only_collections
     ]
 

--- a/app/controllers/my/collections_controller.rb
+++ b/app/controllers/my/collections_controller.rb
@@ -5,13 +5,6 @@ module My
       :show_only_collections
     ]
 
-    def show_only_collections(solr_parameters, user_parameters)
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] += [
-        ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Collection.to_class_uri)
-      ]
-    end
-
     def index
       super
       @selected_tab = :collections

--- a/app/controllers/my/files_controller.rb
+++ b/app/controllers/my/files_controller.rb
@@ -1,7 +1,7 @@
 module My
   class FilesController < MyController
 
-    self.solr_search_params_logic += [
+    self.search_params_logic += [
       :show_only_files_deposited_by_current_user,
       :show_only_generic_files
     ]

--- a/app/controllers/my/highlights_controller.rb
+++ b/app/controllers/my/highlights_controller.rb
@@ -5,14 +5,6 @@ module My
       :show_only_highlighted_files
     ]
 
-    def show_only_highlighted_files(solr_parameters, user_parameters)
-      ids = current_user.trophies.pluck(:generic_file_id)
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] += [
-        ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)
-      ]
-    end
-
     def index
       super
       @selected_tab = :highlighted

--- a/app/controllers/my/highlights_controller.rb
+++ b/app/controllers/my/highlights_controller.rb
@@ -1,7 +1,7 @@
 module My
   class HighlightsController < MyController
 
-    self.solr_search_params_logic += [
+    self.search_params_logic += [
       :show_only_highlighted_files
     ]
 

--- a/app/controllers/my/shares_controller.rb
+++ b/app/controllers/my/shares_controller.rb
@@ -6,13 +6,6 @@ module My
       :show_only_generic_files
     ]
 
-    def show_only_shared_files(solr_parameters, user_parameters)
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] += [
-        "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: current_user.user_key)
-      ]
-    end
-
     def index
       super
       @selected_tab = :shared

--- a/app/controllers/my/shares_controller.rb
+++ b/app/controllers/my/shares_controller.rb
@@ -1,7 +1,7 @@
 module My
   class SharesController < MyController
 
-    self.solr_search_params_logic += [
+    self.search_params_logic += [
       :show_only_shared_files,
       :show_only_generic_files
     ]

--- a/app/search_builders/sufia/search_builder.rb
+++ b/app/search_builders/sufia/search_builder.rb
@@ -1,0 +1,50 @@
+class Sufia::SearchBuilder < Hydra::SearchBuilder
+
+  include BlacklightAdvancedSearch::AdvancedSearchBuilder
+  include Hydra::Collections::SearchBehaviors
+
+  def show_only_collections(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Collection.to_class_uri)
+    ]
+  end
+
+  def show_only_files_deposited_by_current_user(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: scope.current_user.user_key)
+    ]
+  end
+
+  def show_only_generic_files(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::GenericFile.to_class_uri)
+    ]
+  end
+
+  def show_only_shared_files(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: scope.current_user.user_key)
+    ]
+  end
+
+  def show_only_highlighted_files(solr_parameters)
+    ids = scope.current_user.trophies.pluck(:generic_file_id)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)
+    ]
+  end
+
+  # Limits search results just to GenericFiles and collections
+  # @param solr_parameters the current solr parameters
+  # @param user_parameters the current user-subitted parameters
+  def only_generic_files_and_collections(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << "#{Solrizer.solr_name("has_model", :symbol)}:(\"GenericFile\" \"Collection\")"
+  end
+
+end

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -29,7 +29,7 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
-    config.search_builder_class = Hydra::SearchBuilder
+    config.search_builder_class = Sufia::SearchBuilder
     #Show gallery view
     config.view.gallery.partials = [:index_header, :index]
     config.view.slideshow.partials = [:index]

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -10,13 +10,12 @@ require 'parsing_nesting/tree'
 class CatalogController < ApplicationController
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
-  include BlacklightAdvancedSearch::ParseBasicQ
   include Sufia::Catalog
 
   # These before_filters apply the hydra access controls
   before_filter :enforce_show_permissions, only: :show
   # This applies appropriate access controls to all solr queries
-  CatalogController.search_params_logic += [:add_access_controls_to_solr_params]
+  CatalogController.search_params_logic += [:add_access_controls_to_solr_params, :add_advanced_parse_q_to_solr]
 
   skip_before_filter :default_html_head
 

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -58,7 +58,6 @@ describe CollectionsController do
     end
 
     it "should add docs to the collection if a batch id is provided and add the collection id to the documents in the collection" do
-      pending "Change test because we don't re-index member documents anymore?"
       @asset1 = GenericFile.new(title: ["First of the Assets"])
       @asset1.apply_depositor_metadata(user.user_key)
       @asset1.save
@@ -98,7 +97,6 @@ describe CollectionsController do
       end
 
       it "should set collection on members" do
-        pending "Change test because we don't re-index member documents anymore?"
         put :update, id: collection, collection: {members:"add"}, batch_document_ids: [@asset3.id, @asset1.id, @asset2.id]
         expect(response).to redirect_to routes.url_helpers.collection_path(collection)
         expect(assigns[:collection].members).to match_array [@asset2, @asset3, @asset1]

--- a/sufia-models/app/models/concerns/sufia/generic_file/full_text_indexing.rb
+++ b/sufia-models/app/models/concerns/sufia/generic_file/full_text_indexing.rb
@@ -14,21 +14,30 @@ module Sufia
 
       private
 
-        def extract_content
-          url = Blacklight.solr_config[:url] ? Blacklight.solr_config[:url] : Blacklight.solr_config["url"] ? Blacklight.solr_config["url"] : Blacklight.solr_config[:fulltext] ? Blacklight.solr_config[:fulltext]["url"] : Blacklight.solr_config[:default]["url"]
-          uri = URI("#{url}/update/extract?extractOnly=true&wt=json&extractFormat=text")
-          req = Net::HTTP.new(uri.host, uri.port)
-          resp = req.post(uri.to_s, self.content.content, {
-              'Content-type' => "#{self.mime_type};charset=utf-8",
-              'Content-Length' => self.content.content.size.to_s
-            })
-          raise "URL '#{uri}' returned code #{resp.code}" unless resp.code == "200"
-          self.content.content.rewind if self.content.content.respond_to?(:rewind)
-          extracted_text = JSON.parse(resp.body)[''].rstrip
-          full_text.content = extracted_text if extracted_text.present?
-        rescue => e
-          logger.error("Error extracting content from #{self.id}: #{e.inspect}")
+      def extract_content
+        uri = URI("#{connection_url}/update/extract?extractOnly=true&wt=json&extractFormat=text")
+        req = Net::HTTP.new(uri.host, uri.port)
+        resp = req.post(uri.to_s, self.content.content, {
+            'Content-type' => "#{self.mime_type};charset=utf-8",
+            'Content-Length' => self.content.content.size.to_s
+          })
+        raise "URL '#{uri}' returned code #{resp.code}" unless resp.code == "200"
+        self.content.content.rewind if self.content.content.respond_to?(:rewind)
+        extracted_text = JSON.parse(resp.body)[''].rstrip
+        full_text.content = extracted_text if extracted_text.present?
+      rescue => e
+        logger.error("Error extracting content from #{self.id}: #{e.inspect}")
+      end
+
+      def connection_url
+        case
+          when Blacklight.connection_config[:url] then Blacklight.connection_config[:url]
+          when Blacklight.connection_config["url"] then Blacklight.connection_config["url"]
+          when Blacklight.connection_config[:fulltext] then Blacklight.connection_config[:fulltext]["url"]
+          else Blacklight.connection_config[:default]["url"]
         end
+      end
+
     end
   end
 end

--- a/sufia-models/app/models/proxy_deposit_request.rb
+++ b/sufia-models/app/models/proxy_deposit_request.rb
@@ -1,5 +1,5 @@
 class ProxyDepositRequest < ActiveRecord::Base
-  include Blacklight::SolrHelper
+  include Blacklight::SearchHelper
   include ActionView::Helpers::UrlHelper
 
   belongs_to :receiving_user, class_name: 'User'

--- a/sufia-models/app/services/sufia/generic_file_indexing_service.rb
+++ b/sufia-models/app/services/sufia/generic_file_indexing_service.rb
@@ -6,7 +6,6 @@ module Sufia
         solr_doc[Solrizer.solr_name('file_format')] = object.file_format
         solr_doc[Solrizer.solr_name('file_format', :facetable)] = object.file_format
         solr_doc['all_text_timv'] = object.full_text.content
-        solr_doc = object.index_collection_ids(solr_doc)
       end
     end
   end

--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "hydra-head", "~> 9.0"
   spec.add_dependency "active-fedora", "~> 9.0"
-  spec.add_dependency "hydra-collections", "~> 5.0"
+  spec.add_dependency "hydra-collections", [">= 5.0.2", "< 6.0"]
   spec.add_dependency 'hydra-derivatives', '~> 1.0'
   spec.add_dependency 'nest', '~> 1.1'
   spec.add_dependency 'resque', '~> 1.23'

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'Apache2'
 
   gem.add_dependency 'sufia-models', version
-  gem.add_dependency 'blacklight_advanced_search', '~> 5.1'
+  gem.add_dependency 'blacklight_advanced_search', ['>= 5.1.4', '< 6.0']
   gem.add_dependency 'blacklight', '~> 5.10'
   gem.add_dependency 'tinymce-rails', '~> 4.0.19'
   gem.add_dependency 'tinymce-rails-imageupload', '~> 4.0.16.beta'


### PR DESCRIPTION
This preps Sufia for Blacklight 6.0 and removes deprecation warnings. Note, this PR depends on updates in projecthydra-labs/hydra-collections#74 and projectblacklight/blacklight_advanced_search#35 and shouldn't be merged until those are addressed and new gems have been released.