### PR TITLE
Fix sorting issues with collections.

### DIFF
--- a/app/controllers/concerns/sufia/my_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/my_controller_behavior.rb
@@ -52,6 +52,8 @@ module Sufia
       @batch_size_on_other_page = batch_size - count_on_page
       @batch_part_on_other_page = (@batch_size_on_other_page) > 0
 
+      @add_files_to_collection = params.fetch(:add_files_to_collection, '')
+
       respond_to do |format|
         format.html {}
         format.rss  { render layout: false }

--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -45,7 +45,17 @@ module Sufia
       return unless field.present?
       begin
         Date.parse(field).to_formatted_s(:standard)
-      rescue
+      rescue ArgumentError
+        ActiveFedora::Base.logger.info "Unable to parse date: #{field.first.inspect} for #{self['id']}"
+      end
+    end
+
+    def create_date
+      field = self[CatalogController.uploaded_field]
+      return unless field.present?
+      begin
+        Date.parse(field).to_formatted_s(:standard)
+      rescue ArgumentError
         ActiveFedora::Base.logger.info "Unable to parse date: #{field.first.inspect} for #{self['id']}"
       end
     end

--- a/app/views/collections/_form_for_select_collection.html.erb
+++ b/app/views/collections/_form_for_select_collection.html.erb
@@ -13,9 +13,10 @@
               <fieldset>
                 <legend><%= t("sufia.collection.select_form.select_heading") %></legend>
               <ul>
-                <% user_collections.sort { |c1,c2| c1['date_modified_dtsi'] <=> c2['date_modified_dtsi'] }.each do |collection|  %>
+                <% user_collections.sort { |c1,c2| c2[CatalogController.uploaded_field] <=> c1[CatalogController.uploaded_field] }.each_with_index do |collection,index|  %>
                   <li>
-                    <%= radio_button_tag(:id, collection.id, true, class: "collection-selector") %>
+                    <% selected = (collection.id == @add_files_to_collection) || (@add_files_to_collection.blank? && index == 0) %>
+                    <%= radio_button_tag(:id, collection.id, selected, class: "collection-selector") %>
                     <%= label_tag(:collection, collection.title, for: "id_#{collection.id}") %>
                   </li>
                 <% end %>
@@ -28,10 +29,10 @@
           <button type="button" class="btn btn-default" data-dismiss="modal"><%= t("sufia.collection.select_form.close")%></button>
           <% if user_collections.blank? %>
             <%= button_for_create_collection t("sufia.collection.select_form.create") %>
-          <% else %> 
+          <% else %>
             <%= button_for_update_collection t("sufia.collection.select_form.update") %>
             <%= button_for_create_collection t("sufia.collection.select_form.create_new") %>
-          <% end %> 
+          <% end %>
         </div>
       </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/app/views/collections/_show_actions.html.erb
+++ b/app/views/collections/_show_actions.html.erb
@@ -2,6 +2,6 @@
 <div class="actions-controls-collections">
   <% if can? :edit, @collection %>
       <span class="label label-default"><%= link_to "Edit", collections.edit_collection_path, title: "Edit this Collection" %></span> &nbsp;&nbsp;
-      <span class="label label-default"><%= link_to "Add files",  sufia.dashboard_files_path, title: "Add files to this Collection" %></span>
+      <span class="label label-default"><%= link_to "Add files",  sufia.dashboard_files_path( add_files_to_collection: @collection.id ), title: "Add files to this Collection" %></span>
   <%end %>
 </div>

--- a/app/views/my/_index_partials/_default_group.html.erb
+++ b/app/views/my/_index_partials/_default_group.html.erb
@@ -5,7 +5,7 @@
   <tr>
     <th><label for="check_all" class="sr-only"><%= t("sufia.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
     <th>Title</th>
-    <th class="sorts-dash"><i id="date_uploaded_dtsi" class="<%=params[:sort]== "date_uploaded_dtsi desc" ? 'caret' : params[:sort]== "date_uploaded_dtsi asc" ? 'caret up' : ''%>"></i>Date Uploaded</th>
+    <th class="sorts-dash"><i id="<%= CatalogController.uploaded_field %>" class="<%=params[:sort]== "#{CatalogController.uploaded_field} desc" ? 'caret' : params[:sort]== "#{CatalogController.uploaded_field} asc" ? 'caret up' : ''%>"></i>Date Uploaded</th>
     <th>Visibility</th>
     <th>Action</th>
   </tr>

--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -21,7 +21,7 @@
       </div>
     </div>
   </td>
-  <td width="17%"><%= document.date_uploaded %> </td>
+  <td width="17%" class="text-center"><%= document.create_date %> </td>
   <td width="5%" class="text-center">
       <% if document.registered? %>
      <span class="label label-info" title="<%=t('sufia.institution_name') %>"><%=t('sufia.institution_name') %></span></a>

--- a/app/views/my/_index_partials/_list_files.html.erb
+++ b/app/views/my/_index_partials/_list_files.html.erb
@@ -22,7 +22,7 @@
     </a>
     <div class="part_of_collection"><%= render_collection_list(gf) %></div>
   </td>
-  <td class="text-center"><%= document.date_uploaded %> </td>
+  <td class="text-center"><%= document.create_date %> </td>
   <td class="text-center">
     <%= render_visibility_link document %>
   </td>

--- a/app/views/my/_sort_and_per_page.html.erb
+++ b/app/views/my/_sort_and_per_page.html.erb
@@ -1,4 +1,4 @@
-<div class="batch-info"> 
+<div class="batch-info">
   <div>
     <%= render partial: 'collections/form_for_select_collection', locals: {user_collections: @user_collections}  %>
   </div>
@@ -17,7 +17,7 @@
 
   <div class="sort-toggle">
     <% unless @response.response['numFound'] < 2 %>
-      <%= form_tag sufia.dashboard_files_path, method: :get, class: 'per_page form-inline' do %>
+      <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page form-inline' do %>
             <fieldset class="col-xs-12">
               <legend class="sr-only"><%= t('sufia.sort_label') %></legend>
               <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
@@ -35,5 +35,5 @@
       <% end %>
     <% end unless sort_fields.empty? %>
   </div>
-  
+
 </div>

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -20,11 +20,11 @@ class CatalogController < ApplicationController
   skip_before_filter :default_html_head
 
   def self.uploaded_field
-    solr_name('date_uploaded', :stored_sortable, type: :date)
+    solr_name('system_create', :stored_sortable, type: :date)
   end
 
   def self.modified_field
-    solr_name('date_modified', :stored_sortable, type: :date)
+    solr_name('system_modified', :stored_sortable, type: :date)
   end
 
   configure_blacklight do |config|

--- a/spec/controllers/my/files_controller_spec.rb
+++ b/spec/controllers/my/files_controller_spec.rb
@@ -87,4 +87,9 @@ describe My::FilesController, type: :controller do
       expect(assigns(:batches)).to include("ss-" + batch_id2)
     end
   end
+
+  it "sets add_files_to_collection when provided in params" do
+    get :index, add_files_to_collection: '12345'
+    expect(assigns(:add_files_to_collection)).to eql('12345')
+  end
 end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -25,6 +25,15 @@ describe 'collection', type: :feature do
   let(:title2) { "Test Collection 2" }
   let(:description2) { "Description for collection 2 we are testing." }
 
+  let(:collection1) do
+    Collection.create(title: title1, description: description1,
+                      members: []) { |c| c.apply_depositor_metadata(user.user_key) }
+  end
+  let(:collection2) do
+    Collection.create(title: title2, description: description2,
+                      members: []) { |c| c.apply_depositor_metadata(user.user_key) }
+  end
+
   let(:user) { FactoryGirl.create(:user) }
 
   let(:gfs) do
@@ -137,6 +146,69 @@ describe 'collection', type: :feature do
       expect(page).to have_content("Search Results")
       expect(page).to have_content(gf1.title.first)
       expect(page).to_not have_content(gf2.title.first)
+    end
+  end
+
+  describe 'collection sorting' do
+    before do
+      collection1 # create the collections by referencing them
+      sleep(1) # make sure the timestamps aren't equal
+      collection2
+      sleep(1)
+      collection1.title += 'changed'
+      collection1.save
+      # collection 1 is now earlier when sorting by create date but later
+      # when sorting by modified date
+
+      sign_in user
+      visit '/dashboard/collections'
+    end
+
+    it "has creation date for collections" do
+      expect(page).to have_content(collection1.create_date.to_date.to_formatted_s(:standard))
+    end
+
+    it "allows changing sort order" do
+      find(:xpath, "//select[@id='sort']/option[contains(., 'date modified')][contains(@value, 'asc')]") \
+        .select_option
+      click_button('Refresh')
+      expect(page).to have_css("#document_#{collection1.id}")
+      expect(page).to have_css("#document_#{collection2.id}")
+      expect(page.body.index("id=\"document_#{collection1.id}")).to be > page.body.index("id=\"document_#{collection2.id}")
+
+      find(:xpath, "//select[@id='sort']/option[contains(., 'date modified')][contains(@value, 'desc')]") \
+        .select_option
+      click_button('Refresh')
+      expect(page).to have_css("#document_#{collection1.id}")
+      expect(page).to have_css("#document_#{collection2.id}")
+      expect(page.body.index("id=\"document_#{collection1.id}")).to be < page.body.index("id=\"document_#{collection2.id}")
+    end
+  end
+
+  describe 'add files to collection' do
+    let!(:gf1) { gfs[0] }
+    let!(:gf2) { gfs[1] }
+
+    before do
+      collection1 # create collections by referencing them
+      collection2
+      sign_in user
+    end
+
+    it "preselects the collection we are adding files to" do
+      visit "/collections/#{collection1.id}"
+      click_link 'Add files'
+      first('input#check_all').click
+      click_button "Add to Collection"
+      expect(page).to have_css("input#id_#{collection1.id}[checked='checked']")
+      expect(page).not_to have_css("input#id_#{collection2.id}[checked='checked']")
+
+      visit "/collections/#{collection2.id}"
+      click_link 'Add files'
+      first('input#check_all').click
+      click_button "Add to Collection"
+      expect(page).not_to have_css("input#id_#{collection1.id}[checked='checked']")
+      expect(page).to have_css("input#id_#{collection2.id}[checked='checked']")
     end
   end
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -8,6 +8,34 @@ describe SolrDocument, type: :model do
     it "is a date" do
       expect(subject.date_uploaded).to eq '03/14/2013'
     end
+    it "logs parse errors" do
+      expect(ActiveFedora::Base.logger).to receive(:info).with(/Unable to parse date.*/)
+      subject['date_uploaded_dtsi'] = 'Test'
+      subject.date_uploaded
+    end
+  end
+
+  describe "create_date" do
+    before do
+      subject['system_create_dtsi'] = '2013-03-14T00:00:00Z'
+    end
+    it "is a date" do
+      expect(subject.create_date).to eq '03/14/2013'
+    end
+    it "logs parse errors" do
+      expect(ActiveFedora::Base.logger).to receive(:info).with(/Unable to parse date.*/)
+      subject['system_create_dtsi'] = 'Test'
+      subject.create_date
+    end
+  end
+
+  describe "resource_type" do
+    before do
+      subject['resource_type_tesim'] = ['Image']
+    end
+    it "returns the resource type" do
+      expect(subject.resource_type).to eq ['Image']
+    end
   end
 
   describe '#to_param' do

--- a/spec/views/catalog/sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/catalog/sort_and_per_page.html.erb_spec.rb
@@ -24,6 +24,6 @@ describe 'catalog/_sort_and_per_page.html.erb', type: :view do
 
   it 'displays the relevance option for sorting' do
     render
-    expect(rendered).to include("<li><a href=\"/catalog?sort=score+desc%2C+date_uploaded_dtsi+desc\">relevance</a></li>")
+    expect(rendered).to include("<li><a href=\"/catalog?sort=score+desc%2C+system_create_dtsi+desc\">relevance</a></li>")
   end
 end

--- a/spec/views/collections/_form_for_select_collection.html.erb_spec.rb
+++ b/spec/views/collections/_form_for_select_collection.html.erb_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'collections/_form_for_select_collection.html.erb' do
+  let(:collections) {
+    [
+      Collection.new(id: '1234', title: 'collection 1', create_date: DateTime.parse('Thu, 13 Aug 2015 14:20:22 +0100')),
+      Collection.new(id: '1235', title: 'collection 2', create_date: DateTime.parse('Thu, 13 Aug 2015 14:18:22 +0100')),
+      Collection.new(id: '1236', title: 'collection 3', create_date: DateTime.parse('Thu, 13 Aug 2015 14:16:22 +0100')),
+      Collection.new(id: '1237', title: 'collection 4', create_date: DateTime.parse('Thu, 13 Aug 2015 14:29:22 +0100'))
+    ]
+  }
+  let(:solr_collections) {
+    collections.map do |c|
+      SolrDocument.new(c.to_solr).tap do |sd|
+        sd['system_create_dtsi'] = c.create_date.to_s
+      end
+    end
+  }
+
+  let(:doc) {
+    Nokogiri::HTML(rendered)
+  }
+
+  before do
+    allow(view).to receive(:user_collections).and_return(solr_collections)
+  end
+
+  it "sorts the collections" do
+    render
+    collection_ids = doc.xpath("//input[@class='collection-selector']/@id").map(&:to_s)
+    expect(collection_ids).to eql(["id_1237", "id_1234", "id_1235", "id_1236"])
+  end
+
+  it "selects the right collection when instructed to do so" do
+    assign(:add_files_to_collection, collections[2].id)
+    render
+    expect(rendered).not_to have_selector "#id_#{collections[0].id}[checked='checked']"
+    expect(rendered).not_to have_selector "#id_#{collections[1].id}[checked='checked']"
+    expect(rendered).not_to have_selector "#id_#{collections[3].id}[checked='checked']"
+    expect(rendered).to have_selector "#id_#{collections[2].id}[checked='checked']"
+  end
+
+  it "selects the first collection when nothing else specified" do
+    # first when sorted by create date, so not index 0
+    render
+    expect(rendered).not_to have_selector "#id_#{collections[0].id}[checked='checked']"
+    expect(rendered).not_to have_selector "#id_#{collections[1].id}[checked='checked']"
+    expect(rendered).not_to have_selector "#id_#{collections[2].id}[checked='checked']"
+    expect(rendered).to have_selector "#id_#{collections[3].id}[checked='checked']"
+  end
+end


### PR DESCRIPTION
Fixes #1272. There are a some potential issues with this pull request which should be considered before merging.

As discussed in the issue page, collections don't have date_uploaded or date_modified set so something else needs to be used for sorting. I changed sorting to use create_date and modified_date, which are indexed in Solr as system_create_dtsi and system_modified_dtsi. This change applies to both GenericFiles and Collections. One file that needed changing was the [catalog_controller generator template](https://github.com/projecthydra/sufia/blob/master/lib/generators/sufia/templates/catalog_controller.rb#L22-L28) where it's difficult to differentiate the behaviour between GenericFiles and Collections.

At first I thought that create_date and date_uploaded would be identical in GenericFiles so this wouldn't be a problem, but I then came across [this comment](https://github.com/projecthydra/sufia/blob/master/sufia-models/app/models/concerns/sufia/generic_file/metadata.rb#L51-L55) in metadata.rb

```ruby
# We reserve date_uploaded for the original creation date of the record.
# For example, when migrating data from a fedora3 repo to fedora4,
# fedora's system created date will reflect the date when the record
# was created in fedora4, but the date_uploaded will preserve the
# original creation date from the old repository.
```

So using the create_date instead of date_uploaded is less than ideal in cases where migration has been used at some point. (As a side note, not having the original creation date of collections preserved at all in migrations might be a problem in itself.)

Note that this PR also adds a small improvement that was not part of the original issue but is related. When clicking the Add Files link in a collection page, I set it to pass the id of the collection as a parameter which goes through to the collection list template so that the correct collection can be preselected there. The list used to have the checked attribute set for all options which resulted in the last collection in the list to be selected (at least on the browser I use). The user however might expect the collection where they started the operation at to be selected and if they don't pay attention, they could easily add the files to the wrong collection.