### PR TITLE
Swaps order of heading and sort, adjusts spacing of gallery display, …

### DIFF
--- a/app/assets/stylesheets/sufia/_collections.scss
+++ b/app/assets/stylesheets/sufia/_collections.scss
@@ -62,3 +62,18 @@
   color: #FFF;
   text-align: center;
 }
+
+.edit_collection {
+  margin-top: 20px;
+}
+
+div.view-type {
+  padding-left: 0;
+}
+
+form.per_page {
+  fieldset {
+    margin-bottom: 1em;
+    padding-left: 0;
+  }
+}

--- a/app/views/collections/_sort_and_per_page.html.erb
+++ b/app/views/collections/_sort_and_per_page.html.erb
@@ -13,15 +13,18 @@
      <%# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {action: "index"} but I'm not sure -%>
      <% unless @response.response['numFound'] < 2 %>
         <%= form_tag collections.collection_path(@collection), method: :get, class: 'per_page form-inline' do %>
-          <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
-          <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>
-          &nbsp;&nbsp;&nbsp;
-          <%= label_tag(:per_page) do %>
-            Show <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %> per page
-            <% end %>
-            <%= render_hash_as_hidden_fields(params_for_search.except(:per_page, :sort)) %>
-            &nbsp;&nbsp;&nbsp;
-            <button class="btn btn-info"><i class="glyphicon glyphicon-refresh"></i> Refresh</button>
+             <fieldset class="col-xs-12 col-sm-9 col-md-8 col-lg-10">
+               <legend class="sr-only"><%= t('sufia.sort_label') %></legend>
+               <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
+               <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>
+               <%= label_tag(:per_page) do %>
+                   Show <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %>
+                   per page
+               <% end %>
+               <%= render_hash_as_hidden_fields(params_for_search.except(:per_page, :sort)) %>
+               &nbsp;&nbsp;&nbsp;
+               <button class="btn btn-info"><span class="glyphicon glyphicon-refresh"></span> Refresh</button>
+             </fieldset>
             <%= render 'view_type_group' %>
          <% end %>
       <% end unless sort_fields.empty? %>

--- a/app/views/collections/_view_type_group.html.erb
+++ b/app/views/collections/_view_type_group.html.erb
@@ -1,5 +1,5 @@
 <% if has_alternative_views? -%>
-<div class="view-type">
+<div class="view-type col-xs-12 col-sm-3 col-md-4 col-lg-2">
   <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
   <div class="view-type-group btn-group">
     <%  document_index_views.each do |view, config| %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -20,19 +20,20 @@
     </div>
   </div>
 
-<%= render 'sort_and_per_page' %>
-
 <% if has_collection_search_parameters? %>
     <% header_title = "Search Results within this Collection" %>
 <% else %>
     <% header_title = "Items in this Collection" %>
 <% end %>
 
-<div>
-  <!-- Use CSS class h2 rather than HTML h2 tag to allow header and search box to align vertically -->
-  <span class="h2"><%= header_title %></span>
-  <%= render partial: 'search_form'%>
+<div class="row">
+  <div class="col-xs-12">
+    <h2 class="col-xs-6 col-md-7 col-lg-6"><%= header_title %></h2>
+    <div class="col-xs-6 col-md-5 col-lg-6"><%= render partial: 'search_form' %></div>
+  </div>
 </div>
+
+<%= render 'sort_and_per_page' %>
 
 <%= render_document_index @member_docs %>
 

--- a/app/views/my/_sort_and_per_page.html.erb
+++ b/app/views/my/_sort_and_per_page.html.erb
@@ -18,16 +18,20 @@
   <div class="sort-toggle">
     <% unless @response.response['numFound'] < 2 %>
       <%= form_tag sufia.dashboard_files_path, method: :get, class: 'per_page form-inline' do %>
-        <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
-        <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>			      
-        &nbsp;&nbsp;&nbsp;
-        <%= label_tag :per_page do %>
-          Show <%= select_tag :per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), 
-                              title: "Number of results to display per page" %> per page
-        <% end %>
-        <%= render_hash_as_hidden_fields params_for_search().except(:per_page, :sort, :utf8) %>
-        &nbsp;&nbsp;&nbsp;
-        <button class="btn btn-info" id="dashboard_sort_submit"><i class="glyphicon glyphicon-refresh"></i> Refresh</button>
+            <fieldset class="col-xs-12">
+              <legend class="sr-only"><%= t('sufia.sort_label') %></legend>
+              <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
+              <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>
+              <%= label_tag :per_page do %>
+                  Show <%= select_tag :per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])),
+                                      title: "Number of results to display per page" %> per page
+              <% end %>
+              <%= render_hash_as_hidden_fields(params_for_search.except(:per_page, :sort, :utf8)) %>
+              &nbsp;&nbsp;&nbsp;
+              <button class="btn btn-info" id="dashboard_sort_submit"><span class="glyphicon glyphicon-refresh"></span>
+                Refresh
+              </button>
+            </fieldset>
       <% end %>
     <% end unless sort_fields.empty? %>
   </div>

--- a/sufia-models/config/locales/sufia.en.yml
+++ b/sufia-models/config/locales/sufia.en.yml
@@ -4,3 +4,5 @@ en:
     product_twitter_handle: "@HydraSphere"
     institution_name:   "Institution Name"
     institution_name_full: "The Institution Name"
+    sort_label: "Sort the listing of items"
+


### PR DESCRIPTION
…and adds Bootstrap columns for structure

I've had to introduce Bootstrap rows and columns to accommodate different screen sizes and work around the inline style for the search box from Hydra Collections.

![screen shot 2015-07-10 at 1 35 38 pm](https://cloud.githubusercontent.com/assets/4163828/8625633/0cc8f94c-270e-11e5-8638-ddba233264d4.png)


![screen shot 2015-07-10 at 1 33 01 pm](https://cloud.githubusercontent.com/assets/4163828/8625637/14e7c446-270e-11e5-805a-92d2b4e10d16.png)

![screen shot 2015-07-10 at 1 32 01 pm](https://cloud.githubusercontent.com/assets/4163828/8625642/1c38ef72-270e-11e5-97b0-b21a5d58f33e.png)
