### PR TITLE
Adding an announcement editable content block to the home page

### DIFF
--- a/app/assets/stylesheets/sufia/_home-page.scss
+++ b/app/assets/stylesheets/sufia/_home-page.scss
@@ -55,3 +55,13 @@
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
 }
+
+div#announcement {
+  text-align: center;
+  color: white;
+  font-size: 1.5em;
+  background-color: $vermilion;
+  border: 10px solid white;
+  padding-top: 10px;
+  border-radius: 15px;
+}

--- a/app/controllers/concerns/sufia/homepage_controller.rb
+++ b/app/controllers/concerns/sufia/homepage_controller.rb
@@ -18,6 +18,7 @@ module Sufia::HomepageController
     @featured_researcher ||= ContentBlock.create(name: ContentBlock::RESEARCHER)
     @marketing_text = ContentBlock.find_or_create_by(name: ContentBlock::MARKETING)
     @featured_work_list = FeaturedWorkList.new
+    @announcement_text = ContentBlock.find_or_create_by(name: ContentBlock::ANNOUNCEMENT)
     recent
   end
 

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -2,6 +2,7 @@ class ContentBlock < ActiveRecord::Base
 
   MARKETING  = 'marketing_text'
   RESEARCHER = 'featured_researcher'
+  ANNOUNCEMENT = 'announcement_text'
 
   def self.recent_researchers
     where(name: RESEARCHER).order('created_at DESC')

--- a/app/views/homepage/_announcement.html.erb
+++ b/app/views/homepage/_announcement.html.erb
@@ -1,0 +1,5 @@
+<% if  can?(:update, ContentBlock) || !@announcement_text.value.blank? %>
+  <div id="announcement" class="row">
+    <%= editable_content_block @announcement_text %>
+  </div>
+<% end %>

--- a/app/views/homepage/_home.html.erb
+++ b/app/views/homepage/_home.html.erb
@@ -1,3 +1,4 @@
+<%= render 'announcement' %>
 <div id="home_header" class="row">
   <%= render partial: 'home_header' %>
 </div>

--- a/spec/controllers/homepage_controller_spec.rb
+++ b/spec/controllers/homepage_controller_spec.rb
@@ -99,5 +99,15 @@ describe HomepageController, :type => :controller do
         expect(assigns(:featured_work_list)).to be_kind_of FeaturedWorkList
       end
     end
+
+    it "sets announcement content block" do
+      get :index
+      expect(response).to be_success
+      assigns(:announcement_text).tap do |announcement|
+        expect(announcement).to be_kind_of ContentBlock
+        expect(announcement.name).to eq 'announcement_text'
+      end
+    end
+
   end
 end

--- a/spec/views/homepage/_announcement.html.erb_spec.rb
+++ b/spec/views/homepage/_announcement.html.erb_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe "homepage/_announcement.html.erb" do
+  let(:groups) { [] }
+  let(:ability) { instance_double("Ability") }
+  let(:announcement) { ContentBlock.new(name: ContentBlock::ANNOUNCEMENT, value: announcement_value) }
+
+  subject { rendered }
+
+  before do
+    assign(:announcement_text, announcement)
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:can?).with(:update, ContentBlock).and_return(can_update_content_block)
+    render
+  end
+
+  context "when there is an announcement" do
+    let(:announcement_value) { "I have an announcement!" }
+
+    context "when the user can update content" do
+      let(:can_update_content_block) { true }
+
+      it { is_expected.to have_content announcement_value }
+      it { is_expected.to have_button("Edit") }
+    end
+
+    context "when the user can't update content" do
+      let(:can_update_content_block) { false }
+
+      it { is_expected.to have_content announcement_value }
+      it { is_expected.not_to have_button("Edit") }
+    end
+  end
+
+  context "when there is no announcement" do
+    let(:announcement_value) { "" }
+
+    context "when the user can update content" do
+      let(:can_update_content_block) { true }
+
+      it { is_expected.to have_selector "#announcement" }
+      it { is_expected.to have_button("Edit") }
+    end
+
+    context "when the user can't update content" do
+      let(:can_update_content_block) { false }
+
+      it { is_expected.not_to have_selector "#announcement" }
+    end
+  end
+end


### PR DESCRIPTION
Non Admin User with no Announcement looks the same as it used to:
![screen shot 2015-07-16 at 12 40 59 pm](https://cloud.githubusercontent.com/assets/1599081/8729235/f71eead0-2bb7-11e5-821d-72877811be96.png)

Non Admin user with an announcement:
![screen shot 2015-07-16 at 12 40 22 pm](https://cloud.githubusercontent.com/assets/1599081/8729241/ff9ac5ee-2bb7-11e5-8ea1-64eb69df0d9e.png)

Admin user with an announcement:
![screen shot 2015-07-16 at 12 40 34 pm](https://cloud.githubusercontent.com/assets/1599081/8729239/fc881096-2bb7-11e5-811b-0d2e8c52f9d8.png)
