### PR TITLE
Handle unauthorized access to DepositorsController

### DIFF
--- a/app/controllers/concerns/sufia/depositors_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/depositors_controller_behavior.rb
@@ -7,6 +7,17 @@ module Sufia
       before_filter :validate_users, only: :create
     end
 
+
+    # Overriding the default behavior from Hydra::Core::ContorllerBehavior
+    def deny_access(exception)
+      if current_user and current_user.persisted?
+        redirect_to root_path, alert: exception.message
+      else
+        session['user_return_to'.freeze] = request.url
+        redirect_to new_user_session_path, alert: exception.message
+      end
+    end
+
     def create
       grantor = authorize_and_return_grantor
       grantee = ::User.from_url_component(params[:grantee_id])

--- a/spec/controllers/depositors_controller_spec.rb
+++ b/spec/controllers/depositors_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe DepositorsController, :type => :controller do
-  let(:user) { FactoryGirl.find_or_create(:jill) }
-  let(:grantee) { FactoryGirl.find_or_create(:archivist) }
+describe DepositorsController do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:grantee) { FactoryGirl.create(:user) }
 
   describe "as a logged in user" do
     before do
@@ -38,12 +38,16 @@ describe DepositorsController, :type => :controller do
     end
     describe "create" do
       it "should not be successful" do
-        expect { post :create, user_id: user, grantee_id: grantee, format: 'json' }.to raise_error
+        post :create, user_id: user.user_key, grantee_id: grantee.user_key, format: 'json'
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq "You are not authorized to access this page."
       end
     end
     describe "destroy" do
       it "should not be successful" do
-        expect { delete :destroy, user_id: user, id: grantee, format: 'json' }.to raise_error
+        delete :destroy, user_id: user.user_key, id: grantee.user_key, format: 'json'
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq "You are not authorized to access this page."
       end
     end
   end


### PR DESCRIPTION
The test was expecting some kind of error and it was receiving
ActionController::UrlGenerationError. This was caused by the default
access denied error redirecting to the `show` action which doesn't exist
for this particular controller.  This commit overrides the default
error handling code and updates the tests.