### PR TITLE
Remove logic around user groups from ability methods.

### DIFF
--- a/sufia-models/app/models/concerns/sufia/ability.rb
+++ b/sufia-models/app/models/concerns/sufia/ability.rb
@@ -19,7 +19,7 @@ module Sufia
       can :transfer, String do |id|
         depositor_for_document(id) == current_user.user_key
       end
-      can :create, ProxyDepositRequest if user_groups.include? 'registered'
+      can :create, ProxyDepositRequest if registered_user?
       can :accept, ProxyDepositRequest, receiving_user_id: current_user.id, status: 'pending'
       can :reject, ProxyDepositRequest, receiving_user_id: current_user.id, status: 'pending'
       # a user who sent a proxy deposit request can cancel it if it's pending.
@@ -31,16 +31,16 @@ module Sufia
     end
 
     def featured_work_abilities
-      can [:create, :destroy, :update], FeaturedWork if user_groups.include? 'admin'
+      can [:create, :destroy, :update], FeaturedWork if admin_user?
     end
 
     def generic_file_abilities
       can :view_share_work, [GenericFile]
-      can :create, [GenericFile, Collection] if user_groups.include? 'registered'
+      can :create, [GenericFile, Collection] if registered_user?
     end
 
     def editor_abilities
-      if user_groups.include? 'admin'
+      if admin_user?
         can :create, TinymceAsset
         can [:create, :update], ContentBlock
       end
@@ -53,9 +53,16 @@ module Sufia
 
     private
 
-    def depositor_for_document(document_id)
-      ::GenericFile.load_instance_from_solr(document_id).depositor
-    end
+      def depositor_for_document(document_id)
+        ::GenericFile.load_instance_from_solr(document_id).depositor
+      end
 
+      def registered_user?
+        user_groups.include? 'registered'
+      end
+
+      def admin_user?
+        user_groups.include? 'admin'
+      end
   end
 end


### PR DESCRIPTION
The current code forces downstream adopters to override entire ability methods, such as #editor_abilities, if they use a different strategy for determining if a user is an admin/registered user. Case in point: ScholarSphere overrides #editor_abilities, and because of this, when that method needs to change in Sufia, ScholarSphere's method needs to be updated manually to pick up the change. Instead, abstract away *how* users are determined to be registered/admin into their OWN methods.