### PR TITLE
Pin to hydra-jetty 8.4.0 until projecthydra/active_fedora#883 is sorted out.

### DIFF
--- a/tasks/sufia-dev.rake
+++ b/tasks/sufia-dev.rake
@@ -4,6 +4,8 @@ require 'jettywrapper'
 require 'engine_cart/rake_task'
 require 'rubocop/rake_task'
 
+Jettywrapper.hydra_jetty_version = "v8.4.0"
+
 desc 'Run style checker'
 RuboCop::RakeTask.new(:rubocop) do |task|
   task.requires << 'rubocop-rspec'


### PR DESCRIPTION
Because Sufia atop latest AF atop Fedora 4.3.0 causes breakages: https://travis-ci.org/projecthydra/sufia/jobs/77663967

This issue in AF describes the problem: projecthydra/active_fedora#883