### PR TITLE
Refactors CSS to keep defaults intact and more specifically targets remove

### DIFF
--- a/app/assets/stylesheets/sufia/_buttons.scss
+++ b/app/assets/stylesheets/sufia/_buttons.scss
@@ -35,20 +35,16 @@ ul.listing .add, ul.listing .remove {
   }
 }
 
-.remove, .btn-danger {
+span.appliedFilter .remove, .btn-danger {
   background-color: $remove-background-color;
   border-color: $remove-border-color;
   color: $remove-text-color;
 }
-.remove:hover, .remove:focus,
+span.appliedFilter .remove:hover, span.appliedFilter .remove:focus,
 .btn-danger:hover, .btn-danger:focus {
   background-color: $remove-background-hover;
   border-color: $remove-border-color;
   color: $remove-text-hover;
-}
-
-span.facet-label .remove {
-  background-color: $panel-background-color;
 }
 
 .btn-warning {


### PR DESCRIPTION
Metadata edit for remove is using btn-danger, so I just needed to add span.appliedFilter to .remove to get the desired result. Facet X no longer has red background.