### PR TITLE
Tweak link text and switch Bootstrap icon from italic element to span.

### DIFF
--- a/app/views/users/_notify_link.html.erb
+++ b/app/views/users/_notify_link.html.erb
@@ -1,5 +1,5 @@
 <%= link_to sufia.notifications_path, id: "notify_link", class: "btn btn-default", title: "User Notifications" do %>
- <span class="sr-only">click for notifications.</span>
+ <span class="sr-only">View user notifications.</span>
  <%= render partial: 'users/notify_number' %>
 <% end %>  
 <div class='hide'> 

--- a/app/views/users/_notify_number.html.erb
+++ b/app/views/users/_notify_number.html.erb
@@ -1,4 +1,4 @@
-<i class="glyphicon glyphicon-bullhorn"></i>
+<span class="glyphicon glyphicon-bullhorn"></span>
 <% if @notify_number > 0 %>
   <span id="notify_number" class="overlay"> <%= @notify_number %></span>
   <span class="sr-only">unread notifications</span>


### PR DESCRIPTION
Minor tweak that originally came up as an empty link in the accessibility report.