### PR TITLE
Adding a coffescript test for testing the terms of service javascript…

### DIFF
--- a/spec/javascripts/jasmine_spec.rb
+++ b/spec/javascripts/jasmine_spec.rb
@@ -1,16 +1,27 @@
 require 'spec_helper'
 
+# Run the jasmine tests by running the jasmine:ci rake command and capturing the output
+#   The spec will fail if any jasmine tests fails
+#
+#   If you have a jasmine syntax error the test will fail since there will not be zero failures
+#
+#   If you add a new jasmine test by adding a file to spec/javascripts/*spec.js* make sure the
+#   number of test run increments or you may have a syntax error inside your jasmine test
+#
 describe "Jasmine" do
   it "expects all jasmine tests to pass" do
     load_rake_environment ["#{jasmine_path}/lib/jasmine/tasks/jasmine.rake"]
     jasmine_out = run_task 'jasmine:ci'
     unless jasmine_out.include?  "0 failures"
-      puts "************************  Jasmine Output *************\n\n"
+      puts "\n\n************************  Jasmine Output *************"
       puts jasmine_out
       puts "************************  Jasmine Output *************\n\n"
+    else
+      js_specs_count = Dir['spec/javascripts/**/*_spec.js*'].count
+      puts "#{jasmine_out.match(/\n(.+) specs/)[1]} jasmine specs run (in #{js_specs_count} jasmine test files)"
     end
     expect(jasmine_out).to include "0 failures"
-    expect(jasmine_out).to_not include "0 specs"
+    expect(jasmine_out).to_not include "\n0 specs"
   end
 
 end

--- a/spec/javascripts/single_use_link_spec.js.coffee
+++ b/spec/javascripts/single_use_link_spec.js.coffee
@@ -1,0 +1,23 @@
+describe "single use link", ->
+
+    # call ajax to get a link
+    it "calls for the expected link", ->
+      # set up mock and response
+      resp = responseText: "/single_use_linkabc123"
+      options = {
+                  headers:
+                    Accept: 'application/javascript'
+                  type: 'get'
+                  url: "#{window.location.protocol}//#{window.location.host}/single_use_link/generate_show/abc123"
+                  async: false
+                }
+      se = spyOn($, "ajax").and.returnValue resp
+
+      # get the single use link
+      result = getSingleUse "copy_link_abc123"
+
+      #verify the result
+      expect(result).toEqual "#{window.location.protocol}//#{window.location.host}/single_use_linkabc123"
+
+      # verify the options sent to the ajax call
+      expect(se).toHaveBeenCalledWith(options)

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -51,7 +51,7 @@ helpers:
 #   - **/*[sS]pec.js
 #
 spec_files:
-  - '**/*[sS]pec.js'
+  - '**/*[sS]pec.js*'
 
 # src_dir
 #

--- a/spec/javascripts/terms_of_service_spec.js.coffee
+++ b/spec/javascripts/terms_of_service_spec.js.coffee
@@ -1,0 +1,32 @@
+describe "terms of service", ->
+    beforeEach ->
+        # setup a simple form with a checkbox and a button tomimic the upload forms
+        setFixtures  '<input id="check" type="checkbox" data-activate="activate-submit"><input><div id="div1" class="activate-container" data-toggle="tooltip"><button type="submit" class="activate-submit"></button></div>'
+
+        # call all the Blacklight.onLoad functions
+        Blacklight.activate()
+
+
+    # no submit button unless activate-submit is checked
+    it "submit is disabled by default", ->
+        expect($('.activate-submit')).toBeDisabled()
+
+    # shows tooltip until active-submit is checked
+    it "shows the tooltip by defualt", ->
+        se = spyOn $.fn, 'tooltip' # spy on tooltip call
+        $('.activate-container').trigger('mousemove')
+        expect(se).toHaveBeenCalledWith 'show'
+
+    describe "when checked", ->
+        # agree to the terms of service
+        beforeEach ->
+            $('#check').trigger('click')
+
+        it "activates submit when clicked", ->
+            expect($('.activate-submit')).not.toBeDisabled()
+
+        it "does not show the tooltip after checked", ->
+            se = spyOn $.fn, 'tooltip' # spy on tooltip call
+            $('.activate-container').trigger('mousemove')
+            expect(se).toHaveBeenCalledWith 'hide'
+


### PR DESCRIPTION
… and single use link javascript

Updated the spec runner to not fail on multiples of 10 and to output the number of jasmine tests run on passing to make it more transparant how many jasmine tests are running.