### PR TITLE
Update Arkivo subscription format

### DIFF
--- a/lib/sufia/arkivo/create_subscription_job.rb
+++ b/lib/sufia/arkivo/create_subscription_job.rb
@@ -48,7 +48,7 @@ module Sufia
           plugins: [
             {
               name: "sufia",
-              parameters: { user_token: @user.arkivo_token }
+              options: { token: @user.arkivo_token }
             }
           ]
         }.to_json


### PR DESCRIPTION
This just updates the subscription format used by Arkivo; you could (optionally) pass the base URL of the current Sufia instance using the `base` option.

Hope I didn't miss anything!