### PR TITLE
Fix problems with single use download links.

### DIFF
--- a/app/controllers/concerns/sufia/single_use_links_viewer_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/single_use_links_viewer_controller_behavior.rb
@@ -31,6 +31,12 @@ module Sufia
 
     protected
 
+      def content_options
+        super.tap do |options|
+          options[:disposition] = 'attachment' if action_name == 'download'
+        end
+      end
+
       def presenter
         presenter_class.new(@asset)
       end

--- a/app/views/single_use_links/new_download.html.erb
+++ b/app/views/single_use_links/new_download.html.erb
@@ -1,5 +1,5 @@
 <div class="single-use-link">
 <h1>Single Use Link</h1>
 <p>Anyone can use the following link once to download the file</p>
-<%= link_to @asset, @link, class: 'download-link' %> <%= link_to raw('<i class="glyphicon glyphicon-link large-icon"></i>'), '#', class: 'copypaste itemicon itemcode', title: 'Copy File URL', id: "copy_link_#{@asset.id}" %>
+<%= link_to @asset, @link, class: 'download-link', data: { 'no-turbolink' => ''} %> <%= link_to raw('<i class="glyphicon glyphicon-link large-icon"></i>'), '#', class: 'copypaste itemicon itemcode', title: 'Copy File URL', id: "copy_link_#{@asset.id}" %>
 </div>

--- a/app/views/single_use_links_viewer/show.html.erb
+++ b/app/views/single_use_links_viewer/show.html.erb
@@ -2,7 +2,7 @@
   <h1 class="lower"><%= @asset %></h1>
     <h2 class="non lower">Actions</h2>
     <p>
-      <%= link_to "Download (can only be used once)", @download_link %>
+      <%= link_to "Download (can only be used once)", @download_link, data: { 'no-turbolink' => ''} %>
     </p>
   <h2> Descriptions:</h2>
 

--- a/spec/controllers/single_use_links_viewer_controller_spec.rb
+++ b/spec/controllers/single_use_links_viewer_controller_spec.rb
@@ -30,7 +30,7 @@ describe SingleUseLinksViewerController do
       let(:expected_content) { ActiveFedora::Base.find(file.id).content.content }
 
       it "and_return http success" do
-        expect(controller).to receive(:send_file_headers!).with(filename: 'world.png', disposition: 'inline', type: 'image/png')
+        expect(controller).to receive(:send_file_headers!).with(filename: 'world.png', disposition: 'attachment', type: 'image/png')
         get :download, id: download_link_hash
         expect(response.body).to eq expected_content
         expect(response).to be_success

--- a/spec/views/single_use_links/new_download.html.erb_spec.rb
+++ b/spec/views/single_use_links/new_download.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'single_use_links/new_download.html.erb' do
+  let(:user) { FactoryGirl.find_or_create(:jill) }
+  let(:file) do
+    GenericFile.create do |f|
+      f.add_file(File.open(fixture_path + '/world.png'), path: 'content', original_name: 'world.png')
+      f.label = 'world.png'
+      f.apply_depositor_metadata(user)
+    end
+  end
+
+  let(:hash) { "some-dummy-sha2-hash" }
+
+  before do
+    assign :asset, file
+    assign :link, Sufia::Engine.routes.url_helpers.download_single_use_link_path(hash)
+    render
+  end
+
+  it "has the download link" do
+    expect(rendered).to have_selector "a.download-link"
+  end
+
+  it "has turbolinks disabled in the download link" do
+    expect(rendered).to have_selector "a.download-link[data-no-turbolink]"
+  end
+end

--- a/spec/views/single_use_links_viewer/show.html.erb_spec.rb
+++ b/spec/views/single_use_links_viewer/show.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'single_use_links_viewer/show.html.erb' do
+  let(:user) { FactoryGirl.find_or_create(:jill) }
+  let(:file) do
+    GenericFile.create do |f|
+      f.add_file(File.open(fixture_path + '/world.png'), path: 'content', original_name: 'world.png')
+      f.label = 'world.png'
+      f.apply_depositor_metadata(user)
+    end
+  end
+
+  let(:hash) { "some-dummy-sha2-hash" }
+
+  before do
+    assign :asset, file
+    assign :download_link, Sufia::Engine.routes.url_helpers.download_single_use_link_path(hash)
+    assign :presenter, Sufia::GenericFilePresenter.new(file)
+    render
+  end
+
+  it "contains a download link" do
+    expect(rendered).to have_selector "a[href^='/single_use_link/download/']"
+  end
+
+  it "has turbolinks disabled in the download link" do
+    expect(rendered).to have_selector "a[data-no-turbolink][href^='/single_use_link/download/']"
+  end
+end


### PR DESCRIPTION
Fixes two problems that caused single use download links not to work.

First problem was caused by Turbolinks attempting to load the file asynchronously before the browser did a proper request. The first request by Turbolinks invalidated the single use link and then the browser failed to download the file. This is fixed by adding data-no-turbolink in the link attributes, which disabled Turbolinks for this link.

The second problem was also caused by multiple requests for the same single use link. At least in Chrome, trying to download a PDF file causes the browser to first issue a request, then it opens a PDF viewer (presumably after seeing the content-type in the response headers) which issues another request for the file. The second request will fail because the link is invalid at this point. This is fixed by instructing the browser to save the file with a Content-Disposition: attachment header. 
