### PR TITLE
updated link_to_field in sufia_helper_behavior

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -105,7 +105,7 @@ module Sufia
     end
 
     def link_to_field(fieldname, fieldvalue, displayvalue = nil)
-      p = { search_field: 'advanced', fieldname => '"'+fieldvalue+'"' }
+      p = { search_field: 'advanced', fieldname => '"'+fieldvalue.to_s+'"' }
       link_url = catalog_index_path(p)
       display = displayvalue.blank? ? fieldvalue : displayvalue
       link_to(display, link_url)

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -28,11 +28,21 @@ describe SufiaHelper, :type => :helper do
   end
 
   describe "#link_to_field" do
+    context "when fieldvalue is a string" do
       it "should return a link to the proper field" do
         document = build(:generic_file, contributor: ["Joe"])
         field_link = catalog_index_path document, :contributor => "\"Joe\"", :search_field => "advanced"
         expect(helper.link_to_field("contributor", document.contributor.first)).to eq("<a href=\"#{ERB::Util.html_escape(field_link)}\">Joe</a>")
       end
+    end
+
+    context "when fieldvalue is an URI::RDF object" do
+      it "should return a link to the proper field" do
+        document = build(:generic_file, subject: [RDF::URI("http://id.loc.gov/authorities/subjects/sh88006360")])
+        field_link = catalog_index_path document, :subject => "\"" + document.subject.first.to_s + "\"", :search_field => "advanced"
+        expect(helper.link_to_field("subject", document.subject.first)).to eq("<a href=\"#{ERB::Util.html_escape(field_link)}\">#{ERB::Util.html_escape(document.subject.first.to_s)}</a>")
+      end
+    end
   end
 
   describe "has_collection_search_parameters?" do

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -27,6 +27,14 @@ describe SufiaHelper, :type => :helper do
     end
   end
 
+  describe "#link_to_field" do
+      it "should return a link to the proper field" do
+        document = build(:generic_file, contributor: ["Joe"])
+        field_link = catalog_index_path document, :contributor => "\"Joe\"", :search_field => "advanced"
+        expect(helper.link_to_field("contributor", document.contributor.first)).to eq("<a href=\"#{ERB::Util.html_escape(field_link)}\">Joe</a>")
+      end
+  end
+
   describe "has_collection_search_parameters?" do
     subject { helper }
     context "when cq is set" do


### PR DESCRIPTION
Updated link_to_field in sufia_helper_behavior so that it can receive other fieldvalue objects such as uri fields. Fixes #1263 