### PR TITLE
Updating view test, fixes #991

### DIFF
--- a/spec/views/homepage/_home_header.html.erb_spec.rb
+++ b/spec/views/homepage/_home_header.html.erb_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-RSpec.describe "homepage/_home_header.html.erb" do
+describe "homepage/_home_header.html.erb" do
   let(:groups) { [] }
   let(:ability) { instance_double("Ability") }
   describe "share your work button" do
     before do
       allow(controller).to receive(:current_ability).and_return(ability)
       allow(ability).to receive(:can?).with(:view_share_work, GenericFile).and_return(can_view_share_work)
-      stub_template "homepage/_marketing" => "marketing"
+      stub_template "homepage/_marketing.html.erb" => "marketing"
       render
     end
     context "when the user can view" do


### PR DESCRIPTION
Minor change in the view test avoids a misleading deprecation warning in the test suite.