### PR TITLE
Refactor Transfers to use GenericWork.

### DIFF
--- a/app/controllers/concerns/sufia/batch_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_controller_behavior.rb
@@ -39,9 +39,11 @@ module Sufia
     end
 
     def uploading_on_behalf_of? batch
-      file = batch.generic_files.first
-      return false if file.nil? || file.on_behalf_of.blank?
-      current_user.user_key != file.on_behalf_of
+      return false if batch.generic_files.empty?
+
+      work = batch.generic_files.first.generic_work
+      return false if work.nil? || work.on_behalf_of.blank?
+      current_user.user_key != work.on_behalf_of
     end
 
   end

--- a/app/controllers/concerns/sufia/dashboard_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/dashboard_controller_behavior.rb
@@ -34,7 +34,7 @@ module Sufia
       @user = current_user
       @activity = current_user.get_all_user_activity(params[:since].blank? ? DateTime.now.to_i - Sufia.config.activity_to_show_default_seconds_since_now : params[:since].to_i)
       @notifications = current_user.mailbox.inbox
-      @incoming = ProxyDepositRequest.where(receiving_user_id: current_user.id).reject &:deleted_file?
+      @incoming = ProxyDepositRequest.where(receiving_user_id: current_user.id).reject &:deleted_work?
       @outgoing = ProxyDepositRequest.where(sending_user_id: current_user.id)
     end
 

--- a/app/controllers/concerns/sufia/transfers_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/transfers_controller_behavior.rb
@@ -19,7 +19,7 @@ module Sufia
     end
 
     def new
-      @generic_file = ::GenericFile.load_instance_from_solr(@id)
+      @generic_work = ::GenericWork.load_instance_from_solr(@id)
     end
 
     def create
@@ -32,7 +32,7 @@ module Sufia
     end
 
     def index
-      @incoming = ProxyDepositRequest.where(receiving_user_id: current_user.id).reject &:deleted_file?
+      @incoming = ProxyDepositRequest.where(receiving_user_id: current_user.id).reject &:deleted_work?
       @outgoing = ProxyDepositRequest.where(sending_user_id: current_user.id)
     end
 
@@ -59,9 +59,9 @@ module Sufia
     def get_id_and_authorize_depositor
       @id = params[:id]
       authorize! :transfer, @id
-      @proxy_deposit_request.generic_file_id = @id
+      @proxy_deposit_request.generic_work_id = @id
     rescue CanCan::AccessDenied
-      redirect_to root_url, alert: 'You are not authorized to transfer this file'
+      redirect_to root_url, alert: 'You are not authorized to transfer this work.'
     end
 
     def load_proxy_deposit_request

--- a/app/controllers/curation_concern/generic_works_controller.rb
+++ b/app/controllers/curation_concern/generic_works_controller.rb
@@ -32,7 +32,6 @@ module CurationConcern
 
 
     def after_create_response
-      puts "\n\nparams #{params[:save_with_files]}"
       if params[:save_with_files].blank?
         redirect_to sufia.generic_work_path(curation_concern.id)
       else

--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -20,10 +20,10 @@ module Sufia
     end
 
     def show_transfer_request_title(req)
-      if req.deleted_file?
+      if req.deleted_work?
         req.title
       else
-        link_to(req.title, sufia.generic_file_path(req.generic_file_id))
+        link_to(req.title, sufia.generic_work_path(req.generic_work_id))
       end
     end
 

--- a/app/jobs/content_delete_event_job.rb
+++ b/app/jobs/content_delete_event_job.rb
@@ -1,7 +1,7 @@
 class ContentDeleteEventJob < EventJob
 
   def run
-    action = "User #{link_to_profile depositor_id} has deleted file '#{generic_file_id}'"
+    action = "User #{link_to_profile depositor_id} has deleted file '#{id}'"
     timestamp = Time.now.to_i
     depositor = User.find_by_user_key(depositor_id)
     # Create the event

--- a/app/jobs/content_deposit_event_job.rb
+++ b/app/jobs/content_deposit_event_job.rb
@@ -1,6 +1,6 @@
 class ContentDepositEventJob < EventJob
   def run
-    gf = GenericFile.find(generic_file_id)
+    gf = GenericFile.find(id)
     action = "User #{link_to_profile depositor_id} has deposited #{link_to gf.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(gf)}"
     timestamp = Time.now.to_i
     depositor = User.find_by_user_key(depositor_id)

--- a/app/jobs/content_new_version_event_job.rb
+++ b/app/jobs/content_new_version_event_job.rb
@@ -1,6 +1,6 @@
 class ContentNewVersionEventJob < EventJob
   def run
-    gf = GenericFile.find(generic_file_id)
+    gf = GenericFile.find(id)
     action = "User #{link_to_profile depositor_id} has added a new version of #{link_to gf.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(gf)}"
     timestamp = Time.now.to_i
     depositor = User.find_by_user_key(depositor_id)

--- a/app/jobs/content_restored_version_event_job.rb
+++ b/app/jobs/content_restored_version_event_job.rb
@@ -2,13 +2,13 @@ class ContentRestoredVersionEventJob < EventJob
   attr_accessor :revision_id
 
   def initialize(generic_file_id, depositor_id, revision_id)
-    self.generic_file_id = generic_file_id
+    self.id = generic_file_id
     self.depositor_id = depositor_id
     self.revision_id = revision_id
   end
 
   def run
-    gf = GenericFile.find(generic_file_id)
+    gf = GenericFile.find(id)
     action = "User #{link_to_profile depositor_id} has restored a version '#{revision_id}' of #{link_to gf.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(gf)}"
     timestamp = Time.now.to_i
     depositor = User.find_by_user_key(depositor_id)

--- a/app/jobs/content_update_event_job.rb
+++ b/app/jobs/content_update_event_job.rb
@@ -1,6 +1,6 @@
 class ContentUpdateEventJob < EventJob
   def run
-    gf = GenericFile.find(generic_file_id)
+    gf = GenericFile.find(id)
     action = "User #{link_to_profile depositor_id} has updated #{link_to gf.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(gf)}"
     timestamp = Time.now.to_i
     depositor = User.find_by_user_key(depositor_id)

--- a/app/jobs/event_job.rb
+++ b/app/jobs/event_job.rb
@@ -9,10 +9,10 @@ class EventJob
     :event
   end
 
-  attr_accessor :generic_file_id, :depositor_id
+  attr_accessor :id, :depositor_id
 
-  def initialize(generic_file_id, depositor_id)
-    self.generic_file_id = generic_file_id
+  def initialize(id, depositor_id)
+    self.id = id
     self.depositor_id = depositor_id
   end
 

--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -105,6 +105,10 @@ module Sufia
       generate "sufia:upgrade600"
     end
 
+    def install_sufia_700
+      generate "sufia:upgrade700"
+    end
+
     def install_blacklight_gallery
       generate "blacklight_gallery:install"
     end

--- a/lib/generators/sufia/upgrade700_generator.rb
+++ b/lib/generators/sufia/upgrade700_generator.rb
@@ -1,0 +1,16 @@
+# -*- encoding : utf-8 -*-
+require 'rails/generators'
+
+class Sufia::Upgrade700Generator < Rails::Generators::Base
+
+  source_root File.expand_path('../templates', __FILE__)
+
+  desc """
+This generator for upgrading sufia to 7.0 makes the following changes to your application:
+       """
+
+  def migrations
+    generate "sufia:models:upgrade700"
+  end
+
+end

--- a/spec/controllers/curation_concern/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concern/generic_works_controller_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe CurationConcern::GenericWorksController do
   let(:public_work_factory_name) { :public_generic_work }
   let(:private_work_factory_name) { :work }
-
   let(:user) { FactoryGirl.create(:user) }
   before { sign_in user }
 
@@ -44,12 +43,21 @@ describe CurationConcern::GenericWorksController do
   end
 
   describe "#create" do
+    let!(:jill) { FactoryGirl.find_or_create(:jill) }
     it "should create a work" do
       expect {
         post :create, generic_work: { title: ["a title"] }
       }.to change { GenericWork.count }.by(1)
       expect(response).to redirect_to Sufia::Engine.routes.url_helpers.generic_work_path(assigns[:curation_concern])
     end
+
+    it "should record on_behalf_of" do
+      post :create, generic_work: { id: 'test123', title: ["work title"], on_behalf_of: 'jilluser@example.com'}
+      expect(response).to redirect_to Sufia::Engine.routes.url_helpers.generic_work_path('test123')
+      saved_work = GenericWork.find('test123')
+      expect(saved_work.on_behalf_of).to eq 'jilluser@example.com'
+    end
+
   end
 
   describe "#edit" do

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -35,11 +35,11 @@ describe DashboardController, :type => :controller do
     context 'with transfers' do
       let(:another_user) { FactoryGirl.find_or_create(:archivist) }
       context 'when incoming' do
-        let!(:incoming_file) do
-            GenericFile.new.tap do |f|
-              f.apply_depositor_metadata(another_user.user_key)
-              f.save!
-              f.request_transfer_to(user)
+        let!(:incoming_work) do
+            GenericWork.new.tap do |w|
+              w.apply_depositor_metadata(another_user.user_key)
+              w.save!
+              w.request_transfer_to(user)
             end
         end
 
@@ -47,16 +47,16 @@ describe DashboardController, :type => :controller do
           get :index
           expect(response).to be_success
           expect(assigns[:incoming].first).to be_kind_of ProxyDepositRequest
-          expect(assigns[:incoming].first.generic_file_id).to eq(incoming_file.id)
+          expect(assigns[:incoming].first.generic_work_id).to eq(incoming_work.id)
         end
       end
 
       context 'when outgoing' do
-        let!(:outgoing_file) do
-            GenericFile.new.tap do |f|
-              f.apply_depositor_metadata(user.user_key)
-              f.save!
-              f.request_transfer_to(another_user)
+        let!(:outgoing_work) do
+            GenericWork.new.tap do |w|
+              w.apply_depositor_metadata(user.user_key)
+              w.save!
+              w.request_transfer_to(another_user)
             end
         end
 
@@ -64,7 +64,7 @@ describe DashboardController, :type => :controller do
           get :index
           expect(response).to be_success
           expect(assigns[:outgoing].first).to be_kind_of ProxyDepositRequest
-          expect(assigns[:outgoing].first.generic_file_id).to eq(outgoing_file.id)
+          expect(assigns[:outgoing].first.generic_work_id).to eq(outgoing_work.id)
         end
      end
     end

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -21,14 +21,6 @@ describe GenericFilesController do
         allow(GenericFile).to receive(:new).and_return(mock)
       end
 
-      it "should record on_behalf_of" do
-        file = fixture_file_upload('/world.png','image/png')
-        xhr :post, :create, files: [file], Filename: 'The world', batch_id: batch_id, on_behalf_of: 'carolyn', terms_of_service: '1'
-        expect(response).to be_success
-        saved_file = GenericFile.find('test123')
-        expect(saved_file.on_behalf_of).to eq 'carolyn'
-      end
-
       context "when the file submitted isn't a file" do
         let(:file) { 'hello' }
 

--- a/spec/features/ownership_transfer_spec.rb
+++ b/spec/features/ownership_transfer_spec.rb
@@ -5,14 +5,14 @@ include Selectors::Dashboard
 include Selectors::NewTransfers
 include Selectors::Transfers
 
-describe 'Transferring file ownership:', :type => :feature do
+describe 'Transferring work ownership:', :type => :feature do
   let(:original_owner) { FactoryGirl.create(:archivist, display_name: 'Original Owner') }
   let(:new_owner) { FactoryGirl.create(:jill, display_name: 'New Owner') }
-  let!(:file) do
-    GenericFile.new.tap do |f|
-      f.title = ['little_file.txt']
-      f.creator = ['little_file.txt_creator']
-      f.resource_type = ["stuff" ]
+  let!(:work) do
+    GenericWork.new.tap do |f|
+      f.title = ['little_generic_work']
+      f.creator = ['little_generic_work.creator']
+      f.resource_type = ["stuff"]
       f.read_groups = ['public']
       f.apply_depositor_metadata(original_owner.user_key)
       f.save!
@@ -20,88 +20,54 @@ describe 'Transferring file ownership:', :type => :feature do
   end
 
   before do
-    sign_in original_owner
-    go_to_dashboard_files
+    # sign_in original_owner
+    # go_to_dashboard_files
   end
 
-  describe 'When I request a file transfer:', :js do
-    context 'For a file I do not own' do
+  describe 'When I request a work transfer:', :js do
+    context 'For a work I do not own' do
       pending 'The transfer option is not available' do
         fail
       end
     end
 
     context 'To myself' do
-      before { transfer_ownership_of_file file, original_owner }
-      it 'Displays an appropriate error message', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
-        expect(page).to have_content 'Sending user must specify another user to receive the file'
+      pending 'The transfer option is not available' do
+        fail
       end
     end
 
     context 'To someone else' do
-      before { transfer_ownership_of_file file, new_owner }
-      it 'Creates a transfer request', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
-        expect(page).to have_content 'Transfer request created'
+      pending 'The transfer option is not available' do
+        fail
       end
       context 'If the new owner accepts it' do
-        before do
-          new_owner.proxy_deposit_requests.last.transfer!
-          user_utility_toggle.click
-          click_link 'transfer requests'
-        end
-        specify 'I should see it was accepted', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
-          expect(page.find('#outgoing-transfers')).to have_content 'Accepted'
-        end
+      pending 'The transfer option is not available' do
+        fail
+      end
       end
       context 'If I cancel it' do
-        before do
-          user_utility_toggle.click
-          click_link 'transfer requests'
-          first_sent_cancel_button.click
-        end
-        specify 'I should see it was cancelled', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
-          expect(page).to have_content 'Transfer canceled'
-        end
+      pending 'The transfer option is not available' do
+        fail
+      end
       end
     end
   end
 
-  describe 'When someone requests a file transfer to me', :js do
-    before do
-      # As the original_owner, transfer a file to the new_owner
-      transfer_ownership_of_file file, new_owner
-      # Become the new_owner so we can manage transfers sent to us
-      sign_in new_owner
-      visit '/dashboard'
-      user_utility_toggle.click
-      within '#user_utility_links' do
-        click_link 'transfer requests'
+  describe 'When someone requests a work transfer to me', :js do
+      pending 'The transfer option is not available' do
+        fail
       end
-      expect(page).to have_content 'Transfer of Ownership'
-    end
-    specify 'I should receive a notification', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
-      user_notifications_link.click
-      expect(page).to have_content "#{original_owner.name} wants to transfer a file to you"
-    end
-    specify 'I should be able to accept it', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
-      first_received_accept_dropdown.click
-      click_link 'Allow depositor to retain edit access'
-      expect(page).to have_content 'Transfer complete'
-    end
-    specify 'I should be able to reject it', skip: 'Will ownership transfer be at the GenericWork level or the GenericFile level?' do
-      first_received_reject_button.click
-      expect(page).to have_content 'Transfer rejected'
-    end
   end
 
-  def transfer_ownership_of_file(file, new_owner)
-    db_item_actions_toggle(file).click
-    click_link 'Transfer Ownership of File'
-    expect(page).to have_content "Select a user to transfer #{file.title.first} to, add optional comments and then press transfer."
+  def transfer_ownership_of_work(work, new_owner)
+    db_item_actions_toggle(work).click
+    click_link 'Transfer Ownership of Work'
+    expect(page).to have_content "Select a user to transfer #{work.title.first} to, add optional comments and then press transfer."
     new_owner_dropdown.click
     new_owner_search_field.set new_owner.user_key
     new_owner_search_result.click
-    fill_in 'proxy_deposit_request[sender_comment]', with: 'File transfer comments'
+    fill_in 'proxy_deposit_request[sender_comment]', with: 'Work transfer comments'
     submit_button.click
   end
 end

--- a/spec/jobs/content_depositor_change_event_job_spec.rb
+++ b/spec/jobs/content_depositor_change_event_job_spec.rb
@@ -1,20 +1,36 @@
 require 'spec_helper'
 
 describe ContentDepositorChangeEventJob do
-  before do
-    @depositor = FactoryGirl.find_or_create(:jill)
-    @receiver = FactoryGirl.find_or_create(:archivist)
-    @file = ::GenericFile.new.tap do |gf|
-      gf.apply_depositor_metadata(@depositor.user_key)
-      gf.save!
+  let!(:depositor){ FactoryGirl.find_or_create(:jill) }
+  let!(:receiver){ FactoryGirl.find_or_create(:archivist) }
+  let!(:file) do 
+    GenericFile.new.tap do |f|
+      f.apply_depositor_metadata(depositor.user_key)
+      f.save!
     end
-    ContentDepositorChangeEventJob.new(@file.id, @receiver.user_key).run
+  end
+  let!(:work) do 
+    GenericWork.new.tap do |w|
+      w.apply_depositor_metadata(depositor.user_key)
+      w.save!
+    end
+  end
+
+  before do
+    work.generic_files += [file]
+    ContentDepositorChangeEventJob.new(work.id, receiver.user_key).run
   end
 
   it "changes the depositor and records an original depositor" do
-    @file.reload
-    expect(@file.depositor).to eq @receiver.user_key
-    expect(@file.proxy_depositor).to eq @depositor.user_key
-    expect(@file.edit_users).to include(@receiver.user_key, @depositor.user_key)
+    work.reload
+    expect(work.depositor).to eq receiver.user_key
+    expect(work.proxy_depositor).to eq depositor.user_key
+    expect(work.edit_users).to include(receiver.user_key, depositor.user_key)
+  end
+
+  it "changes the depositor of the child generic files" do
+    file.reload
+    expect(file.depositor).to eq receiver.user_key
+    expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -40,34 +40,34 @@ describe Sufia::Ability, :type => :model do
   describe "proxies and transfers" do
     let(:sender) { FactoryGirl.find_or_create(:jill) }
     let(:user) { FactoryGirl.find_or_create(:archivist) }
-    let(:file) do
-      GenericFile.new.tap do|file|
-        file.apply_depositor_metadata(sender.user_key)
-        file.save!
+    let(:work) do
+      GenericWork.new.tap do|work|
+        work.apply_depositor_metadata(sender.user_key)
+        work.save!
       end
     end
     subject { Ability.new(user) }
-    it { should_not be_able_to(:transfer, file.id) }
+    it { should_not be_able_to(:transfer, work.id) }
 
     describe "depositor_for_document" do
       it "should return the depositor" do
-        expect(subject.send(:depositor_for_document, file.id)).to eq sender.user_key
+        expect(subject.send(:depositor_for_document, work.id)).to eq sender.user_key
       end
     end
 
-    context "with a ProxyDepositRequest for a file they have deposited" do
+    context "with a ProxyDepositRequest for a work they have deposited" do
       subject { Ability.new(sender) }
-      it { should be_able_to(:transfer, file.id) }
+      it { should be_able_to(:transfer, work.id) }
     end
 
     context "with a ProxyDepositRequest that they receive" do
-      let(:request) { ProxyDepositRequest.create!(generic_file_id: file.id, receiving_user: user, sending_user: sender) }
+      let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: user, sending_user: sender) }
       it { should be_able_to(:accept, request) }
       it { should be_able_to(:reject, request) }
       it { should_not be_able_to(:destroy, request) }
 
       context "and the request has already been accepted" do
-        let(:request) { ProxyDepositRequest.create!(generic_file_id: file.id, receiving_user: user, sending_user: sender, status: 'accepted') }
+        let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: user, sending_user: sender, status: 'accepted') }
         it { should_not be_able_to(:accept, request) }
         it { should_not be_able_to(:reject, request) }
         it { should_not be_able_to(:destroy, request) }
@@ -75,13 +75,13 @@ describe Sufia::Ability, :type => :model do
     end
 
     context "with a ProxyDepositRequest they are the sender of" do
-      let(:request) { ProxyDepositRequest.create!(generic_file_id: file.id, receiving_user: sender, sending_user: user) }
+      let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: sender, sending_user: user) }
       it { should_not be_able_to(:accept, request) }
       it { should_not be_able_to(:reject, request) }
       it { should be_able_to(:destroy, request) }
 
       context "and the request has already been accepted" do
-        let(:request) { ProxyDepositRequest.create!(generic_file_id: file.id, receiving_user: sender, sending_user: user, status: 'accepted') }
+        let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: sender, sending_user: user, status: 'accepted') }
         it { should_not be_able_to(:accept, request) }
         it { should_not be_able_to(:reject, request) }
         it { should_not be_able_to(:destroy, request) }

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -24,32 +24,7 @@ describe GenericFile, :type => :model do
       end
     end
   end
-
-  describe "created for someone (proxy)" do
-    before do
-      @transfer_to = FactoryGirl.find_or_create(:jill)
-    end
-
-    it "transfers the request" do
-      @file.on_behalf_of = @transfer_to.user_key
-      stub_job = double('change depositor job')
-      allow(ContentDepositorChangeEventJob).to receive(:new).and_return(stub_job)
-      expect(Sufia.queue).to receive(:push).with(stub_job).once.and_return(true)
-      @file.save!
-    end
-  end
-
-  describe "delegations" do
-    before do
-      @file.proxy_depositor = "sally@example.com"
-    end
-    it "should include proxies" do
-      expect(@file).to respond_to(:relative_path)
-      expect(@file).to respond_to(:depositor)
-      expect(@file.proxy_depositor).to eq 'sally@example.com'
-    end
-  end
-
+  
   describe '#to_s' do
     it 'uses the provided titles' do
       subject.title = ["Hello", "World"]

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -34,14 +34,14 @@ describe "Rake tasks" do
       Rake::Task.define_task(:environment)
     end
 
-    describe "deleting the namespace from ProxyDepositRequest#generic_file_id" do
+    describe "deleting the namespace from ProxyDepositRequest#generic_work_id" do
       let(:sender) { FactoryGirl.find_or_create(:jill) }
       let(:receiver) { FactoryGirl.find_or_create(:archivist) }
       before do
-        ProxyDepositRequest.create(generic_file_id: namespaced_id, sending_user: sender, receiving_user: receiver, sender_comment: "please take this")
+        ProxyDepositRequest.create(generic_work_id: namespaced_id, sending_user: sender, receiving_user: receiver, sender_comment: "please take this")
         Rake::Task["sufia:migrate:proxy_deposits"].invoke
       end
-      subject { ProxyDepositRequest.first.generic_file_id }
+      subject { ProxyDepositRequest.first.generic_work_id }
       it { is_expected.to eql corrected_id }
     end
 

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -151,15 +151,15 @@ describe "dashboard/index.html.erb", :type => :view do
       let(:title2) { 'bazquux' }
 
       before do
-        GenericFile.new(title: [title1]).tap do |f|
-          f.apply_depositor_metadata(another_user.user_key)
-          f.save!
-          f.request_transfer_to(user)
+        GenericWork.new(title: [title1]).tap do |w|
+          w.apply_depositor_metadata(another_user.user_key)
+          w.save!
+          w.request_transfer_to(user)
         end
-        GenericFile.new(title: [title2]).tap do |f|
-          f.apply_depositor_metadata(user.user_key)
-          f.save!
-          f.request_transfer_to(another_user)
+        GenericWork.new(title: [title2]).tap do |w|
+          w.apply_depositor_metadata(user.user_key)
+          w.save!
+          w.request_transfer_to(another_user)
         end
         allow(controller).to receive(:current_user).and_return(user)
         assign(:incoming, ProxyDepositRequest.where(receiving_user_id: user.id))
@@ -168,8 +168,8 @@ describe "dashboard/index.html.erb", :type => :view do
 
       it 'renders received and sent transfer requests' do
         render
-        expect(rendered).not_to include "You haven't received any file transfers requests"
-        expect(rendered).not_to include "You haven't transferred any files"
+        expect(rendered).not_to include "You haven't received any work transfers requests"
+        expect(rendered).not_to include "You haven't transferred any works"
         expect(rendered).to include title1
         expect(rendered).to include title2
       end

--- a/sufia-models/app/models/concerns/sufia/ability.rb
+++ b/sufia-models/app/models/concerns/sufia/ability.rb
@@ -54,7 +54,7 @@ module Sufia
     private
 
     def depositor_for_document(document_id)
-      ::GenericFile.load_instance_from_solr(document_id).depositor
+      ::GenericWork.load_instance_from_solr(document_id).depositor
     end
 
   end

--- a/sufia-models/app/models/concerns/sufia/generic_file.rb
+++ b/sufia-models/app/models/concerns/sufia/generic_file.rb
@@ -15,7 +15,6 @@ module Sufia
     include Sufia::GenericFile::Content
     include Sufia::GenericFile::VirusCheck
     include Sufia::GenericFile::FullTextIndexing
-    include Sufia::GenericFile::ProxyDeposit
     include Hydra::Collections::Collectible
     include Sufia::GenericFile::Batches
     include Sufia::GenericFile::Indexing

--- a/sufia-models/app/models/concerns/sufia/works/generic_work.rb
+++ b/sufia-models/app/models/concerns/sufia/works/generic_work.rb
@@ -11,5 +11,6 @@ module Sufia::Works
     include Sufia::GenericFile::Batches
     include Sufia::GenericFile::Content
     include Sufia::GenericFile::Permissions
+    include Sufia::Works::GenericWork::ProxyDeposit
   end
 end

--- a/sufia-models/app/models/concerns/sufia/works/generic_work/proxy_deposit.rb
+++ b/sufia-models/app/models/concerns/sufia/works/generic_work/proxy_deposit.rb
@@ -1,0 +1,31 @@
+module Sufia::Works
+  module GenericWork
+    module ProxyDeposit
+      extend ActiveSupport::Concern
+
+      included do
+        property :proxy_depositor, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#proxyDepositor'), multiple: false do |index|
+          index.as :symbol
+        end
+
+        # This value is set when a user indicates they are depositing this for someone else
+        property :on_behalf_of, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#onBehalfOf'), multiple: false do |index|
+          index.as :symbol
+        end
+
+        after_create :create_transfer_request
+      end
+
+
+      def create_transfer_request
+        Sufia.queue.push(ContentDepositorChangeEventJob.new(id, on_behalf_of)) if on_behalf_of.present?
+      end
+
+      def request_transfer_to(target)
+        raise ArgumentError, "Must provide a target" unless target
+        deposit_user = ::User.find_by_user_key(depositor)
+        ProxyDepositRequest.create!(generic_work_id: id, receiving_user: target, sending_user: deposit_user)
+      end
+    end
+  end
+end

--- a/sufia-models/app/models/concerns/sufia/works/proxy_deposit.rb
+++ b/sufia-models/app/models/concerns/sufia/works/proxy_deposit.rb
@@ -1,5 +1,5 @@
-module Sufia
-  module GenericFile
+module Sufia::Works
+  module GenericWork
     module ProxyDeposit
       extend ActiveSupport::Concern
 
@@ -24,7 +24,7 @@ module Sufia
       def request_transfer_to(target)
         raise ArgumentError, "Must provide a target" unless target
         deposit_user = ::User.find_by_user_key(depositor)
-        ProxyDepositRequest.create!(generic_file_id: id, receiving_user: target, sending_user: deposit_user)
+        ProxyDepositRequest.create!(generic_work_id: id, receiving_user: target, sending_user: deposit_user)
       end
     end
   end

--- a/sufia-models/app/models/proxy_deposit_request.rb
+++ b/sufia-models/app/models/proxy_deposit_request.rb
@@ -5,7 +5,10 @@ class ProxyDepositRequest < ActiveRecord::Base
   belongs_to :receiving_user, class_name: 'User'
   belongs_to :sending_user, class_name: 'User'
 
-  validates :sending_user, :generic_file_id, presence: true
+  # attribute generic_work_id exists as result of renaming in db migrations.
+  # See upgrade600_generator.rb and upgrade700_generator.rb
+
+  validates :sending_user, :generic_work_id, presence: true
   validate :transfer_to_should_be_a_valid_username
   validate :sending_user_should_not_be_receiving_user
   validate :should_not_be_already_part_of_a_transfer
@@ -24,17 +27,17 @@ class ProxyDepositRequest < ActiveRecord::Base
   end
 
   def sending_user_should_not_be_receiving_user
-    errors.add(:sending_user, 'must specify another user to receive the file') if receiving_user and receiving_user.user_key == sending_user.user_key
+    errors.add(:sending_user, 'must specify another user to receive the work') if receiving_user and receiving_user.user_key == sending_user.user_key
   end
 
   def should_not_be_already_part_of_a_transfer
-    transfers = ProxyDepositRequest.where(generic_file_id: generic_file_id, status: 'pending')
-    errors.add(:open_transfer, 'must close open transfer on the file before creating a new one') unless transfers.blank? || ( transfers.count == 1 && transfers[0].id == self.id)
+    transfers = ProxyDepositRequest.where(generic_work_id: generic_work_id, status: 'pending')
+    errors.add(:open_transfer, 'must close open transfer on the work before creating a new one') unless transfers.blank? || ( transfers.count == 1 && transfers[0].id == self.id)
   end
 
   def send_request_transfer_message
     if self.updated_at == self.created_at
-      message = "#{link_to(sending_user.name, Sufia::Engine.routes.url_helpers.profile_path(sending_user.user_key))} wants to transfer a file to you. Review all <a href='#{Sufia::Engine.routes.url_helpers.transfers_path}'>transfer requests</a>"
+      message = "#{link_to(sending_user.name, Sufia::Engine.routes.url_helpers.profile_path(sending_user.user_key))} wants to transfer a work to you. Review all <a href='#{Sufia::Engine.routes.url_helpers.transfers_path}'>transfer requests</a>"
       User.batchuser.send_message(receiving_user, message, "Ownership Change Request")
       else
         message = "Your transfer request was #{status}."
@@ -53,7 +56,7 @@ class ProxyDepositRequest < ActiveRecord::Base
 
   # @param [Boolean] reset (false) should the access controls be reset. This means revoking edit access from the depositor
   def transfer!(reset = false)
-    Sufia.queue.push(ContentDepositorChangeEventJob.new(generic_file_id, receiving_user.user_key, reset))
+    Sufia.queue.push(ContentDepositorChangeEventJob.new(generic_work_id, receiving_user.user_key, reset))
     self.status = 'accepted'
     self.fulfillment_date = Time.now
     save!
@@ -72,13 +75,13 @@ class ProxyDepositRequest < ActiveRecord::Base
     save!
   end
 
-  def deleted_file?
-    !GenericFile.exists?(generic_file_id)
+  def deleted_work?
+    !GenericWork.exists?(generic_work_id)
   end
 
   def title
-    return 'file not found' if deleted_file?
-    query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids([generic_file_id])
+    return 'work not found' if deleted_work?
+    query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids([generic_work_id])
     solr_response = ActiveFedora::SolrService.query(query, raw: true)
     SolrDocument.new(solr_response['response']['docs'].first, solr_response).title
   end

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/change_proxy_deposit_generic_file_id_to_generic_work_id.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/change_proxy_deposit_generic_file_id_to_generic_work_id.rb
@@ -1,0 +1,5 @@
+class ChangeProxyDepositGenericFileIdToGenericWorkId < ActiveRecord::Migration
+  def change
+    rename_column :proxy_deposit_requests, :generic_file_id, :generic_work_id
+  end
+end

--- a/sufia-models/lib/generators/sufia/models/upgrade600_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/upgrade600_generator.rb
@@ -12,8 +12,7 @@ This generator for upgrading sufia-models to 6.0 makes the following changes to 
   def copy_migrations
     [
       'change_audit_log_pid_to_generic_file_id.rb',
-      'change_proxy_deposit_request_pid_to_generic_file_id.rb',
-      'change_trophy_generic_file_id_to_generic_work_id.rb'
+      'change_proxy_deposit_request_pid_to_generic_file_id.rb'
     ].each do |file|
       better_migration_template file
     end

--- a/sufia-models/lib/generators/sufia/models/upgrade700_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/upgrade700_generator.rb
@@ -11,7 +11,8 @@ This generator for upgrading sufia-models to 7.0 makes the following changes to 
   # Setup the database migrations
   def copy_migrations
     [
-      'change_trophy_generic_file_id_to_generic_work_id.rb'
+      'change_trophy_generic_file_id_to_generic_work_id.rb',
+      'change_proxy_deposit_generic_file_id_to_generic_work_id.rb'
     ].each do |file|
       better_migration_template file
     end

--- a/sufia-models/lib/tasks/migrate.rake
+++ b/sufia-models/lib/tasks/migrate.rake
@@ -4,7 +4,7 @@
     desc "Migrate proxy deposits"
     task proxy_deposits: :environment do
       ProxyDepositRequest.all.each do |pd|
-        pd.generic_file_id = pd.generic_file_id.delete "#{Sufia.config.redis_namespace}:"
+        pd.generic_work_id = pd.generic_work_id.delete "#{Sufia.config.redis_namespace}:"
         pd.save
       end
     end


### PR DESCRIPTION
Refactor transfer and proxy specs to use GenericWork
Refactor ContentDepositorChangeEventJob to use GenericWork.
Refactor EvenJob attribute to id from generic_file_id.
  The version even job might eventually serve for both File and Work.
  In order to handle both, the id has to be agnostic.
Refactor EventJob spec to use GenericWork for depositor change event.
Refactor ProxyDepositRequest to use GenericWork.
Refactor ProxyDepositRequest spec for GenericWork.
Add proxy deposit test to GenericWork spec.
Add delegations test to GenericWork spec.
Remove proxy deposit test from GenericFile spec.
Remove delegations test from GenericFile spec.
Update migration template for ProxyDepositRequest to use generic_work_id.
Add migration template for ProxyDepositRequest.
Add upgrade migration for ProxyDepositRequest table.
Add comment explaining generic_work_id attribute in ProxyDepositRequest model.
Add proxy deposit to GenericWork.
Remove proxy deposit from GenericFile.
BatchControllerBehavior to check work of file to discover proxy deposit.
Update ProxyDeposit spec for GenericWork.
Add on_behalf_of test to Generic Work Controller spec.
Remove on_behalf_of test to Generic File Controller spec.
Refactor Abitity module for proxy and transfer to use GenericWork.
Refactor Ability module to check GenericWork for depositor.
Refactor Ability module proxies spec for GenericWork.
Refactor owner transfer controller for GenericWork.
Refactor owner transfer controller spec for GenericWork.
Refactor owner transfer spec to use GenericWork.
Update dashboard transfer spec to use GenericWork.
Make all pending in transfer work feature spec until UI and work_action_menu is implmented.
Refactor sufia helper behavior to use GenericWork for proxy and transfer.
Update rake task and spec for migrate proxy deposits.
The task for migrating proxies should use work instead of file.
The spec for migrating proxies should use work instead of file.