### PR TITLE
Show works instead of files on 'My Files' dashboard page. Story #999

### DIFF
--- a/app/controllers/my/files_controller.rb
+++ b/app/controllers/my/files_controller.rb
@@ -3,7 +3,7 @@ module My
 
     self.search_params_logic += [
       :show_only_resources_deposited_by_current_user,
-      :show_only_generic_files
+      :show_only_generic_works
     ]
 
     def index

--- a/app/search_builders/sufia/search_builder.rb
+++ b/app/search_builders/sufia/search_builder.rb
@@ -24,6 +24,13 @@ module Sufia::SearchBuilder
     ]
   end
 
+  def show_only_generic_works(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Sufia::Works::GenericWork.to_class_uri)
+    ]
+  end
+
   def show_only_shared_files(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += [

--- a/app/views/my/_index_partials/_default_group.html.erb
+++ b/app/views/my/_index_partials/_default_group.html.erb
@@ -14,6 +14,8 @@
   <tbody>
   <% docs.each_with_index do |document,counter| %>
     <% case document.hydra_model %>
+    <% when "Sufia::Works::GenericWork" %>
+      <%= render partial: 'my/_index_partials/list_works', locals: { document: document, counter: counter } %>
     <% when "GenericFile" %>
       <%= render partial: 'my/_index_partials/list_files', locals: {document: document, counter: counter} %>
     <% when "Collection" %>

--- a/app/views/my/_index_partials/_list_works.html.erb
+++ b/app/views/my/_index_partials/_list_works.html.erb
@@ -1,0 +1,33 @@
+<tr id="document_<%= document.id %>" class="<%= cycle("", "zebra") %>">
+
+  <td> TODO: Batch Controls </td>
+
+  <td>
+    <div class='media'>
+      <%= link_to sufia.sufia_works_generic_work_path(document), class: 'media-left', 'aria-hidden' => true do %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to sufia.sufia_works_generic_work_path(document), id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("sufia.dashboard.my.sr.show_label") %>
+            </span>
+            <%= document.title_or_label %>
+            <br /> TODO: list collections for this work
+          <% end %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class='text-center'> <%= document.date_uploaded %> </td>
+  <td class='text-center'> TODO: Visibility Link </td>
+
+  <td class='text-center'>
+    <%= render partial: 'my/work_action_menu', locals: { document: document } %>
+  </td>
+</tr>

--- a/app/views/my/_work_action_menu.html.erb
+++ b/app/views/my/_work_action_menu.html.erb
@@ -1,0 +1,47 @@
+<div class="btn-group">
+
+  <button class="btn btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true">
+    <span class="sr-only">Press to </span>
+    Select an action
+    <span class="caret" aria-hidden="true"></span>
+  </button>
+
+  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
+
+    <li role="menuitem" tabindex="-1">
+      <%= link_to(sufia.edit_generic_work_path(document.id)) do %>
+        <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
+        <span> Edit Work </span>
+      <% end %>
+    </li>
+
+    <li role="menuitem" tabindex="-1">
+      <%= link_to('#') do %>
+        <i class="glyphicon glyphicon-download-alt" aria-hidden="true"></i>
+        <span> TODO: Download Work </span>
+      <% end %>
+    </li>
+
+    <li role="menuitem" tabindex="-1">
+      <%= link_to(sufia.generic_work_path(document.id), method: :delete, data: { confirm: "Deleting a work from #{t('sufia.product_name')} is permanent. Click OK to delete this work from #{t('sufia.product_name')}, or Cancel to cancel this operation" }) do %>
+        <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+        <span> Delete Work </span>
+      <% end %>
+    </li>
+
+    <li role="menuitem" tabindex="-1">
+      <%= link_to('#') do %>
+        <i aria-hidden="true" class='glyphicon glyphicon-star'></i>
+        <span> TODO: Highlight Work on Profile </span>
+      <% end %>
+    </li>
+
+    <li role="menuitem" tabindex="-1">
+      <%= link_to('#') do %>
+        <i class="glyphicon glyphicon-transfer" aria-hidden="true"></i>
+        <span> TODO: Transfer Ownership of Work </span>
+      <% end %>
+    </li>
+
+  </ul>
+</div>

--- a/spec/actors/curation_concern/generic_work_actor_spec.rb
+++ b/spec/actors/curation_concern/generic_work_actor_spec.rb
@@ -147,7 +147,6 @@ describe Sufia::CurationConcern::GenericWorkActor do
 
       it "should add to collections" do
         reload = Sufia::Works::GenericWork.find(curation_concern.id)
-        puts curation_concern.collection_ids
         expect(reload.collections).to eq [collection1]
 
         expect(subject.update).to be true

--- a/spec/controllers/my/files_controller_spec.rb
+++ b/spec/controllers/my/files_controller_spec.rb
@@ -2,58 +2,22 @@ require 'spec_helper'
 
 describe My::FilesController, :type => :controller do
 
-  let(:my_collection) do
-    Collection.new(title: 'test collection').tap do |c|
-      c.apply_depositor_metadata(user.user_key)
-      c.save!
-    end
-  end
-
-  let(:shared_file) do
-    FactoryGirl.build(:generic_file).tap do |r|
-      r.apply_depositor_metadata FactoryGirl.create(:user)
-      r.edit_users += [user.user_key]
-      r.save!
-    end
-  end
-
   let(:user) { FactoryGirl.find_or_create(:archivist) }
 
-  before do
-    sign_in user
-    @my_file = FactoryGirl.create(:generic_file, depositor: user)
-    @my_collection = my_collection
-    @shared_file = shared_file
-    @unrelated_file = FactoryGirl.create(:generic_file, depositor: FactoryGirl.create(:user))
-    @wrong_type = Batch.create
-  end
+  before { sign_in user }
 
   it "should respond with success" do
     get :index
     expect(response).to be_successful
+    expect(response).to render_template :index
   end
 
   it "should paginate" do
-    FactoryGirl.create(:generic_file)
-    FactoryGirl.create(:generic_file)
+    3.times { FactoryGirl.create(:work, user: user) }
     get :index, per_page: 2
     expect(assigns[:document_list].length).to eq 2
     get :index, per_page: 2, page: 2
     expect(assigns[:document_list].length).to be >= 1
-  end
-
-  it "shows the correct files" do
-    get :index
-    # shows documents I deposited
-    expect(assigns[:document_list].map(&:id)).to include(@my_file.id)
-    # doesn't show collections
-    expect(assigns[:document_list].map(&:id)).to_not include(@my_collection.id)
-    # doesn't show shared files
-    expect(assigns[:document_list].map(&:id)).to_not include(@shared_file.id)
-    # doesn't show other users' files
-    expect(assigns[:document_list].map(&:id)).to_not include(@unrelated_file.id)
-    # doesn't show non-generic files
-    expect(assigns[:document_list].map(&:id)).to_not include(@wrong_type.id)
   end
 
   describe "batch processing" do
@@ -68,10 +32,48 @@ describe My::FilesController, :type => :controller do
       User.batchuser().send_message(user, multiple_success(batch_id2, [batch]), success_subject, sanitize_text = false)
       get :index
     end
+
     it "gets batches that are complete" do
       expect(assigns(:batches).count).to eq(2)
       expect(assigns(:batches)).to include("ss-"+batch_id)
       expect(assigns(:batches)).to include("ss-"+batch_id2)
     end
   end
+
+
+  context 'with different types of records' do
+    let(:someone_else) { FactoryGirl.find_or_create(:user) }
+
+    let!(:my_collection) do
+      Collection.new(title: 'test collection').tap do |c|
+        c.apply_depositor_metadata(user.user_key)
+        c.save!
+      end
+    end
+
+    let!(:my_work) { FactoryGirl.create(:work, user: user) }
+    let!(:shared_work) { FactoryGirl.create(:work, edit_users: [user.user_key], user: someone_else) }
+    let!(:unrelated_work) { FactoryGirl.create(:public_work, user: someone_else) }
+    let!(:my_file) { FactoryGirl.create(:generic_file, depositor: user) }
+    let!(:wrong_type) { Batch.create }
+
+    it 'shows only the correct records' do
+      get :index
+      doc_ids = assigns[:document_list].map(&:id)
+      expect(doc_ids.count).to eq 1
+
+      # shows works I deposited
+      expect(doc_ids).to include(my_work.id)
+      # doesn't show collections
+      expect(doc_ids).to_not include(my_collection.id)
+      # doesn't show shared works
+      expect(doc_ids).to_not include(shared_work.id)
+      # doesn't show other users' works
+      expect(doc_ids).to_not include(unrelated_work.id)
+      # doesn't show non-works
+      expect(doc_ids).to_not include(wrong_type.id)
+      expect(doc_ids).to_not include(my_file.id)
+    end
+  end  # context 'with different types of records'
+
 end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -13,13 +13,12 @@ FactoryGirl.define do
     end
 
 
-    factory :public_generic_work do
+    factory :public_generic_work, aliases: [:public_work] do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
     factory :work_with_files do
       after(:build) { |work, _| 2.times { work.generic_files << FactoryGirl.create(:generic_file) }}
     end
-
   end
 end

--- a/spec/features/browse_dashboard_files_spec.rb
+++ b/spec/features/browse_dashboard_files_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 
 describe "Browse Dashboard", type: :feature do
   let(:user) { FactoryGirl.create(:user) }
-  let!(:fixtures) { create_file_fixtures(user.user_key) }
+
+  let!(:dissertation) { FactoryGirl.create(:public_work, user: user, title: ["Fake PDF Title"], subject: %w"lorem ipsum dolor sit amet") }
+
+  let!(:mp3_work) { FactoryGirl.create(:public_work, user: user, title: ["Test Document MP3"], subject: %w"consectetur adipisicing elit") }
+
+  let!(:audio_work) { FactoryGirl.create(:public_work, user: user, title: ["Fake Wav Files"], subject: %w"sed do eiusmod tempor incididunt ut labore") }
+
 
   before do
     sign_in user
@@ -15,28 +21,18 @@ describe "Browse Dashboard", type: :feature do
     expect(page).to have_content("Fake PDF Title")
   end
 
-  context "within my files page" do
+  it 'has buttons for user actions' do
+    expect(page).to have_link("Create Collection")
+    expect(page).to have_link("Upload")
+  end
 
+
+  context "within my files page" do
     before do
       visit "/dashboard/files"
     end
 
-    it "should display all the necessary information" do
-      # TODO this would make a good view test.
-      within("#document_#{fixtures.first.id}") do
-        click_button("Select an action")
-      end
-      expect(page).to have_content("Edit File")
-      expect(page).to have_content("Download File")
-      expect(page).to_not have_content("Is part of:")
-      first(".label-success") do
-        expect(page).to have_content("Open Access")
-      end
-      expect(page).to have_link("Create Collection")
-      expect(page).to have_link("Upload")
-    end
-
-    it "should allow you to search your own files and remove constraints" do
+    it "should allow you to search your own works and remove constraints" do
       fill_in "q", with: "PDF"
       click_button "search-submit-header"
       expect(page).to have_content("Fake PDF Title")
@@ -52,32 +48,23 @@ describe "Browse Dashboard", type: :feature do
       click_link "Subject"
       click_link "more Subjects"
       click_link "consectetur"
-      within("#document_#{fixtures[1].id}") do
-        click_link "Display all details of Test Document MP3.mp3"
+
+      within("#document_#{mp3_work.id}") do
+        expect(page).to have_link("Display all details of Test Document MP3", href: sufia.generic_work_path(mp3_work))
       end
-      expect(page).to have_content("File Details")
     end
 
-    it "should allow me to edit files (from the fixtures)" do
-      # TODO this would make a good view test.
-      fill_in "q", with: "Wav"
-      click_button "search-submit-header"
-      click_button "Select an action"
-      click_link "Edit File"
-      expect(page).to have_content("Edit Fake Wav File.wav")
-    end
-
-    it "should refresh the page of files" do
+    it "should refresh the page" do
       # TODO this would make a good view test.
       click_button "Refresh"
-      within("#document_#{fixtures.first.id}") do
+      within("#document_#{dissertation.id}") do
         click_button("Select an action")
-        expect(page).to have_content("Edit File")
-        expect(page).to have_content("Download File")
+        expect(page).to have_content("Edit Work")
+        expect(page).to have_content("Download Work")
       end
     end
 
-    it "should allow me to edit files in batches" do
+    it "should allow me to edit works in batches", skip: 'Not yet implemented' do
       first('input#check_all').click
       click_button('Edit Selected')
       expect(page).to have_content('3 files')

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -47,7 +47,7 @@ describe 'collection', :type => :feature do
       create_collection(title2, description2)
     end
 
-    it "should create collection from the dashboard and include files", js: true do
+    it "should create collection from the dashboard and include files", js: true, skip: 'pending future work to add works to collections' do
       visit '/dashboard/files'
       first('input#check_all').click
       click_button "Add to Collection" # opens the modal

--- a/spec/features/ownership_transfer_spec.rb
+++ b/spec/features/ownership_transfer_spec.rb
@@ -33,14 +33,14 @@ describe 'Transferring file ownership:', :type => :feature do
 
     context 'To myself' do
       before { transfer_ownership_of_file file, original_owner }
-      it 'Displays an appropriate error message' do
+      it 'Displays an appropriate error message', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
         expect(page).to have_content 'Sending user must specify another user to receive the file'
       end
     end
 
     context 'To someone else' do
       before { transfer_ownership_of_file file, new_owner }
-      it 'Creates a transfer request' do
+      it 'Creates a transfer request', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
         expect(page).to have_content 'Transfer request created'
       end
       context 'If the new owner accepts it' do
@@ -49,7 +49,7 @@ describe 'Transferring file ownership:', :type => :feature do
           user_utility_toggle.click
           click_link 'transfer requests'
         end
-        specify 'I should see it was accepted' do
+        specify 'I should see it was accepted', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
           expect(page.find('#outgoing-transfers')).to have_content 'Accepted'
         end
       end
@@ -59,7 +59,7 @@ describe 'Transferring file ownership:', :type => :feature do
           click_link 'transfer requests'
           first_sent_cancel_button.click
         end
-        specify 'I should see it was cancelled' do
+        specify 'I should see it was cancelled', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
           expect(page).to have_content 'Transfer canceled'
         end
       end
@@ -79,16 +79,16 @@ describe 'Transferring file ownership:', :type => :feature do
       end
       expect(page).to have_content 'Transfer of Ownership'
     end
-    specify 'I should receive a notification' do
+    specify 'I should receive a notification', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
       user_notifications_link.click
       expect(page).to have_content "#{original_owner.name} wants to transfer a file to you"
     end
-    specify 'I should be able to accept it' do
+    specify 'I should be able to accept it', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
       first_received_accept_dropdown.click
       click_link 'Allow depositor to retain edit access'
       expect(page).to have_content 'Transfer complete'
     end
-    specify 'I should be able to reject it' do
+    specify 'I should be able to reject it', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
       first_received_reject_button.click
       expect(page).to have_content 'Transfer rejected'
     end

--- a/spec/views/my/_list_works.html.erb_spec.rb
+++ b/spec/views/my/_list_works.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'my/_index_partials/_list_works.html.erb' do
+
+  let(:title) { 'Work Title' }
+  let(:work) { FactoryGirl.create(:work, title: [title]) }
+  let(:doc) { SolrDocument.new(work.to_solr) }
+
+  let(:config) { My::FilesController.new.blacklight_config }
+
+  before do
+    allow(view).to receive(:blacklight_config) { config }
+    render partial: 'my/_index_partials/list_works', locals: { document: doc }
+  end
+
+  it 'the line item displays the work and its actions' do
+    expect(rendered).to have_selector("tr#document_#{work.id}")
+    expect(rendered).to have_link title, href: sufia.generic_work_path(work)
+    expect(rendered).to have_link 'Edit Work', href: sufia.edit_generic_work_path(work)
+    expect(rendered).to have_link 'Delete Work', href: sufia.generic_work_path(work)
+  end
+
+end


### PR DESCRIPTION
Here is how the page looks now, including "TODO" placeholders:

![my_files_dashboard](https://cloud.githubusercontent.com/assets/298865/7505132/261dc520-f415-11e4-846c-4ffb32f078d0.png)

I assumed that the following things were out-of-scope for this story.  I put TODO placeholders in the code, and I'll write new stories for these things if stories don't already exist for them:

  * Transfer of ownership of a work (Story #1011)
  * Visibility link
  * The 'Click for more details' toggle
  * Batch Controls
      * Add to Collection
      * Batch delete
      * Batch edit (Story #1050 & #1003)
  * Highlight work on profile (Story #1079)
  * Download a work
  * 'Single Use Link' for a work
  * List collections that the work belongs to (depends on how solr indexing is done)