### PR TITLE
Feature link is removed from Generic File Show page and the code is left...

### DIFF
--- a/app/views/generic_files/_show_actions.html.erb
+++ b/app/views/generic_files/_show_actions.html.erb
@@ -13,15 +13,15 @@
             <%= link_to "Edit", sufia.edit_generic_file_path(@generic_file) %>
           <% end %>
       <% end %>
-      <% if can?(:create, FeaturedWork) && @generic_file.public? %>
-        <% if FeaturedWork.can_create_another? && !@generic_file.featured?%>
+      <!--<%# if can?(:create, FeaturedWork) && @generic_file.public? %>
+        <%# if FeaturedWork.can_create_another? && !@generic_file.featured?%>
           &nbsp;|&nbsp;
-          <%= link_to "Feature", sufia.featured_work_path(@generic_file, format: :json), data: {behavior: 'feature'} %>
-        <% elsif @generic_file.featured? %>
+          <%#= link_to "Feature", sufia.featured_work_path(@generic_file, format: :json), data: {behavior: 'feature'} %>
+        <%# elsif @generic_file.featured? %>
           &nbsp;|&nbsp;
           Featured
-        <% end %>
-      <% end %>
+        <%# end %>
+      <%# end %>-->
     </p>
     <p>Export to:
       <%= link_to 'EndNote', sufia.generic_file_path(@generic_file, format: 'endnote') %>

--- a/spec/views/generic_file/show.html.erb_spec.rb
+++ b/spec/views/generic_file/show.html.erb_spec.rb
@@ -218,7 +218,7 @@ describe 'generic_files/show.html.erb', :type => :view do
     end
   end
 
-  describe 'featured' do
+  describe 'no feature link' do
     before do
       allow(generic_file).to receive(:public?).and_return(public)
       render
@@ -228,8 +228,8 @@ describe 'generic_files/show.html.erb', :type => :view do
     context "public file" do
       let(:public) { true }
 
-      it "shows featured feature link for public file" do
-        expect(page).to have_selector('a[data-behavior="feature"]', count: 1)
+      it "does not show feature link for public file" do
+        expect(page).to have_no_selector('a[data-behavior="feature"]')
       end
     end
 


### PR DESCRIPTION
Feature link is removed from Generic File Show page and the code is left in comments to be moved to Work Show page.

![fixes-1066_before](https://cloud.githubusercontent.com/assets/8228221/7477334/193d400a-f321-11e4-95cf-d12c4745e0fd.png)
![fixes-1066_after](https://cloud.githubusercontent.com/assets/8228221/7477336/1db5e808-f321-11e4-80a9-ad2b10e81ba8.png)
