### PR TITLE
Allow the GenericFile show page to be loaded exclusively from solr

### DIFF
--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -524,6 +524,7 @@ describe GenericFilesController do
 
     describe "#show" do
       it "should show me the file and set breadcrumbs" do
+        expect(GenericFile).not_to receive(:find)
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('sufia.dashboard.title'), Sufia::Engine.routes.url_helpers.dashboard_index_path)
         get :show, id: generic_file
         expect(response).to be_successful

--- a/spec/services/generic_file_audit_service_spec.rb
+++ b/spec/services/generic_file_audit_service_spec.rb
@@ -44,19 +44,55 @@ describe Sufia::GenericFileAuditService do
 
   describe "#audit_stat" do
     subject { service.send(:audit_stat) }
-    context "when no audits have been run" do
-      it "should report that audits have not been run" do
-        expect(subject).to eq "Audits have not yet been run on this file."
+
+    describe "file loaded from fedora" do
+      context "when no audits have been run" do
+        it "should report that audits have not been run" do
+          expect(subject).to eq "Audits have not yet been run on this file."
+        end
+      end
+
+      context "when no audit is passing" do
+        before do
+         ChecksumAuditLog.create!(pass: 1, generic_file_id: f.id, version: f.content.versions.first.label, dsid: 'content')
+        end
+
+        it "should report that audit result" do
+          expect(subject).to eq 1
+        end
       end
     end
 
-    context "when no audit is pasing" do
-      before do
-       ChecksumAuditLog.create!(pass: 1, generic_file_id: f.id, version: f.content.versions.first.label, dsid: 'content')
+    describe "file loaded from solr" do
+      let(:solr_file) { GenericFile.load_instance_from_solr(f.id) }
+      let(:service) { Sufia::GenericFileAuditService.new(solr_file) }
+
+      it "should not audit by version" do
+        expect(service).not_to receive(:audit_stat_by_version)
+        expect(subject).to eq "Audits have not yet been run on this file."
       end
 
-      it "should report that audits have not been run" do
-        expect(subject).to eq 1
+      context "when no audit is passing" do
+        before do
+          ChecksumAuditLog.create!(pass: 1, generic_file_id: f.id, version: f.content.versions.first.label, dsid: 'content')
+        end
+
+        it "should report that audit result" do
+          expect(service).not_to receive(:audit_stat_by_version)
+          expect(subject).to eq 1
+        end
+      end
+
+      context "when one audit is passing" do
+        before do
+          ChecksumAuditLog.create!(pass: 0, generic_file_id: f.id, version: f.content.versions.first.label, dsid: 'content')
+          ChecksumAuditLog.create!(pass: 1, generic_file_id: f.id, version: f.content.versions.first.label, dsid: 'content')
+        end
+
+        it "should report that audit result" do
+          expect(service).not_to receive(:audit_stat_by_version)
+          expect(subject).to eq 0
+        end
       end
     end
   end

--- a/sufia-models/app/models/concerns/sufia/generic_file/characterization.rb
+++ b/sufia-models/app/models/concerns/sufia/generic_file/characterization.rb
@@ -100,7 +100,7 @@ module Sufia
 
       def characterization_terms
         h = {}
-        self.characterization.class.terminology.terms.each_pair do |k, v|
+        FitsDatastream.terminology.terms.each_pair do |k, v|
           next unless v.respond_to? :proxied_term
           term = v.proxied_term
           begin


### PR DESCRIPTION
Needed to adjust Audits and Characterization slightly to accommodate the solr backed GenericFile not having access to the same api as the fedora backed GenericFile. 