### PR TITLE
Use the label instead of the file_name, #981

### DIFF
--- a/spec/actors/generic_file/actor_spec.rb
+++ b/spec/actors/generic_file/actor_spec.rb
@@ -20,6 +20,20 @@ describe Sufia::GenericFile::Actor do
       actor.create_content(uploaded_file, 'world.png', 'content', 'image/png')
     end
 
+    context "when generic_file.title is empty and generic_file.label is not" do
+      let(:file)       { "world.png" }
+      let(:long_name)  { "an absurdly long title that goes on way to long and messes up the display of the page which should not need to be this big in order to show this impossibly long, long, long, oh so long string" }
+      let(:short_name) { "Nice Short Name" }
+      let(:actor)      { Sufia::GenericFile::Actor.new(generic_file, user) }
+      before do
+        allow(generic_file).to receive(:label).and_return(short_name)
+        allow(Sufia.queue).to receive(:push)
+        actor.create_content(fixture_file_upload(file), long_name, 'content', 'image/png')
+      end 
+      subject { generic_file.title }
+      it { is_expected.to eql [short_name] }
+    end
+
     context "with two existing versions from different users" do
 
       let(:file1)       { "world.png" }

--- a/sufia-models/app/actors/sufia/generic_file/actor.rb
+++ b/sufia-models/app/actors/sufia/generic_file/actor.rb
@@ -31,7 +31,7 @@ module Sufia::GenericFile
     def create_content(file, file_name, path, mime_type)
       generic_file.add_file(file, path: path, original_name: file_name, mime_type: mime_type)
       generic_file.label ||= file_name
-      generic_file.title = [file_name] if generic_file.title.blank?
+      generic_file.title = [generic_file.label] if generic_file.title.blank?
       save_characterize_and_record_committer do
         if Sufia.config.respond_to?(:after_create_content)
           Sufia.config.after_create_content.call(generic_file, user)


### PR DESCRIPTION
This fixes issue #981. We were seeing long urls when ingesting files via Box. The label property contained the correct file name, where as title was getting set to the `file_name` variable which was in fact the url to reach the file on Box, long, randomly generated one. This corrects the issue by setting title to the same as label.