### PR TITLE
Fixes issue with FireFox displaying search results outside containing div

### DIFF
--- a/app/assets/stylesheets/sufia/_file-listing.scss
+++ b/app/assets/stylesheets/sufia/_file-listing.scss
@@ -13,7 +13,7 @@ h4 .small {
 }
 
 .table-responsive {
-  overflow-x: visible;
+  overflow-x: auto;
 }
 
 .table thead th {


### PR DESCRIPTION
In FireFox (40.0.2) search results appear well outside their containing div, switching overflow-x to auto fixes this behavior.

![sufia_css](https://cloud.githubusercontent.com/assets/436691/9331941/1d062438-4590-11e5-97bd-154776f17569.png)
