### PR TITLE
Replaces redundant title attribute with more beneficial text for all ...

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -162,9 +162,9 @@ module Sufia
       if document.registered?
         content_tag :span, t('sufia.institution_name'), class: "label label-info", title: t('sufia.institution_name')
       elsif document.public?
-        content_tag :span, t('sufia.visibility.open'), class: "label label-success", title: t('sufia.visibility.open')
+        content_tag :span, t('sufia.visibility.open'), class: "label label-success", title: t('sufia.visibility.open_title_attr')
       else
-        content_tag :span, t('sufia.visibility.private'), class: "label label-danger", title: t('sufia.visibility.private')
+        content_tag :span, t('sufia.visibility.private'), class: "label label-danger", title: t('sufia.visibility.private_title_attr')
       end
     end
 

--- a/app/views/collections/_show_document_list_row.html.erb
+++ b/app/views/collections/_show_document_list_row.html.erb
@@ -29,9 +29,9 @@
       <% if document.registered? %>
         <span class="label label-info" title="<%= t('sufia.institution_name') %>"><%= t('sufia.institution_name') %></span>
       <% elsif document.public? %>
-        <span class="label label-success" title="Open Access">Open Access</span>
+        <span class="label label-success" title="<%= t('sufia.visibility.open_title_attr') %>"><%= t('sufia.visibility.open') %></span>
       <% else %>
-        <span class="label label-danger" title="Private">Private</span>
+        <span class="label label-danger" title="<%= t('sufia.visibility.private_title_attr') %>"><%= t('sufia.visibility.private') %></span>
       <% end %>
     </a>
   </td>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -128,6 +128,8 @@ en:
     visibility:
       open: "Open Access"
       private: "Private"
+      open_title_attr: "Change the visibility of this resource"
+      private_title_attr: "Change the visibility of this resource"
     user_profile:
       no_followers: "No one is following you."
       no_following: "You are not following anyone."

--- a/spec/views/generic_file/show.html.erb_spec.rb
+++ b/spec/views/generic_file/show.html.erb_spec.rb
@@ -270,7 +270,7 @@ describe 'generic_files/show.html.erb', :type => :view do
       render
     end
     it "should display the visibility badge" do
-      expect(rendered).to include('<span class="label label-danger" title="'+t('sufia.visibility.private')+'">'+t('sufia.visibility.private')+'</span></a>')
+      expect(rendered).to include('<span class="label label-danger" title="'+t('sufia.visibility.private_title_attr')+'">'+t('sufia.visibility.private')+'</span></a>')
     end
   end
 


### PR DESCRIPTION
users. Instead of just repeating the text that is the main link text in the title attribute, replace it with advisory information that informs users that they can change the permissions or visibility of the resource by selecting the link.