### PR TITLE
Hide Buttons When No Permission

### DIFF
--- a/app/views/dashboard/_index_partials/_heading_actions.html.erb
+++ b/app/views/dashboard/_index_partials/_heading_actions.html.erb
@@ -1,16 +1,18 @@
 <div class="col-xs-12 heading-row">
-  <div class="col-xs-6 col-sm-3 heading-tile">
-    <%= link_to sufia.new_generic_file_path do %>
-        <span class="glyphicon glyphicon-upload"></span>
-        <%= t("sufia.dashboard.upload") %>
-    <% end %>
-  </div>
-  <div class="col-xs-6 col-sm-3 heading-tile">
-    <%= link_to collections.new_collection_path, id: "hydra-collection-add" do %>
-        <span class="glyphicon glyphicon-plus"></span>
-        <%= t("sufia.dashboard.create_collection") %>
-    <% end %>
-  </div>
+  <% if can?(:create, GenericFile) %>
+    <div class="col-xs-6 col-sm-3 heading-tile">
+      <%= link_to sufia.new_generic_file_path do %>
+          <span class="glyphicon glyphicon-upload"></span>
+          <%= t("sufia.dashboard.upload") %>
+      <% end %>
+    </div>
+    <div class="col-xs-6 col-sm-3 heading-tile">
+      <%= link_to collections.new_collection_path, id: "hydra-collection-add" do %>
+          <span class="glyphicon glyphicon-plus"></span>
+          <%= t("sufia.dashboard.create_collection") %>
+      <% end %>
+    </div>
+  <% end  %>
   <div class="col-xs-6 col-sm-3 heading-tile">
     <%= link_to sufia.dashboard_collections_path, id: "hydra-collection-view" do %>
         <span class="glyphicon glyphicon-th"></span>

--- a/app/views/dashboard/_index_partials/_heading_actions.html.erb
+++ b/app/views/dashboard/_index_partials/_heading_actions.html.erb
@@ -6,6 +6,8 @@
           <%= t("sufia.dashboard.upload") %>
       <% end %>
     </div>
+  <% end %>
+  <% if can?(:create, Collection) %>
     <div class="col-xs-6 col-sm-3 heading-tile">
       <%= link_to collections.new_collection_path, id: "hydra-collection-add" do %>
           <span class="glyphicon glyphicon-plus"></span>

--- a/app/views/homepage/_home_header.html.erb
+++ b/app/views/homepage/_home_header.html.erb
@@ -1,12 +1,11 @@
 <div class="home_call_action col-xs-12 col-sm-4 pull-right">
-  <div class="home_share_work">
-    <%= link_to "<i class=\"glyphicon glyphicon-upload\"></i> #{t('sufia.share_button')}".html_safe, sufia.new_generic_file_path, class: "btn btn-primary btn-lg btn-block", id: "contribute_link" %>
-    <p class="text-center"><a href="/terms/">Terms of Use</a></p>
-  </div><!-- /.home_share_work -->
+  <% if can?(:view_upload) %>
+    <div class="home_share_work">
+      <%= link_to "<i class=\"glyphicon glyphicon-upload\"></i> #{t('sufia.share_button')}".html_safe, sufia.new_generic_file_path, class: "btn btn-primary btn-lg btn-block", id: "contribute_link" %>
+      <p class="text-center"><a href="/terms/">Terms of Use</a></p>
+    </div><!-- /.home_share_work -->
+  <% end %>
 </div><!-- /.col-xs-3 -->
 <div class="col-xs-12 col-sm-8">
   <%= render partial: "marketing" %>
 </div>
-
-
-

--- a/app/views/homepage/_home_header.html.erb
+++ b/app/views/homepage/_home_header.html.erb
@@ -1,5 +1,5 @@
 <div class="home_call_action col-xs-12 col-sm-4 pull-right">
-  <% if can?(:view_upload) %>
+  <% if can?(:view_upload, GenericFile) %>
     <div class="home_share_work">
       <%= link_to "<i class=\"glyphicon glyphicon-upload\"></i> #{t('sufia.share_button')}".html_safe, sufia.new_generic_file_path, class: "btn btn-primary btn-lg btn-block", id: "contribute_link" %>
       <p class="text-center"><a href="/terms/">Terms of Use</a></p>

--- a/app/views/homepage/_home_header.html.erb
+++ b/app/views/homepage/_home_header.html.erb
@@ -1,5 +1,5 @@
 <div class="home_call_action col-xs-12 col-sm-4 pull-right">
-  <% if can?(:view_upload, GenericFile) %>
+  <% if can?(:view_share_work, GenericFile) %>
     <div class="home_share_work">
       <%= link_to "<i class=\"glyphicon glyphicon-upload\"></i> #{t('sufia.share_button')}".html_safe, sufia.new_generic_file_path, class: "btn btn-primary btn-lg btn-block", id: "contribute_link" %>
       <p class="text-center"><a href="/terms/">Terms of Use</a></p>

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -10,7 +10,7 @@ describe Sufia::Ability, :type => :model do
     it { is_expected.not_to be_able_to(:create, ContentBlock) }
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
     it { is_expected.to     be_able_to(:read,  ContentBlock) }
-    it { is_expected.to     be_able_to(:view_upload, GenericFile) }
+    it { is_expected.to     be_able_to(:view_share_work, GenericFile) }
   end
 
   describe "a registered user" do
@@ -21,7 +21,7 @@ describe Sufia::Ability, :type => :model do
     it { is_expected.not_to be_able_to(:create, ContentBlock) }
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
     it { is_expected.to     be_able_to(:read,  ContentBlock) }
-    it { is_expected.to     be_able_to(:view_upload, GenericFile) }
+    it { is_expected.to     be_able_to(:view_share_work, GenericFile) }
   end
 
   describe "a user in the admin group" do
@@ -33,7 +33,7 @@ describe Sufia::Ability, :type => :model do
     it { is_expected.to be_able_to(:create, ContentBlock) }
     it { is_expected.to be_able_to(:update, ContentBlock) }
     it { is_expected.to be_able_to(:read,  ContentBlock) }
-    it { is_expected.to     be_able_to(:view_upload, GenericFile) }
+    it { is_expected.to     be_able_to(:view_share_work, GenericFile) }
   end
 
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -10,6 +10,7 @@ describe Sufia::Ability, :type => :model do
     it { is_expected.not_to be_able_to(:create, ContentBlock) }
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
     it { is_expected.to     be_able_to(:read,  ContentBlock) }
+    it { is_expected.to     be_able_to(:view_upload, GenericFile) }
   end
 
   describe "a registered user" do
@@ -20,6 +21,7 @@ describe Sufia::Ability, :type => :model do
     it { is_expected.not_to be_able_to(:create, ContentBlock) }
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
     it { is_expected.to     be_able_to(:read,  ContentBlock) }
+    it { is_expected.to     be_able_to(:view_upload, GenericFile) }
   end
 
   describe "a user in the admin group" do
@@ -31,6 +33,7 @@ describe Sufia::Ability, :type => :model do
     it { is_expected.to be_able_to(:create, ContentBlock) }
     it { is_expected.to be_able_to(:update, ContentBlock) }
     it { is_expected.to be_able_to(:read,  ContentBlock) }
+    it { is_expected.to     be_able_to(:view_upload, GenericFile) }
   end
 
 

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -15,11 +15,15 @@ describe "dashboard/index.html.erb", :type => :view do
     allow(@user).to receive(:total_file_views).and_return(1)
     allow(@user).to receive(:total_file_downloads).and_return(3)
     allow(controller).to receive(:current_user).and_return(@user)
+    @ability = instance_double("Ability")
+    allow(controller).to receive(:current_ability).and_return(@ability)
+    allow(@ability).to receive(:can?).with(:create, GenericFile).and_return(can_create_file)
     allow(view).to receive(:number_of_files).and_return("15")
     allow(view).to receive(:number_of_collections).and_return("3")
     assign(:activity, [])
     assign(:notifications, [])
   end
+  let(:can_create_file) { true }
 
   describe "heading" do
 
@@ -34,6 +38,14 @@ describe "dashboard/index.html.erb", :type => :view do
       expect(@heading).to have_link("View Files", sufia.dashboard_files_path)
       expect(@heading).to include "My Dashboard"
       expect(@heading).to include "Hello, Charles Francis Xavier"
+    end
+
+    context "when the user can't create files" do
+      let(:can_create_file) { false }
+      it "should not display the create buttons" do
+        expect(@heading).not_to have_link("Upload", sufia.new_generic_file_path)
+        expect(@heading).not_to have_link("Create Collection", collections.new_collection_path)
+      end
     end
 
   end

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -18,12 +18,14 @@ describe "dashboard/index.html.erb", :type => :view do
     @ability = instance_double("Ability")
     allow(controller).to receive(:current_ability).and_return(@ability)
     allow(@ability).to receive(:can?).with(:create, GenericFile).and_return(can_create_file)
+    allow(@ability).to receive(:can?).with(:create, Collection).and_return(can_create_collection)
     allow(view).to receive(:number_of_files).and_return("15")
     allow(view).to receive(:number_of_collections).and_return("3")
     assign(:activity, [])
     assign(:notifications, [])
   end
   let(:can_create_file) { true }
+  let(:can_create_collection) { true }
 
   describe "heading" do
 
@@ -42,8 +44,13 @@ describe "dashboard/index.html.erb", :type => :view do
 
     context "when the user can't create files" do
       let(:can_create_file) { false }
-      it "should not display the create buttons" do
+      it "should not display the upload button" do
         expect(@heading).not_to have_link("Upload", sufia.new_generic_file_path)
+      end
+    end
+    context "when the user can't create collections" do
+      let(:can_create_collection) { false }
+      it "should not display the create collection button" do
         expect(@heading).not_to have_link("Create Collection", collections.new_collection_path)
       end
     end

--- a/spec/views/homepage/_home_header.html.erb_spec.rb
+++ b/spec/views/homepage/_home_header.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe "homepage/_home_header.html.erb" do
+  let(:groups) { [] }
+  let(:ability) { instance_double("Ability") }
+  describe "share your work button" do
+    before do
+      allow(controller).to receive(:current_ability).and_return(ability)
+      allow(ability).to receive(:can?).with(:view_upload).and_return(can_view_upload)
+      stub_template "homepage/_marketing" => "marketing"
+      render
+    end
+    context "when the user can view" do
+      let(:can_view_upload) { true }
+      it "should display" do
+        expect(rendered).to have_content t("sufia.share_button")
+      end
+    end
+    context "when the user can't view" do
+      let(:can_view_upload) { false }
+      it "should not display" do
+        expect(rendered).not_to have_content t("sufia.share_button")
+      end
+    end
+  end
+end

--- a/spec/views/homepage/_home_header.html.erb_spec.rb
+++ b/spec/views/homepage/_home_header.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "homepage/_home_header.html.erb" do
   describe "share your work button" do
     before do
       allow(controller).to receive(:current_ability).and_return(ability)
-      allow(ability).to receive(:can?).with(:view_upload).and_return(can_view_upload)
+      allow(ability).to receive(:can?).with(:view_upload, GenericFile).and_return(can_view_upload)
       stub_template "homepage/_marketing" => "marketing"
       render
     end

--- a/spec/views/homepage/_home_header.html.erb_spec.rb
+++ b/spec/views/homepage/_home_header.html.erb_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe "homepage/_home_header.html.erb" do
   describe "share your work button" do
     before do
       allow(controller).to receive(:current_ability).and_return(ability)
-      allow(ability).to receive(:can?).with(:view_upload, GenericFile).and_return(can_view_upload)
+      allow(ability).to receive(:can?).with(:view_share_work, GenericFile).and_return(can_view_share_work)
       stub_template "homepage/_marketing" => "marketing"
       render
     end
     context "when the user can view" do
-      let(:can_view_upload) { true }
+      let(:can_view_share_work) { true }
       it "should display" do
         expect(rendered).to have_content t("sufia.share_button")
       end
     end
     context "when the user can't view" do
-      let(:can_view_upload) { false }
+      let(:can_view_share_work) { false }
       it "should not display" do
         expect(rendered).not_to have_content t("sufia.share_button")
       end

--- a/sufia-models/app/models/concerns/sufia/ability.rb
+++ b/sufia-models/app/models/concerns/sufia/ability.rb
@@ -35,6 +35,7 @@ module Sufia
     end
 
     def generic_file_abilities
+      can :view_upload, [GenericFile]
       can :create, [GenericFile, Collection] if user_groups.include? 'registered'
     end
 

--- a/sufia-models/app/models/concerns/sufia/ability.rb
+++ b/sufia-models/app/models/concerns/sufia/ability.rb
@@ -35,7 +35,7 @@ module Sufia
     end
 
     def generic_file_abilities
-      can :view_upload, [GenericFile]
+      can :view_share_work, [GenericFile]
       can :create, [GenericFile, Collection] if user_groups.include? 'registered'
     end
 


### PR DESCRIPTION
This hides the create file/collection buttons when there's no permission to access them. It also lets you configure whether or not to show the "Share Your Work" button.