### PR TITLE
Prevent user profile page from crashing if a file listed as a trophy 

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -28,6 +28,7 @@ describe UsersController, :type => :controller do
       let!(:trophy1) { user.trophies.create!(generic_file_id: file1.id) }
       let!(:trophy2) { user.trophies.create!(generic_file_id: file2.id) }
       let!(:trophy3) { user.trophies.create!(generic_file_id: file3.id) }
+      let!(:badtrophy) { user.trophies.create!(generic_file_id: 'not_a_generic_file') }
 
       it "show the user profile if user exists" do
         get :show, id: user.user_key

--- a/sufia-models/app/models/concerns/sufia/user.rb
+++ b/sufia-models/app/models/concerns/sufia/user.rb
@@ -77,8 +77,13 @@ module Sufia::User
 
   def trophy_files
     trophies.map do |t|
-      ::GenericFile.load_instance_from_solr(t.generic_file_id)
-    end
+      begin
+        ::GenericFile.load_instance_from_solr(t.generic_file_id)
+      rescue ActiveFedora::ObjectNotFoundError
+        logger.error("Invalid trophy for user #{user_key} (generic file id #{t.generic_file_id})")
+        nil
+      end
+    end.compact
   end
 
   # method needed for messaging


### PR DESCRIPTION
does not exist in Fedora. We log the error instead.