### PR TITLE
Uses correct file date when collecting analytics

### DIFF
--- a/spec/models/file_usage_spec.rb
+++ b/spec/models/file_usage_spec.rb
@@ -155,4 +155,27 @@ describe FileUsage, :type => :model do
 
     end
   end
+
+  describe "on a migrated file" do 
+    let(:date_uploaded) { "2014-12-31" }
+
+    let(:file_migrated) do
+      GenericFile.new.tap do |file|
+        file.apply_depositor_metadata("awead")
+        file.date_uploaded = date_uploaded
+        file.save
+      end
+    end
+
+    let(:usage) {
+      expect(FileDownloadStat).to receive(:ga_statistics).and_return(sample_download_statistics)
+      expect(FileViewStat).to receive(:ga_statistics).and_return(sample_pageview_statistics)
+      FileUsage.new(file_migrated.id)
+    }
+
+    it "should use the date_uploaded for analytics" do
+      expect(usage.created).to eq(date_uploaded)
+    end
+  end
+
 end

--- a/sufia-models/app/models/file_usage.rb
+++ b/sufia-models/app/models/file_usage.rb
@@ -9,11 +9,28 @@ class FileUsage
 
     self.id = id
     self.path = Sufia::Engine.routes.url_helpers.generic_file_path(id)
-    earliest = Sufia.config.analytic_start_date
-    self.created = ::GenericFile.find(id).create_date
-    self.created = earliest > created ? earliest : created unless earliest.blank?
+    self.created = date_for_analytics(file)
     self.downloads = FileDownloadStat.to_flots FileDownloadStat.statistics(id, created, user_id)
     self.pageviews = FileViewStat.to_flots FileViewStat.statistics(id, created, user_id)
+  end
+
+  # file.date_uploaded reflects the date the file was uploaded by the user 
+  # and therefore (if available) the date that we want to use for the stats 
+  # file.create_date reflects the date the file was added to Fedora. On data 
+  # migrated from one repository to another the created_date can be later 
+  # than the date the file was uploaded.
+  def date_for_analytics(file) 
+    earliest = Sufia.config.analytic_start_date
+    date_uploaded = string_to_date file.date_uploaded
+    date_analytics = date_uploaded ? date_uploaded : file.create_date
+    return date_analytics if earliest.blank?
+    earliest > date_analytics ? earliest : date_analytics 
+  end
+
+  def string_to_date(date_str)
+    return DateTime.parse(date_str) 
+  rescue ArgumentError, TypeError
+    return nil
   end
 
   def total_downloads


### PR DESCRIPTION
This handles the situation in which the "created date" for a file is more recent than the "date uploaded" which happens for data migrated from Fedora 3 to Fedora 4. For those files, the "created date" reflects the date the file was migrated to Fedora 4 rather than the date the file was originally uploaded to the system (in Fedora 3).

This PR makes sure we prefer the "date uploaded" if available.