### PR TITLE
Making the image thumbnail alt tag empty for better accessibility, …

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -54,6 +54,7 @@ module Sufia
           else
             "default.png"
           end
+        options[:alt] = " "
         image_tag path, options
       end
     end


### PR DESCRIPTION
…since there is more information about title and description in the result.

The alt text should indicate the content or the function of the image rather than repeating the title. Rather than having duplicate information, it is preferred to leave the alt attribute empty with one space.