### PR TITLE
Reset contact form on success, fixes #1302

### DIFF
--- a/app/controllers/concerns/sufia/contact_form_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/contact_form_controller_behavior.rb
@@ -11,6 +11,7 @@ module Sufia
       if @contact_form.respond_to?(:deliver_now) ? @contact_form.deliver_now : @contact_form.deliver
         flash.now[:notice] = 'Thank you for your message!'
         after_deliver
+        @contact_form = ContactForm.new
         render :new
       else
         flash.now[:error] = 'Sorry, this message was not sent successfully. '

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -17,6 +17,7 @@ describe "Sending an email via the contact form", type: :feature do
     select "Depositing content", from: "contact_form_category"
     click_button "Send"
     expect(page).to have_content "Thank you"
+    expect(page).not_to have_content "I am contacting you regarding ScholarSphere."
     # this step allows the delivery to go back to normal
     allow_any_instance_of(ContactForm).to receive(:deliver).and_call_original
   end


### PR DESCRIPTION
Creates a new contact form object when the message is successfully sent.