### PR TITLE
Fixes 2 label issue for radio button and better accessibility …

### DIFF
--- a/app/views/collections/_form_for_select_collection.html.erb
+++ b/app/views/collections/_form_for_select_collection.html.erb
@@ -14,9 +14,9 @@
                 <legend><%= t("sufia.collection.select_form.select_heading") %></legend>
               <ul>
                 <% user_collections.sort { |c1,c2| c1['date_modified_dtsi'] <=> c2['date_modified_dtsi'] }.each do |collection|  %>
-                  <li> <label for="id_<%= collection.id %>" class="sr-only">Add to <%=collection.title%></label>
+                  <li>
                     <%= radio_button_tag(:id, collection.id, true, class: "collection-selector") %>
-                    <%= label_tag(:collection, collection.title, "aria-hidden" =>true) %>
+                    <%= label_tag(:collection, collection.title, for: "id_#{collection.id}") %>
                   </li>
                 <% end %>
               </ul>


### PR DESCRIPTION
…compliance. We were throwing 2 labels at the radio button problem for accessibility. While we used sr-only for the first label to announce to assistive technology the label of the radio button, and then had the second label for visual placement of the name of the collection, it didn't meet html or accessibility standards. 

I removed the first label, which is extraneous, and updated the second label so that the "for" attribute of the label accurately matches the "id" attribute of the radio button. Meets HTML and accessibility standards.

old way:
<img width="1413" alt="screen shot 2015-08-06 at 2 13 59 pm" src="https://cloud.githubusercontent.com/assets/4163828/9119747/63236d0c-3c46-11e5-8431-f374e6644a79.png">


new way:
<img width="1411" alt="screen shot 2015-08-06 at 2 16 00 pm" src="https://cloud.githubusercontent.com/assets/4163828/9119757/73101dc8-3c46-11e5-8389-f8ae49f71e40.png">
