### PR TITLE
Collections Show page should use render_collection_links.  Fixes #1128

### DIFF
--- a/app/views/collections/_show_document_list_row.html.erb
+++ b/app/views/collections/_show_document_list_row.html.erb
@@ -21,7 +21,7 @@
           <%= link_to document.title_or_label, sufia.generic_work_path(document), id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %>
           <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
         </h4>
-        <%= render_collection_list(gw) %>
+        <%= render_collection_links(gw) %>
       </div>
     </div>
   </td>
@@ -46,8 +46,6 @@
     <dl class="expanded-details row">
       <dt class="col-xs-3 col-lg-2">File Name:</dt>
       <dd class="col-xs-9 col-lg-4"><%= link_to document.label, sufia.generic_work_path(document) %></dd>
-      <dt class="col-xs-3 col-lg-2">File Format:</dt>
-      <dd class="col-xs-9 col-lg-4"><%= document.file_format %>JPG</dd>
       <dt class="col-xs-3 col-lg-2">Creator:</dt>
       <dd class="col-xs-9 col-lg-4"><%= document.creator %></dd>
       <dt class="col-xs-3 col-lg-2">Depositor:</dt>

--- a/spec/views/collections/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/collections/_show_document_list_row.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'collections/_show_document_list_row.html.erb', :type => :view do
+
+  let(:user) { FactoryGirl.find_or_create(:jill) }
+
+  let(:work) do
+    gw = GenericWork.new(creator: ["ggm"], title: ['One Hundred Years of Solitude'])
+    gw.apply_depositor_metadata(user)
+    gw.save
+    gw
+  end
+
+  let(:collection) { mock_model(Collection, title: 'My awesome collection', members: [work]) }
+
+  context 'when not logged in' do
+    before do
+      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+      allow(view).to receive(:current_user).and_return(nil)
+      allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
+      allow(work).to receive(:edit_people).and_return([])
+      allow(view).to receive(:render_collection_links).and_return("collections: #{collection.title}")
+    end
+
+    it "should render collections links" do
+      render(partial: 'collections/show_document_list_row.html.erb', locals: {document: work})
+      expect(rendered).to have_content 'My awesome collection'
+    end
+
+    it "should render works" do
+      render(partial: 'collections/show_document_list_row.html.erb', locals: {document: work})
+      expect(rendered).to have_content 'One Hundred Years of Solitude'
+    end
+  end
+end


### PR DESCRIPTION
I could adjust the test to include generic_works if we remove file_format from app/views/collections/_show_document_list_row.html.erb.