### PR TITLE
Increased font size and removed bold type for better legibility and …

### DIFF
--- a/app/assets/stylesheets/sufia/_file-listing.scss
+++ b/app/assets/stylesheets/sufia/_file-listing.scss
@@ -122,6 +122,11 @@ h4 .small {
   display: none;
 }
 
+.visibility-link .label {
+  font-size: .85em;
+  font-weight: normal;
+}
+
 .visibility-link:hover {
   text-decoration: none;
 }

--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -22,7 +22,7 @@
     </div>
   </td>
   <td width="17%" class="text-center"><%= document.create_date %> </td>
-  <td width="5%" class="text-center">
+  <td width="5%" class="text-center visibility-link">
       <% if document.registered? %>
      <span class="label label-info" title="<%=t('sufia.institution_name') %>"><%=t('sufia.institution_name') %></span></a>
     <% elsif document.public? %>


### PR DESCRIPTION
…accessibility.

Old labels were small and hard to read (bold at small sizes fills in the letterforms) and didn't pass WAVE accessibility tool

<img width="920" alt="screen shot 2015-09-01 at 10 46 40 am" src="https://cloud.githubusercontent.com/assets/4163828/9607386/dd379a3c-5096-11e5-8765-06046ac29783.png">

New labels are legible and a touch bigger

<img width="919" alt="screen shot 2015-09-01 at 10 49 15 am" src="https://cloud.githubusercontent.com/assets/4163828/9607437/27eeee22-5097-11e5-92ac-21a81b4ccc5a.png">

