### PR TITLE
Prevent from picking up Blacklight 5.10 

### DIFF
--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'sufia-models', version
   gem.add_dependency 'blacklight_advanced_search', '~> 5.0'
-  gem.add_dependency 'blacklight', '~> 5.5'
+  gem.add_dependency 'blacklight', '~> 5.5', '< 5.10'
   gem.add_dependency 'tinymce-rails', '~> 4.0.19'
   gem.add_dependency 'tinymce-rails-imageupload', '~> 4.0.16.beta'
 


### PR DESCRIPTION
Blacklight 5.10 does not work out of the box with this version of Sufia. 
