### PR TITLE
Restrict versions of bootstrap_form

### DIFF
--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'hydra-editor', '~> 0.3'
   gem.add_dependency 'hydra-collections', '~> 2.0'
   gem.add_dependency 'simple_form', '~> 3.1.0'
-  gem.add_dependency 'bootstrap_form', '~> 2.1'
+  gem.add_dependency 'bootstrap_form', '~> 2.1.1'
   gem.add_dependency 'blacklight-gallery'
   gem.add_dependency 'breadcrumbs_on_rails', '~>2.3.0'
   gem.add_dependency 'select2-rails'


### PR DESCRIPTION
Enables bundle install to finish under Sufia 5.0.