### PR TITLE
Fix Generic File metadata update button

### DIFF
--- a/app/views/generic_files/_descriptions.html.erb
+++ b/app/views/generic_files/_descriptions.html.erb
@@ -10,7 +10,7 @@
 
       </div><!-- /well -->
     <div>
-      <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "upload_submit", name: "update_descriptions" do %>
+      <%= button_tag class: 'btn btn-primary btn-lg', id: "upload_submit", name: "update_descriptions" do %>
         <i class="glyphicon glyphicon-floppy-disk"></i> Save Descriptions
       <% end %>
     </div>

--- a/spec/views/generic_file/edit.html.erb_spec.rb
+++ b/spec/views/generic_file/edit.html.erb_spec.rb
@@ -1,6 +1,35 @@
 require 'spec_helper'
 
 describe 'generic_files/edit.html.erb', :no_clean do
+  let(:content) { double('content', mimeType: 'application/pdf') }
+
+  let(:generic_file) do
+    stub_model(GenericFile, id: '123',
+                            depositor: 'bob',
+                            resource_type: ['Book', 'Dataset'])
+  end
+
+  let(:form) do
+    Sufia::Forms::GenericFileEditForm.new(generic_file)
+  end
+
+  let(:page) do
+    render
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  subject { page }
+
+  before do
+    allow(generic_file).to receive(:content).and_return(content)
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    assign(:generic_file, generic_file)
+    assign(:form, form)
+    assign(:version_list, [])
+  end
+
+  it { is_expected.to have_button('Save Descriptions') }
+
   describe 'when the file has two or more resource types' do
     let(:resource_version) do
       ActiveFedora::VersionsGraph::ResourceVersion.new.tap do |v|
@@ -9,34 +38,12 @@ describe 'generic_files/edit.html.erb', :no_clean do
         v.created = '2014-12-09T02:03:18.296Z'
       end
     end
+
     let(:version_list) { Sufia::VersionListPresenter.new([resource_version]) }
     let(:versions_graph) { double(all: [version1]) }
-    let(:content) { double('content', mimeType: 'application/pdf') }
-
-    let(:generic_file) do
-      stub_model(GenericFile, id: '123',
-                              depositor: 'bob',
-                              resource_type: ['Book', 'Dataset'])
-    end
-
-    let(:form) do
-      Sufia::Forms::GenericFileEditForm.new(generic_file)
-    end
-
-    before do
-      allow(generic_file).to receive(:content).and_return(content)
-      allow(controller).to receive(:current_user).and_return(stub_model(User))
-      assign(:generic_file, generic_file)
-      assign(:form, form)
-      assign(:version_list, version_list)
-    end
-
-    let(:page) do
-      render
-      Capybara::Node::Simple.new(rendered)
-    end
 
     it "only draws one resource_type multiselect" do
+      assign(:version_list, version_list)
       expect(page).to have_selector("select#generic_file_resource_type", count: 1)
     end
   end


### PR DESCRIPTION
`f.submit` doesn't take a block in the current version of Rails.  This fixes it and makes the button match the one in `app/views/batch/edit.html.erb`. Sorry for an extremely small PR but I was fixing it on my end, and thought I'll contribute upstream instead.