### PR TITLE
Fixes HTML source order, adds ARIA roles, and skip to content link …

### DIFF
--- a/app/assets/stylesheets/sufia/_file-listing.scss
+++ b/app/assets/stylesheets/sufia/_file-listing.scss
@@ -1,3 +1,6 @@
+div.facets h3 {
+  font-size: 1.4em;
+}
 h4 .small {
   color: $navbar-default-toggle-icon-bar-bg;
 }

--- a/app/assets/stylesheets/sufia/_styles.scss
+++ b/app/assets/stylesheets/sufia/_styles.scss
@@ -54,6 +54,10 @@ button {
   margin: 20px;
 }
 
+.modal-title {
+  @extend h2
+}
+
 #footer {
   background: $blue-dark;
   clear: both;

--- a/app/views/collections/_form_for_select_collection.html.erb
+++ b/app/views/collections/_form_for_select_collection.html.erb
@@ -3,7 +3,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title" id="col_add_title"><%= t("sufia.collection.select_form.title") %></h4>
+          <span class="modal-title" id="col_add_title"><%= t("sufia.collection.select_form.title") %></span>
         </div>
         <div class="modal-body">
           <% if user_collections.blank? %>

--- a/app/views/layouts/sufia-dashboard.html.erb
+++ b/app/views/layouts/sufia-dashboard.html.erb
@@ -5,19 +5,20 @@
 <div id="wrapper">
   <div class="container-fluid">
     <div id="page-positioner">
-
+      <a href="#skip_to_content" class="sr-only">Skip to Content</a>
       <%= render partial: '/masthead' %>
       <%= render partial: '/controls' %>
       <%= render partial: '/flash_msg' %>
 
-      <div id="content-wrapper" class="dashboard">
+      <div id="content-wrapper" class="dashboard" role="main">
+        <a name="skip_to_content"></a>
         <div class="container-fluid">
           <div id="content-header" class="row"><%= yield :heading %></div>
         </div>
         <div class="container-fluid">
           <div id="content" class="row">
-            <div id="sidebar" class="col-xs-12 col-sm-3"><%= yield :sidebar %></div>
-            <div class="col-xs-12 col-sm-9"><%= yield %></div>
+            <div class="col-xs-12 col-sm-9 col-sm-push-3"><%= yield %></div>
+            <div id="sidebar" class="col-xs-12 col-sm-3 col-sm-pull-9"><%= yield :sidebar %></div>
           </div>
         </div>
       </div>

--- a/app/views/layouts/sufia-one-column.html.erb
+++ b/app/views/layouts/sufia-one-column.html.erb
@@ -8,10 +8,12 @@
 <div  id="wrapper">
   <div class="container-fluid">
     <div id="page-positioner">
+      <a href="#skip_to_content" class="sr-only">Skip to Content</a>
       <%= render partial: '/masthead' %>
       <%= render partial: '/controls' %>
       <%= render partial: '/flash_msg' %>
       <div id="content-wrapper" class="container-fluid">
+        <a name="skip_to_content"></a>
         <div id="content" class="row">
           <div class="col-xs-12">
             <%= yield %>

--- a/app/views/layouts/sufia-two-column.html.erb
+++ b/app/views/layouts/sufia-two-column.html.erb
@@ -8,16 +8,18 @@
 <div  id="wrapper"> 
   <div class="container-fluid">
     <div id="page-positioner">
+      <a href="#skip_to_content" class="sr-only">Skip to Content</a>
       <%= render partial: '/masthead' %>
       <%= render partial: '/controls' %>
       <%= render partial: '/flash_msg' %>
       <div id="content-wrapper" class="container-fluid">
+        <a name="skip_to_content"></a>
         <div class="row">
-          <div id="sidebar" class="col-xs-12 col-sm-3">
-            <%= yield :sidebar %>
-          </div>
-          <div id="content" class="col-xs-12 col-sm-9">
+          <div id="content" class="col-xs-12 col-sm-9 col-sm-push-3">
             <%= yield %>
+          </div>
+          <div id="sidebar" class="col-xs-12 col-sm-3 col-sm-push-9">
+            <%= yield :sidebar %>
           </div>
         </div><!-- /#content -->
       </div><!-- /#content-wrapper -->

--- a/app/views/my/_facet_layout.html.erb
+++ b/app/views/my/_facet_layout.html.erb
@@ -1,8 +1,8 @@
 <div class="panel panel-default facet_limit blacklight-<%= facet_field.field.parameterize %> <%= 'facet_limit-active' if facet_field_in_params?(facet_field.field) %>">
   <div class="<%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle panel-heading" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
-    <h5 class="panel-title">
+    <h4 class="panel-title">
       <%= link_to facet_field_label(facet_field.field), "#", :"data-no-turbolink" => true %>
-    </h5>
+    </h4>
   </div>
   <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'in' %>">
     <div class="panel-body">

--- a/app/views/my/_facets.html.erb
+++ b/app/views/my/_facets.html.erb
@@ -8,13 +8,11 @@
       <span class="fa fa-bars"></span>
     </button>
 
-  <h4>
-    <%= t("sufia.dashboard.my.facet_label.#{current_tab}") %>
-  </h4>
-    </div>
+    <h3><%= t("sufia.dashboard.my.facet_label.#{current_tab}") %></h3>
+  </div>
 
   <div id="facet-panel-collapse" class="collapse panel-group">
-  <%= render_facet_partials %>
-</div>
+    <%= render_facet_partials %>
+  </div>
 </div>
 <% end %>

--- a/app/views/my/index.html.erb
+++ b/app/views/my/index.html.erb
@@ -10,8 +10,8 @@
 
 <% @page_title = "#{current_tab.capitalize} listing" %>
 
-<ul class="nav nav-tabs" id="my_nav">
-  <h1 class="sr-only">Listing Navigation Bar</h1>
+<h1 class="sr-only">My Files, Collections, Highlights, and Files Shared with Me</h1>
+<ul class="nav nav-tabs" id="my_nav" role="navigation">
   <span class="sr-only">You are currently listing your <%= current_tab.pluralize %> .  You have <%= @response.docs.count %> <%= current_tab.pluralize(@response.docs.count)%> </span>
   <li class="<%= "active" if @selected_tab == :files %>">
     <%= link_to t('sufia.dashboard.my.files'), sufia.dashboard_files_path %>
@@ -29,10 +29,11 @@
 
 <%= render 'search_header' %>
 
-<h1 class="sr-only"><%=@page_title %></h1>
+<h2 class="sr-only"><%=@page_title %></h2>
 <%= render partial: 'document_list' %>
 
 <% content_for :sidebar do %>
+  <span class="sr-only">Upload Files or Create Collection</span>
   <%= link_to t('sufia.dashboard.upload_html'), sufia.new_generic_file_path, class: "btn btn-primary" %>
   <%= link_to t('sufia.dashboard.create_collection_html'), collections.new_collection_path, id: "hydra-collection-add", class: "btn btn-primary" %>
   <%= render partial: 'facets', locals: {current_tab: current_tab} %>


### PR DESCRIPTION
…for better accessibility.

I've swapped the order of the sidebar and main content area, adjusted some of the headings, added some ARIA roles, so that we have better accessibility compliance and remove a few errors. The "skip to content" link gives users the ability to jump over the banner and main navigation, so that they don't have to listen to each element being read by a screen reader if they just want to get to the content. The headings H1-H6 in proper order help users who use assistive devices navigate and understand the hierarchy of the content.