### PR TITLE
Index Fedora digest to link NRSes on disk to findable objects.

### DIFF
--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -661,6 +661,18 @@ describe GenericFile, type: :model do
     end
   end
 
+  describe '#where_digest_is' do
+    subject { described_class.where_digest_is digest_string }
+    let(:digest_string) { 'f794b23c0c6fe1083d0ca8b58261a078cd968967' }
+    before do
+      @file.add_file(File.open(fixture_path + '/world.png'), path: 'content', original_name: 'world.png')
+      @file.save
+    end
+    it 'returns a list of files' do
+      expect(subject).to eq [@file]
+    end
+  end
+
   describe "where_access_is" do
     subject { described_class.where_access_is access_level }
     before do

--- a/spec/services/generic_file_indexing_service_spec.rb
+++ b/spec/services/generic_file_indexing_service_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Sufia::GenericFileIndexingService do
+  let(:indexer) { described_class.new(object) }
+  let(:object) do
+    GenericFile.create do |f|
+      f.add_file(File.open(fixture_path + '/world.png'), path: 'content', original_name: 'world.png')
+      f.apply_depositor_metadata('mjg36')
+    end
+  end
+
+  describe '#generate_solr_document' do
+    context 'when GenericFile has no content' do
+      it 'does not try to index Fedora-generated SHA1 digests' do
+        expect(indexer).to receive(:digest_from_content) { nil }
+        indexer.generate_solr_document
+      end
+    end
+    context 'when GenericFile has content' do
+      subject { indexer.generate_solr_document }
+      it 'indexes the Fedora-generated SHA1 digest' do
+        expect(subject[Solrizer.solr_name('digest', :symbol)]).to eq 'urn:sha1:f794b23c0c6fe1083d0ca8b58261a078cd968967'
+      end
+      context 'when a subsequent version is uploaded' do
+        before do
+          object.add_file(File.open(fixture_path + '/xml_fits.xml'), path: 'content', original_name: 'xml_fits.xml')
+          object.save!
+        end
+        it 'reindexes the Fedora-generated SHA1 digest' do
+          expect(object.to_solr[Solrizer.solr_name('digest', :symbol)]).to eq 'urn:sha1:15fa208cb92483eca11253a56e370d96fbced075'
+        end
+      end
+    end
+  end
+end

--- a/sufia-models/app/models/concerns/sufia/generic_file/querying.rb
+++ b/sufia-models/app/models/concerns/sufia/generic_file/querying.rb
@@ -38,6 +38,14 @@ module Sufia
           where Solrizer.solr_name('read_access_group', :symbol) => access_level
         end
 
+        def where_digest_is(digest_string)
+          where Solrizer.solr_name('digest', :symbol) => urnify(digest_string)
+        end
+
+        def urnify(digest_string)
+          "urn:sha1:#{digest_string}"
+        end
+
         def date_format
           "%Y-%m-%dT%H:%M:%SZ"
         end

--- a/sufia-models/app/services/sufia/generic_file_indexing_service.rb
+++ b/sufia-models/app/services/sufia/generic_file_indexing_service.rb
@@ -9,7 +9,18 @@ module Sufia
         solr_doc[Solrizer.solr_name('file_format', :facetable)] = object.file_format
         solr_doc['all_text_timv'] = object.full_text.content
         solr_doc[Solrizer.solr_name('file_size', STORED_INTEGER)] = object.content.size.to_i
+        # Index the Fedora-generated SHA1 digest to create a linkage
+        # between files on disk (in fcrepo.binary-store-path) and objects
+        # in the repository.
+        solr_doc[Solrizer.solr_name('digest', :symbol)] = digest_from_content
       end
     end
+
+    private
+
+      def digest_from_content
+        return unless object.content.has_content?
+        object.content.digest.first.to_s
+      end
   end
 end


### PR DESCRIPTION
Also, provide a query method that knows how to convert a digest string into a URN.

This PR indexes the Fedora-generated SHA1 digest to create a linkage between files on disk (in fcrepo.binary-store-path) and objects in the repository. Penn State has a use case for this: our security folks run a personally identifiable information scan on the filesystem and see a file with SSNs. All we know at that point is the SHA1. This PR lets us look up the repository object containing the offending binary.