### PR TITLE
Removed Bootstrap media object DIVs for accessibility, redundant …

### DIFF
--- a/app/assets/stylesheets/sufia/_file-listing.scss
+++ b/app/assets/stylesheets/sufia/_file-listing.scss
@@ -10,6 +10,16 @@ h4 .small {
     position: relative;
     left: -8em;
   }
+  .file-listing-title {
+    display: inline-block;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .file-listing-title {
+    display: inline-block;
+    padding-top: .65em;
+  }
 }
 
 .table-responsive {
@@ -56,6 +66,16 @@ h4 .small {
 
 .file_listing_thumbnail {
   width: 64px;
+}
+
+.file-listing-links a:link, .file-listing-links a:visited,
+.part_of_collection a:link, .part_of_collection a:visited {
+  color: $blue-default;
+}
+
+.file-listing-links a:hover, .part_of_collection a:hover {
+  color: $gray-dark;
+  text-decoration: underline;
 }
 
 .nav > li > a.accordion-toggle {
@@ -162,9 +182,6 @@ input#check_all {
 }
 
 #documents {
-  .media-body {
-    padding-top: 12px;
-  }
   td {
     vertical-align: middle;
   }

--- a/app/assets/stylesheets/sufia/_settings.scss
+++ b/app/assets/stylesheets/sufia/_settings.scss
@@ -5,6 +5,7 @@
 
 $basic-black: #000;
 $blue-dark: #036;
+$blue-default: #337AB7;
 $blue-medium: #1C5798;
 $blue-medium-bright: #2674CA;
 $teal: #2CAEB7;
@@ -79,3 +80,5 @@ $view-select-text-hover: $blue-medium-bright;
 // File Show Page
 $file-show-term-color: $gray-dark;
 $heading-border-color: $gray-light;
+$link-color: $blue-default;
+$link-color-hover: $gray-dark;

--- a/app/views/my/_index_partials/_list_files.html.erb
+++ b/app/views/my/_index_partials/_list_files.html.erb
@@ -6,30 +6,21 @@
     <%= batch_edit_select(document) %>&nbsp;
     <%# This block is for adding/removing the magic wand while batch updates are processing %>
     <% if gf.processing? %>
-        <i class="glyphicon glyphicon-time <%= 'ss-'+gf.batch.id %>"/>
+        <span class="glyphicon glyphicon-time <%= 'ss-'+gf.batch.id %>"></span>
     <% elsif gf.depositor != @user.user_key %>
-        <i class="glyphicon glyphicon-share-alt"/>
+        <span class="glyphicon glyphicon-share-alt"></span>
     <% end %>
   </td>
-  <td>
-    <div class="media">
-      <%= link_to sufia.generic_file_path(document), class: "media-left", "aria-hidden" => true do %>
-        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
-      <% end %>
-      <div class="media-body">
-        <div class="media-heading">
-          <%= link_to sufia.generic_file_path(document), id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" do %>
-              <span class="sr-only"><%= t("sufia.dashboard.my.sr.show_label") %> </span>
-              <%= document.title_or_label %>
-          <% end %>
-          <a href="#" class="small" title="Click for more details">
-            <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"  aria-hidden="true"></i>
-            <span class="sr-only"> <%= "#{t("sufia.dashboard.my.sr.detail_label")} #{document.title_or_label}" %></span>
-          </a>
-        </div>
-        <%= render_collection_list(gf) %>
-      </div>
-    </div>
+  <td class="file-listing-links">
+    <%= link_to sufia.generic_file_path(document), id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" do %>
+        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail pull-left" }, { suppress_link: true } %>
+        <div class="file-listing-title"><span class="sr-only"><%= t("sufia.dashboard.my.sr.show_label") %> </span> <%= document.title_or_label %></div>
+    <% end %>
+    <a href="#" class="small" title="Click for more details">
+      <span id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"  aria-hidden="true"></span>
+      <span class="sr-only"> <%= "#{t("sufia.dashboard.my.sr.detail_label")} #{document.title_or_label}" %></span>
+    </a>
+    <div class="part_of_collection"><%= render_collection_list(gf) %></div>
   </td>
   <td class="text-center"><%= document.date_uploaded %> </td>
   <td class="text-center">


### PR DESCRIPTION
…links, and responsive layout.

The WAVE accessibility tool bar flagged the thumbnail image and resource title as redundant links, since they go to the same place. In order to get the thumbnail and title into the same hyperlink, I had to break apart the Bootstrap media object approach to organizing images and other elements. It makes the code a little cleaner, too.