### PR TITLE
Implement Work Creation Page. Fixes #1067

### DIFF
--- a/app/views/curation_concern/base/_form.html.erb
+++ b/app/views/curation_concern/base/_form.html.erb
@@ -1,17 +1,17 @@
-<%= simple_form_for [:curation_concern, curation_concern], html: { multipart: true } do |f| %>
+<%= simple_form_for [sufia, @form], html: { multipart: true } do |f| %>
   <div id="works_edit">
     <h2 class="non lower">Describe Your Work</h2>
     <p>The more descriptive information you provide the better we can serve your needs.</p>
     <p>Please consider releasing your work as an <span class="label label-success">Open Access</span> work.</p>
     <p><small class="pull-left"><span class="error">*</span> required</small></p>
-    <p><small class="pull-right"><%= link_to 'Switch to Batch Upload', new_generic_file_path, class: 'a' %></small></p>
+    <p><small class="pull-right"><%= link_to 'Switch to Batch Upload', sufia.new_generic_file_path, class: 'a' %></small></p>
     <div class="well">
       <% f.object.terms.each do |term| %>
         <%= render_edit_field_partial(term, f: f) %>
       <% end %>
     </div>
 
-    <%= render partial: 'curation_concern/base/permission_form' %>
+    <%= render partial: 'curation_concern/base/permission_form', locals: { f: f } %>
 
     <div class="primary-actions">
       <%= f.submit 'Save and Add Files', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>

--- a/app/views/curation_concern/base/_form.html.erb
+++ b/app/views/curation_concern/base/_form.html.erb
@@ -1,0 +1,28 @@
+<%= simple_form_for [:curation_concern, curation_concern], html: { multipart: true } do |f| %>
+  <div id="works_edit">
+    <h2 class="non lower">Describe Your Work</h2>
+    <p>The more descriptive information you provide the better we can serve your needs.</p>
+    <p>Please consider releasing your work as an <span class="label label-success">Open Access</span> work.</p>
+    <p><small class="pull-left"><span class="error">*</span> required</small></p>
+    <p><small class="pull-right"><%= link_to 'Switch to Batch Upload', new_generic_file_path, class: 'a' %></small></p>
+    <div class="well">
+      <% f.object.terms.each do |term| %>
+        <%= render_edit_field_partial(term, f: f) %>
+      <% end %>
+    </div>
+
+    <%= render partial: 'curation_concern/base/permission_form' %>
+
+    <div class="primary-actions">
+      <%= f.submit 'Save and Add Files', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+      <%= f.submit 'Save without Files', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "without_files_submit", name: "save_without_files" %>
+      <%= link_to t(:'helpers.action.cancel'), main_app.root_path, class: 'btn btn-link' %>
+    </div>
+
+    <%= render partial: 'works/base/upload/alerts' %>
+    <ul class="nav nav-tabs" role="tablist" title="Data Source Selectors" id="upload_tabs">
+      <li class="active" id="computer_tab" title="<%= t('sufia.upload.my_computer.sr_tab_label')+' '+ t('sufia.upload.my_computer.tab_label') %>"><a role="tab" href="#local" data-toggle="tab"><i class="glyphicon glyphicon-folder-open" aria-hidden="true"></i> <%= t('sufia.upload.my_computer.tab_label')%></a></li>
+    </ul>
+    <%= render partial: 'works/base/multiple_upload' %>
+  </div>
+<% end %>

--- a/app/views/curation_concern/base/_permission_form.html.erb
+++ b/app/views/curation_concern/base/_permission_form.html.erb
@@ -1,0 +1,115 @@
+<% depositor = f.object.depositor || batch.generic_files.first.depositor %>
+<% public_perm = f.object.permissions.map { |perm| perm.access if perm.agent_name == "public"}.compact.first %>
+<% public_perm = true if params[:controller] == 'batch' %>
+<% registered_perm = f.object.permissions.map { |perm| perm.access if perm.agent_name == "registered"}.compact.first %>
+
+<h2><% if params[:controller] == 'batch' %>Bulk <% end %>Permissions <% if params[:controller] == 'batch' %>
+      <small>(applied to all files just uploaded)</small><% end %>
+</h2>
+
+<div class="alert alert-info hidden" id="save_perm_note">Permissions are <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
+<div class="alert alert-warning hidden" id="permissions_error">
+  <a class="close" data-dismiss="alert" href="#">
+    <span class="sr-only">Close this alert</span>
+    <span aria-hidden="true">×</span>
+  </a>
+<span id="permissions_error_text"></span></div>
+
+<div class="well">
+
+  <h3>Visibility - <small>who should have the ability to read and download</small>
+    <span id="visibility_tooltip" class="h5"><%= visibility_help %></span>
+  </h3>
+  <div class="radio">
+    <label>
+      <input type="radio" id="visibility_open" name="visibility" value="<%=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if !public_perm.blank? %> checked="true"<% end %>/> <span class="label label-success">Open Access</span> Visible to the world.
+    </label>
+    <label>
+      <input type="radio" id="visibility_psu" name="visibility" value="<%=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if !registered_perm.blank? %> checked="true"<% end %> /><span class="label label-info"><%=t('sufia.institution_name') %></span> Visible to all <%=t('sufia.institution_name') %> users.
+    </label>
+    <label>
+      <input type="radio" id="visibility_restricted" name="visibility" value="<%=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>"<% if registered_perm.blank? and public_perm.blank?%> checked="true"<% end %> /> <span class="label label-danger">Private</span> Visible to users/groups specified below, if any.
+    </label>
+  </div>
+
+  <!-- Share With -->
+  <div class="row">
+    <h3 class="col-sm-12">Share With <small>(optional)</small>
+      <span id="share_with_tooltip" class="h5"><%= share_with_help %></span>
+    </h3>
+  </div>
+
+  <div class="form-group row">
+    <div id="new-user">
+      <p class="col-sm-12">Enter <%=t('sufia.account_label') %> (one at a time)</p>
+      <p class="sr-only">Use the add button to give access to one <%=t('sufia.account_label') %> at a time (it will be added to the list below).  Select the user, by name or <%=t('sufia.account_label') %>. Then select the access level you wish to grant and click on Add this <%= t('sufia.account_label') %> to complete adding the permission.</p>
+      <div class="col-sm-5">
+        <label for="new_user_name_skel" class="sr-only"><%= t('sufia.account_label') %> (without the <%= t('sufia.directory.suffix') %> part)</label>
+        <%= text_field_tag 'new_user_name_skel', nil %>
+      </div>
+      <div class="col-sm-4">
+        <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
+        <%= select_tag 'new_user_permission_skel', options_for_select(Sufia.config.permission_levels), class: 'form-control' %>
+      </div>
+      <div class="col-sm-3">
+        <button class="btn btn-mini btn-inverse" id="add_new_user_skel">
+          <span class="sr-only">Add this <%= t('sufia.account_label') %></span>
+          <span aria-hidden="true"><i class="glyphicon glyphicon-plus"></i></span>
+        </button>
+        <br /> <span id="directory_user_result"></span>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <div id="new-group" >
+      <p class="sr-only">Use the add button to give access to one group at a time (it will be added to the list below).</p>
+      <div class="col-sm-5">
+        <label for="new_group_name_skel" class="sr-only">Group</label>
+        <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
+      </div>
+      <div class="col-sm-4">
+        <label for="new_group_permission_skel" class="sr-only">Access type to grant</label>
+        <%= select_tag 'new_group_permission_skel', options_for_select(Sufia.config.permission_levels), class: 'form-control' %>
+      </div>
+      <div class="col-sm-3">
+        <span class="sr-only">Add this group</span>
+        <button class="btn btn-mini btn-inverse" id="add_new_group_skel"><i class="glyphicon glyphicon-plus"></i></button>
+        <br /><span id="directory_group_result"></span>
+      </div>
+    </div>
+  </div>
+
+</div><!-- /.well -->
+
+<table class="table table-bordered">
+  <tr>
+    <th width="60%">Person/Group</th>
+    <th width="40%">Access Level</th>
+  </tr>
+  <tr id="file_permissions">
+    <td>
+      <%= label_tag :owner_access, class: "control-label" do %>
+        Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
+      <% end %>
+    </td>
+    <td>
+      <%= Sufia.config.owner_permission_levels.keys[0] %>
+    </td>
+  </tr>
+  <%= f.fields_for :permissions do |permission_fields| %>
+    <%# skip the public, penn state (aka registered), and depositor perms as they are displayed first at the top %>
+    <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
+    <tr>
+      <td><%= permission_fields.label :agent_name, class: "control-label" do %>
+        <%= user_display_name_and_key(permission_fields.object.agent_name) %>
+      <% end %></td>
+      <td>
+        <div class="col-sm-8">
+          <%= permission_fields.select :access, Sufia.config.permission_levels, {}, class: 'form-control select_perm' %>
+        </div>
+        <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">X</button>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/curation_concern/base/new.html.erb
+++ b/app/views/curation_concern/base/new.html.erb
@@ -1,1 +1,3 @@
-todo new
+<h1>Create New Work</h1>
+
+<%= render 'form' %>

--- a/app/views/curation_concern/base/upload/_agreement.html.erb
+++ b/app/views/curation_concern/base/upload/_agreement.html.erb
@@ -1,0 +1,5 @@
+<div class="alert">
+  <strong>Note:</strong> You must agree to <a href='/agreement/' target="_blank"><%= t('sufia.deposit_agreement') %></a> before starting your upload.
+</div>
+
+

--- a/app/views/curation_concern/base/upload/_alerts.html.erb
+++ b/app/views/curation_concern/base/upload/_alerts.html.erb
@@ -1,0 +1,9 @@
+<div class="alert alert-warning" id="fail">
+  <%= t("sufia.upload.alert.fail_html", reload_href: link_to(t("sufia.upload.alert.fail_restart_href_text"), sufia.new_generic_file_path), contact_href: link_to(t("sufia.upload.alert.contact_href_text"), sufia.contact_form_index_path)) %>
+</div>
+
+<div class="alert alert-warning" id="partial_fail">
+  <%= t("sufia.upload.alert.partial_fail_html", metadata_href: link_to(t("sufia.upload.alert.partial_fail_metadata_href_text"), GenericFilesController.upload_complete_path(@batch_id), class: 'btn'), contact_href: link_to(t("sufia.upload.alert.contact_href_text"), sufia.contact_form_index_path)) %>
+</div>
+
+<div class="alert alert-warning" id="errmsg"> </div>

--- a/app/views/curation_concern/base/upload/_form.html.erb
+++ b/app/views/curation_concern/base/upload/_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_for(@generic_file, url: sufia.generic_files_path, html: { multipart: true, id: 'fileupload' }) do |f| %>
+  <% unless current_user.can_make_deposits_for.empty? %>
+    <div class="controls">
+      <%= label_tag :on_behalf_of, 'On Behalf of' %>
+      <%= select_tag :on_behalf_of, options_for_select(current_user.can_make_deposits_for), prompt: "Yourself" %>
+    </div>
+  <% end %>
+  <div class="well">
+    <%= render partial: 'generic_files/upload/form_fields' %>
+  </div>
+<% end %>

--- a/app/views/curation_concern/base/upload/_form_fields.html.erb
+++ b/app/views/curation_concern/base/upload/_form_fields.html.erb
@@ -1,0 +1,46 @@
+    <!-- The file upload form used as target for the file upload widget -->
+      <%= hidden_field_tag(:total_upload_size, 0) %>
+      <%= hidden_field_tag(:relative_path) %>
+      <%= hidden_field_tag(:batch_id, @batch_id) %>
+      <%= hidden_field_tag "file_coming_from", "local" %>
+      <%= render partial: 'generic_files/upload/tos_checkbox' %>
+        <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+        <div class="row fileupload-buttonbar">
+            <div class="col-md-7">
+                <!-- The fileinput-button span is used to style the file input field as button -->
+                <span class="btn btn-primary fileinput-button">
+                    <i class="glyphicon glyphicon-plus" aria-hidden="true"></i>
+                    <span aria-hidden="true">Select files...</span>
+                    <input type="file" name="files[]" multiple />
+                </span>
+                <% ua = request.env['HTTP_USER_AGENT'] %>
+                <% if !!(ua =~ /Chrome/) %>
+                <span class="btn btn-primary fileinput-button">
+                    <i class="glyphicon glyphicon-plus"  aria-hidden="true"></i>
+                    <span aria-hidden="true">Select folder...</span>
+                    <input type="file" name="files[]" directory webkitdirectory mozdirectory />
+                </span>
+                <% end %>
+                <div id="main_upload_start_span" class="activate-container visible-all-inline-block" data-toggle="tooltip" data-title="<%= t('sufia.upload_tooltip') %>">
+                  <button type="submit" class="activate-submit btn btn-info start" id="main_upload_start">
+                    <i class="glyphicon glyphicon-upload"></i>
+                    <span>Start upload</span>
+                </button>
+                </div>
+                <button type="reset" class="btn btn-warning cancel">
+                    <i class="glyphicon glyphicon-ban-circle"></i>
+                    <span>Cancel upload</span>
+                </button>
+            </div>
+            <div class="col-md-5 fileupload-progress">
+                <!-- The global progress bar -->
+                <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+                </div>
+            </div>
+        </div>
+        <!-- The loading indicator is shown during image processing -->
+        <div class="fileupload-loading"></div>
+        <br />
+        <!-- The table listing the files available for upload/download -->
+        <table id="file-table" class="table table-striped"><tbody class="files" data-toggle="modal-gallery" data-target="#modal-gallery"></tbody></table>

--- a/app/views/curation_concern/base/upload/_local_file_import_chooser.html.erb
+++ b/app/views/curation_concern/base/upload/_local_file_import_chooser.html.erb
@@ -1,0 +1,27 @@
+<% if current_user.directory.present? %>
+  <div class="well">
+    <%= render partial: 'generic_files/upload/tos_checkbox' %>
+    <%= form_for @generic_file, url: sufia.generic_files_path, html: { class: 'form-horizontal well'} do |f| %>
+      <table class="table table-striped">
+        <caption>Select files to deposit from your user directory on the server.</caption>
+        <thead>
+          <tr><th>File</th></tr>
+        </thead>
+        <tbody>
+        <%current_user.files.each do |f| %>
+          <tr>
+            <td>
+              <label><%= check_box_tag 'local_file[]', f[:name] %> <%= f[:directory] ? '<i class="glyphicon glyphicon-folder-close"></i>'.html_safe : '<i class="glyphicon glyphicon-file"></i>'.html_safe %> <%= f[:name] %></label>
+            </td>
+          </tr>
+        <%end%>
+        </tbody>
+      </table>
+      <%= hidden_field_tag(:batch_id, @batch_id) %>
+      <button type="submit" class="activate-submit btn btn-primary start" id="main_upload_start">
+        <i class="glyphicon glyphicon-upload"></i>
+        <span>Deposit Selected Files</span>
+      </button>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/curation_concern/base/upload/_script_templates.html.erb
+++ b/app/views/curation_concern/base/upload/_script_templates.html.erb
@@ -1,0 +1,60 @@
+<div class="alert alert-info hide" id="redirect-loc" type="text/x-jquery-tmpl">
+  <%# Script redirects here once the uploads are complete %>
+  <%= GenericFilesController.upload_complete_path(@batch_id) %>
+</div>
+
+<!-- The template to display files available for upload -->
+<script id="template-upload" type="text/x-jquery-tmpl">
+ {% for (var i=0, file; file=o.files[i]; i++) { %}
+
+    <tr class="template-upload fade">
+        <td class="preview"><span class="fade"></span></td>
+        <td class="name"><span>{%=file.name%}</span></td>
+        <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
+        {% if (file.error) { %}
+            <td class="error" colspan="2"><span class="label label-danger">{%=locale.fileupload.error%}</span> {%=locale.fileupload.errors[file.error] || file.error%}</td>
+        {% } else if (o.files.valid && !i) { %}
+            <td>
+                <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="progress-bar progress-bar-success" style="width:0%;"></div></div>
+            </td>
+            <td class="start">{% if (!o.options.autoUpload) { %}
+              <button class="btn btn-primary hide">
+                    <i class="glyphicon glyphicon-upload"></i>
+                    <span>{%=locale.fileupload.start%}</span>
+              </button>
+            {% } %}</td>
+        {% } else { %}
+            <td colspan="2"></td>
+        {% } %}
+        <td class="cancel">{% if (!i) { %}
+            <button class="btn btn-warning">
+                <i class="glyphicon glyphicon-ban-circle"></i>
+                <span>{%=locale.fileupload.cancel%}</span>
+            </button>
+        {% } %}</td>
+    </tr>
+{% } %}
+</script>
+<!-- The template to display files available for download -->
+<script id="template-download" type="text/x-jquery-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-download fade">
+        {% if (file.error) { %}
+            <td><span></span></td>
+            <td class="name"><span>{%=file.name%}</span></td>
+            <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
+            <td class="error" colspan="2"><span class="label label-danger">{%=locale.fileupload.error%}</span> {%=locale.fileupload.errors[file.error] || file.error%}</td>
+        {% } else { %}
+            <td class="preview">
+              {% if (file.thumbnail_url) { %} <span class="label label-success">Success</span> {% } %}
+            </td>
+            <td class="name">
+                {%=file.name%}
+                <!--a href="{%=file.url%}" title="{%=file.name%}" rel="{%=file.thumbnail_url&&'gallery'%}" download="{%=file.name%}" target="_blank">{%=file.name%}</a-->
+            </td>
+            <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
+            <td colspan="2"></td>
+        {% } %}
+    </tr>
+{% } %}
+</script>

--- a/app/views/curation_concern/base/upload/_tos_checkbox.html.erb
+++ b/app/views/curation_concern/base/upload/_tos_checkbox.html.erb
@@ -1,0 +1,3 @@
+<label>
+  <%= check_box_tag 'terms_of_service', 1, nil, {data: {activate: 'activate-submit'}} %><strong> I have read and do agree to <%= link_to t('sufia.deposit_agreement'), '/agreement/', target: "_blank" %>.</strong>
+</label>


### PR DESCRIPTION
![blacklight](https://cloud.githubusercontent.com/assets/5639859/7640095/2c2b8fd4-fa4f-11e4-8bcc-3eb6d84e03a8.png)

Since a work only has 1 title, this issue required me to change the generic work model's `title` from an array to a scalar value.  That broke many tests, but all have been fixed except for 3 tests in spec/jobs/batch_update_job_spec.rb.  It looks like batch update is broken now that generic works and generic files have different types of values for the `title` field.  It looks like a simple fix, but should probably be it's own ticket.  

As suggested in this ticket's description, this implements the creation of a work without attaching files.  The next step is to allow the user to upload files during the work's creation.