### PR TITLE
Only display upload link if you have permission

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -9,7 +9,9 @@
       <% end %>
       <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#"><span class="sr-only">select for additional menu options</span><span class="caret" ></span></a>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
-        <li><%= link_to raw('<span class="glyphicon glyphicon-upload"></span> upload'), sufia.new_generic_file_path, id: 'upload_nav_link' %></li>
+        <% if can? :create, GenericFile %>
+          <li><%= link_to raw('<span class="glyphicon glyphicon-upload"></span> upload'), sufia.new_generic_file_path, id: 'upload_nav_link' %></li>
+        <% end %>
         <li><%= link_to raw('<span class="glyphicon glyphicon-user"></span> my profile'), sufia.profile_path(current_user), id: 'profile_nav_link' %></li>
         <%= render partial: 'users/user_util_links_extra' %>
         <li class="divider"></li>

--- a/spec/views/users/_user_util_links.html.erb_spec.rb
+++ b/spec/views/users/_user_util_links.html.erb_spec.rb
@@ -6,8 +6,11 @@ describe '/_user_util_links.html.erb', :type => :view do
   before do
     allow(view).to receive(:user_signed_in?).and_return(true)
     allow(view).to receive(:current_user).and_return(stub_model(User, user_key: 'userX'))
+    allow(view).to receive(:can?).with(:create, GenericFile).and_return(can_create_file)
     assign :notify_number, 8
   end
+
+  let(:can_create_file) { true }
 
   it 'should have link to dashboard' do
     render
@@ -19,6 +22,23 @@ describe '/_user_util_links.html.erb', :type => :view do
     render
     page = Capybara::Node::Simple.new(rendered)
     expect(page).to have_link('my profile', href: '/users/userX')
+  end
+
+  describe "upload button" do
+    before do
+      render
+    end
+    context "when the user can create generic files" do
+      it "should have a link to upload" do
+        expect(rendered).to have_link('upload', href: '/files/new')
+      end
+    end
+    context "when the user can't create generic files" do
+      let(:can_create_file) { false }
+      it "should not have a link to upload" do
+        expect(rendered).not_to have_link('upload')
+      end
+    end
   end
 
 end


### PR DESCRIPTION
The upload link in the user menu bar would show whether or not you have permission - this hides it.