### PR TITLE
Fix bug in total upload file size calculation.

### DIFF
--- a/app/assets/javascripts/sufia/uploader.js
+++ b/app/assets/javascripts/sufia/uploader.js
@@ -59,6 +59,7 @@ var filestoupload =0;
         $($('#fileupload .files .cancel button')[data.context[0].rowIndex]).click(); 
       }
       var total_sz = parseInt($('#total_upload_size').val()) + data.files[0].size;
+      $('#total_upload_size').val( total_sz );
       // is file size too big
       if (data.files[0].size > max_file_size) {
         $($('#fileupload .files .cancel button')[data.context[0].rowIndex]).click(); 
@@ -77,9 +78,6 @@ var filestoupload =0;
         $($('#fileupload .files .cancel button')[data.context[0].rowIndex]).click(); 
         $("#errmsg").html("All files selected from " + first_file_after_max + " and after will not be uploaded because your total number of files is too big. You may not upload more than " + max_file_count + " files in one upload.");
         $("#errmsg").fadeIn('slow');
-      }
-      else {
-        $('#total_upload_size').val( parseInt($('#total_upload_size').val()) + data.files[0].size );
       }
     }
 


### PR DESCRIPTION
Prior to this fix, uploadAdded() temporarily computes but does not store
a new total file size. If this excedes the max, the 'cancel' button is
clicked for the file that's been added. This triggers uploadFail() which
subtracts the size of the file in question from the stored total,
incorrectly deflating the total value.

As a result, more files are permitted in the list than configuration
would suggest are allowed. When files are all around the same size, you
see that after a cutoff point every other file is permitted, while the
ones between are removed.

This commit writes the new total file size during uploadAdded so that
when the subtraction in uploadFail is performed it results in the correct
total.