### PR TITLE
Fixes bug in batch edit when users only changes the permissions of the files.

### DIFF
--- a/app/controllers/concerns/sufia/batch_edits_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_edits_controller_behavior.rb
@@ -84,7 +84,8 @@ module Sufia
     end
 
     def generic_file_params
-      Forms::BatchEditForm.model_attributes(params[:generic_file])
+      file_params = params[:generic_file] || ActionController::Parameters.new()
+      Forms::BatchEditForm.model_attributes(file_params)
     end
 
     def redirect_to_return_controller

--- a/spec/controllers/batch_edits_controller_spec.rb
+++ b/spec/controllers/batch_edits_controller_spec.rb
@@ -78,6 +78,13 @@ describe BatchEditsController, :type => :controller do
       expect(GenericFile.find(one.id).subject).to eq ["zzz"]
       expect(GenericFile.find(two.id).subject).to eq ["zzz"]
     end
+
+    it "should update permissions" do
+      put :update, update_type: "update", visibility: "authenticated"
+      expect(response).to be_redirect
+      expect(GenericFile.find(one.id).visibility).to eq "authenticated"
+      expect(GenericFile.find(two.id).visibility).to eq "authenticated"
+    end
   end
 
 end


### PR DESCRIPTION
This PR prevents the controller from failing when no generic_file properties are being changed and only the permissions (public/private/authenticated) are being updated.