### PR TITLE
Migrate pids in audit logs and proxy requests, fixes #853

### DIFF
--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -26,4 +26,33 @@ describe "Rake tasks" do
     end
   end
 
+  describe "sufia:migrate" do
+    let(:namespaced_pid) { "sufia:123" }
+    let(:corrected_pid)  { "123" }
+    before do
+      load File.expand_path("../../../sufia-models/lib/tasks/migrate.rake", __FILE__)
+      Rake::Task.define_task(:environment)
+    end
+
+    describe "deleting the namespace from ProxyDepositRequest#pid" do
+      let(:sender) { FactoryGirl.find_or_create(:jill) }
+      let(:receiver) { FactoryGirl.find_or_create(:archivist) }
+      before do
+        ProxyDepositRequest.create(pid: namespaced_pid, sending_user: sender, receiving_user: receiver, sender_comment: "please take this")
+        Rake::Task["sufia:migrate:proxy_deposits"].invoke
+      end
+      subject { ProxyDepositRequest.first.pid }
+      it { is_expected.to eql corrected_pid }
+    end
+
+    describe "deleting the namespace from ChecksumAuditLog#pid" do
+      before do
+        ChecksumAuditLog.create(pid: namespaced_pid)
+        Rake::Task["sufia:migrate:audit_logs"].invoke
+      end
+      subject { ChecksumAuditLog.first.pid }
+      it { is_expected.to eql corrected_pid }
+    end
+  end
+
 end

--- a/sufia-models/lib/tasks/migrate.rake
+++ b/sufia-models/lib/tasks/migrate.rake
@@ -1,0 +1,21 @@
+ namespace :sufia do
+  namespace :migrate do
+
+    desc "Migrate proxy deposits"
+    task proxy_deposits: :environment do
+      ProxyDepositRequest.all.each do |pd|
+        pd.pid = pd.pid.delete "#{Sufia.config.redis_namespace}:"
+        pd.save
+      end
+    end
+
+    desc "Migrate audit logs"
+    task audit_logs: :environment do
+      ChecksumAuditLog.all.each do |cs|
+        cs.pid = cs.pid.delete "#{Sufia.config.redis_namespace}:"
+        cs.save
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
These rake tasks would be used as part of the Sufia 4.x/5.x to 6 migration process.