### PR TITLE
Adding in links to upload so files can be uploaded to a work and remo…

### DIFF
--- a/app/controllers/concerns/sufia/files_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller_behavior.rb
@@ -49,6 +49,7 @@ module Sufia
     # routed to /files/new
     def new
       @batch_id = ActiveFedora::Noid::Service.new.mint
+      @work_id = params[:work_id]
     end
 
     # routed to /files/:id/edit

--- a/app/controllers/curation_concern/generic_works_controller.rb
+++ b/app/controllers/curation_concern/generic_works_controller.rb
@@ -30,5 +30,15 @@ module CurationConcern
       end
     end
 
+
+    def after_create_response
+      puts "\n\nparams #{params[:save_with_files]}"
+      if params[:save_with_files].blank?
+        redirect_to sufia.generic_work_path(curation_concern.id)
+      else
+        redirect_to sufia.new_generic_file_path work_id: curation_concern.id
+      end
+    end
+
   end
 end

--- a/app/views/curation_concern/base/_form.html.erb
+++ b/app/views/curation_concern/base/_form.html.erb
@@ -19,10 +19,5 @@
       <%= link_to t(:'helpers.action.cancel'), main_app.root_path, class: 'btn btn-link' %>
     </div>
 
-    <%= render partial: 'works/base/upload/alerts' %>
-    <ul class="nav nav-tabs" role="tablist" title="Data Source Selectors" id="upload_tabs">
-      <li class="active" id="computer_tab" title="<%= t('sufia.upload.my_computer.sr_tab_label')+' '+ t('sufia.upload.my_computer.tab_label') %>"><a role="tab" href="#local" data-toggle="tab"><i class="glyphicon glyphicon-folder-open" aria-hidden="true"></i> <%= t('sufia.upload.my_computer.tab_label')%></a></li>
-    </ul>
-    <%= render partial: 'works/base/multiple_upload' %>
   </div>
 <% end %>

--- a/app/views/curation_concern/base/_permission_form.html.erb
+++ b/app/views/curation_concern/base/_permission_form.html.erb
@@ -1,4 +1,4 @@
-<% depositor = f.object.depositor || batch.generic_files.first.depositor %>
+<% depositor = @form.depositor %>
 <% public_perm = f.object.permissions.map { |perm| perm.access if perm.agent_name == "public"}.compact.first %>
 <% public_perm = true if params[:controller] == 'batch' %>
 <% registered_perm = f.object.permissions.map { |perm| perm.access if perm.agent_name == "registered"}.compact.first %>

--- a/app/views/generic_files/upload/_form_fields.html.erb
+++ b/app/views/generic_files/upload/_form_fields.html.erb
@@ -2,6 +2,7 @@
       <%= hidden_field_tag(:total_upload_size, 0) %>
       <%= hidden_field_tag(:relative_path) %>
       <%= hidden_field_tag(:batch_id, @batch_id) %>
+      <%= hidden_field_tag(:work_id, @work_id) %>
       <%= hidden_field_tag "file_coming_from", "local" %>
       <%= render partial: 'generic_files/upload/tos_checkbox' %>
         <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->


### PR DESCRIPTION
…ve errors on work new page.

Some of this code may be temporary, but it gets us back to a working state.

Forwarding to the genericFile upload page from the work adds the file to the work, but then send the user to the batch edit page.  This issue will need to be resolved by either modifying where the forma is being forwarded to on completion, or creating a completely separate for for uploading into a work.

It looks like the start of creating a separate form is in the codebase, but it was just not quite working.