### PR TITLE
Added citation configuration to sufia. Allows for rendering citation link on show page

### DIFF
--- a/app/views/generic_files/_show_actions.html.erb
+++ b/app/views/generic_files/_show_actions.html.erb
@@ -5,6 +5,10 @@
         &nbsp;|&nbsp;
         <%= link_to "Analytics", sufia.stats_generic_file_path(@generic_file), id: 'stats' %>
       <% end %>
+      <% if Sufia.config.citations %>
+        &nbsp;|&nbsp;
+        <%= link_to "Citations", sufia.citation_generic_file_path(@generic_file), id: 'citations' %>
+      <% end %>
       <% if can? :edit, @generic_file %>
           &nbsp;|&nbsp;
           <% if @generic_file.processing? %>

--- a/spec/views/generic_file/show.html.erb_spec.rb
+++ b/spec/views/generic_file/show.html.erb_spec.rb
@@ -216,6 +216,29 @@ describe 'generic_files/show.html.erb', :type => :view do
     end
   end
 
+  describe 'citations' do
+    let(:page) { Capybara::Node::Simple.new(rendered) }
+    before do
+      Sufia.config.citations = citations
+      render
+    end
+    context 'when enabled' do
+      let(:citations) { true }
+
+      it 'appears on page' do
+        expect(page).to have_selector('a#citations', count: 1)
+      end
+    end
+
+    context 'when disabled' do
+      let(:citations) { false }
+
+      it 'does not appear on page' do
+        expect(page).to have_no_selector('a#citations')
+      end
+    end
+  end
+
   describe 'featured' do
     before do
       allow(generic_file).to receive(:public?).and_return(public)

--- a/sufia-models/lib/generators/sufia/models/citation_config_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/citation_config_generator.rb
@@ -1,0 +1,22 @@
+require 'rails/generators'
+
+class Sufia::Models::CitationConfigGenerator < Rails::Generators::Base
+  source_root File.expand_path('../templates', __FILE__)
+
+  desc """
+This Generator makes the following changes to your application:
+  1. Updates existing sufia.rb initializer to include a citation configuration
+       """
+
+  def banner
+    say_status("info", "ADDING CITATIONS OPTION TO SUFIA CONFIG", :blue)
+  end
+
+  def inject_config_initializer
+    inject_into_file 'config/initializers/sufia.rb', before: "# Where to store tempfiles, leave blank for the system temp directory (e.g. /tmp)" do
+      "# Enables a link to the citations page for a generic_file.\n" +
+        "# Default is false\n" +
+        "# config.citations = false\n"
+    end
+  end
+end

--- a/sufia-models/lib/generators/sufia/models/install_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/install_generator.rb
@@ -15,6 +15,7 @@ This generator makes the following changes to your application:
  8. Runs cached stats generator
  9. Runs ORCID field generator
 10. Runs user stats generator
+11. Runs citation config generator
        """
   def banner
     say_status("info", "GENERATING SUFIA MODELS", :blue)
@@ -108,5 +109,10 @@ This generator makes the following changes to your application:
   # Adds clamav initializtion
   def clamav
     generate 'sufia:models:clamav'
+  end
+
+  # Adds citations initialization
+  def citation_config
+    generate 'sufia:models:citation_config'
   end
 end

--- a/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
@@ -91,6 +91,10 @@ Sufia.config do |config|
   # Specify a date you wish to start collecting Google Analytic statistics for.
   # config.analytic_start_date = DateTime.new(2014,9,10)
 
+  # Enables a link to the citations page for a generic_file.
+  # Default is false
+  # config.citations = false
+
   # Where to store tempfiles, leave blank for the system temp directory (e.g. /tmp)
   # config.temp_file_base = '/home/developer1'
 

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -26,6 +26,7 @@ module Sufia
       config.browse_everything = nil
       config.enable_local_ingest = nil
       config.analytics = false
+      config.citations = false
       config.queue = Sufia::Resque::Queue
       config.max_notifications_for_dashboard = 5
       config.activity_to_show_default_seconds_since_now = 24*60*60


### PR DESCRIPTION
Citations are enabled in sufia. There is an ability that you can give to people which allows for viewing of these citations. The issue is that there is no way to activate a link to route to the citations page. Therefore I propose we add this snippet of code to sufia which allows for the configuration of being able to show these citations.