### PR TITLE
Fixes dropdown menu from being hidden on small devices 767px or smaller

### DIFF
--- a/app/assets/stylesheets/sufia/_file-listing.scss
+++ b/app/assets/stylesheets/sufia/_file-listing.scss
@@ -5,6 +5,13 @@ h4 .small {
   color: $navbar-default-toggle-icon-bar-bg;
 }
 
+@media screen and (max-width: 767px) {
+  .table-responsive .open > .dropdown-menu  {
+    position: relative;
+    left: -8em;
+  }
+}
+
 .table-responsive {
   overflow-x: visible;
 }


### PR DESCRIPTION
Adapted solution from a Bootstrap thread:

twbs/bootstrap#11037

![screen shot 2015-07-13 at 10 33 45 am](https://cloud.githubusercontent.com/assets/4163828/8659107/55c4d02a-2976-11e5-92e0-e0993bebf7b4.png)
