### PR TITLE
Resque jobs should be namespaced appropriately under Passenger. Fixes #1131

### DIFF
--- a/sufia-models/lib/generators/sufia/models/install_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/install_generator.rb
@@ -65,6 +65,7 @@ This generator makes the following changes to your application:
     copy_file 'config/redis_config.rb', 'config/initializers/redis_config.rb'
     copy_file 'config/resque_admin.rb', 'config/initializers/resque_admin.rb'
     copy_file 'config/resque_config.rb', 'config/initializers/resque_config.rb'
+    copy_file 'config/resque.rake', 'lib/tasks/resque.rake'
   end
 
   def create_collection

--- a/sufia-models/lib/generators/sufia/models/templates/config/redis_config.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/config/redis_config.rb
@@ -11,13 +11,13 @@ if defined?(PhusionPassenger)
       $redis = Redis.new(host: config[:host], port: config[:port], thread_safe: true) rescue nil
       Resque.redis = $redis
       Resque.redis.client.reconnect if Resque.redis
+      Resque.redis.namespace = "#{Sufia.config.redis_namespace}:#{Rails.env}"
     end
   end
 else
   config = YAML::load(ERB.new(IO.read(File.join(Rails.root, 'config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
   $redis = Redis.new(host: config[:host], port: config[:port], thread_safe: true) rescue nil
 end
-
 
 # Code borrowed from Obie's Redis patterns talk at RailsConf'12
 Nest.class_eval do

--- a/sufia-models/lib/generators/sufia/models/templates/config/resque.rake
+++ b/sufia-models/lib/generators/sufia/models/templates/config/resque.rake
@@ -1,0 +1,16 @@
+# Load the Rails app all the time.
+# See https://github.com/resque/resque/wiki/FAQ for more details
+require 'resque/pool'
+require 'resque/pool/tasks'
+
+# This provides access to the Rails env within all Resque workers
+task "resque:setup" => :environment
+
+task 'resque:pool:setup' do
+  ActiveRecord::Base.connection.disconnect!
+
+  Resque::Pool.after_prefork do |j|
+    ActiveRecord::Base.establish_connection
+    Resque.redis.client.reconnect
+  end
+end


### PR DESCRIPTION
This ensures that Redis keys for Resque queues receive the expected namespace when applications are run under Passenger. A number of Sufia implementations over the years have found that workers are namespaced with sufia:ENV: and queues receive the default Resque namespace of resque:, which meants that workers never pick up jobs. Resolving this issue requires adding the namespace-setting magic to the Redis config initializer and adding a new setup rake task for Resque (since jobs can be worked off via rake tasks).

Will fix new installations, and not affect existing ones.

Thanks too to @narogers, @hackmasterA, @terrellt and others over the months for poking at this and helping us arrive at a workable solution.  This is a longstanding bug that many of us have worked around for a long time!