### PR TITLE
Fix styling of the 'Sort and Per-page Bar'  for files and collections liststings in the dashboard

### DIFF
--- a/app/assets/stylesheets/sufia/_dashboard.scss
+++ b/app/assets/stylesheets/sufia/_dashboard.scss
@@ -106,8 +106,13 @@ div.heading-tile:hover .glyphicon {
   margin-bottom: 0;
 }
 
-.sort-toggle, .batch-toggle {
+.batch-toggle {
   padding: 1.5em 0 1.5em 1em;
+}
+
+.sort-toggle {
+  padding: 1.5em 0 0 1em;
+  overflow: auto;
 }
 
 .transfer_link {

--- a/app/assets/stylesheets/sufia/_file-listing.scss
+++ b/app/assets/stylesheets/sufia/_file-listing.scss
@@ -112,9 +112,6 @@ h4 .small {
 .sorts-dash, .sorts, .expandable_new {
   cursor: pointer;
 }
-.sort-toggle {
-  padding: 10px 0 10px 0;
-}
 .caret.up {
   border-top: 0;
   border-bottom: 4px solid;


### PR DESCRIPTION
I think this was broken when fixing the responsive-table for FF40. It now looks like this:
![sufia_broken_my](https://cloud.githubusercontent.com/assets/3236815/9529376/86f75106-4cbf-11e5-8052-666577c5385f.png)
This makes it look like it did before and moves the css for `sort-toggler` to where it was getting overwritten from. `padding-bottom` is set to 0 because `fieldset` added in 04c20aa63a0b81c6b7480c6221927e7f54f39602 comes with it's own margin at the bottom. Here's how it looks after the fix:
![sufia-fixed](https://cloud.githubusercontent.com/assets/3236815/9529534/77b15f88-4cc0-11e5-9543-72ec1b78b900.png)

FWIW I'm not much of a CSS expert.