### PR TITLE
Include the correct Metadata namespace. 

### DIFF
--- a/sufia-models/app/models/concerns/sufia/works/generic_work.rb
+++ b/sufia-models/app/models/concerns/sufia/works/generic_work.rb
@@ -5,7 +5,7 @@ module Sufia::Works
     include Hydra::Works::GenericWorkBehavior
     include Sufia::Works::Work
     include Sufia::Works::CurationConcern::WithBasicMetadata
-    include Sufia::Works::GenericWork::Metadata
+    include Sufia::Works::Metadata
     # TODO: Remove these items once the collection size(#1120) and 
     # processing tickets(#1122) are closed.
     include Sufia::GenericFile::Batches


### PR DESCRIPTION
The previous code referenced a non-existing namespace (but Rails masked the issue and loaded the correct one)