### PR TITLE
upload files into a collection starting from its show page

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@
 * Add configuration allowing select menu on batch upload to upload files to a collection. [E. Lynette Rayle]
 * Bump active-fedora version to 9.4 [E. Lynette Rayle]
 * Bump hydra-collections to 5.0.3 [E. Lynette Rayle]
+* Add button 'Upload files' on collection show page which goes to batch upload with collection select menu set to the calling collection [E. Lynette Rayle]
 
 ## 6.3.0
 

--- a/app/assets/stylesheets/sufia/_collections.scss
+++ b/app/assets/stylesheets/sufia/_collections.scss
@@ -56,6 +56,11 @@
   margin: 1em 0 0 1em;
 }
 
+.actions-controls-collections-line2 {
+  display: block;
+  margin: .5em 0 0 1em;
+}
+
 .label-default a:link,
 .label-default a:visited,
 .label-default a:hover {

--- a/app/controllers/concerns/sufia/files_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller_behavior.rb
@@ -64,6 +64,7 @@ module Sufia
 
     # routed to /files/new
     def new
+      set_variables_for_new_form
       @batch_id = ActiveFedora::Noid::Service.new.mint
     end
 
@@ -156,6 +157,10 @@ module Sufia
     end
 
     protected
+
+      def set_variables_for_new_form
+        @collection_id = params[:collection] if @user_collections.collect(&:id).include? params[:collection]
+      end
 
       def set_variables_for_edit_form
         @form = edit_form

--- a/app/views/collections/_show_actions.html.erb
+++ b/app/views/collections/_show_actions.html.erb
@@ -1,7 +1,12 @@
 <h2 class="sr-only">Actions</h2>
 <div class="actions-controls-collections">
   <% if can? :edit, @collection %>
-      <span class="label label-default"><%= link_to "Edit", collections.edit_collection_path, title: "Edit this Collection" %></span> &nbsp;&nbsp;
-      <span class="label label-default"><%= link_to "Add files",  sufia.dashboard_files_path( add_files_to_collection: @collection.id ), title: "Add files to this Collection" %></span>
+      <span class="label label-default"><%= link_to t("sufia.collection.show.edit.label"), collections.edit_collection_path, title: t("sufia.collection.show.edit.label") %></span> &nbsp;&nbsp;
+      <span class="label label-default"><%= link_to t("sufia.collection.show.add_files.label"),  sufia.dashboard_files_path( add_files_to_collection: @collection.id ), title: t("sufia.collection.show.add_files.label") %></span>
+      <% if Sufia.config.upload_to_collection %>
+          <div class="actions-controls-collections-line2">
+            <span class="label label-default"><%= link_to t("sufia.collection.show.upload_files.label"),  sufia.new_generic_file_path( collection: @collection.id ), title: t("sufia.collection.show.upload_files.desc") %></span>
+          </div>
+      <%end %>
   <%end %>
 </div>

--- a/app/views/generic_files/upload/_to_collection.html.erb
+++ b/app/views/generic_files/upload/_to_collection.html.erb
@@ -1,5 +1,5 @@
 <p>
   <label><%= t("sufia.upload.collection.select_label") %></label>
-  <%= select_tag 'collection', options_from_collection_for_select(@user_collections, "id", "title") %>
+  <%= select_tag 'collection', options_from_collection_for_select(@user_collections, "id", "title", @collection_id) %>
 </p>
 <p>&nbsp;</p>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -163,6 +163,16 @@ en:
         add_another_keyword: "add another Keyword"
         add_another_creator: "add another Creator"
         add_another_rights: "add another Rights"
+      show:
+        edit:
+          label: "Edit"
+          desc: "Edit metadata for this Collection"
+        add_files:
+          label: "Add files"
+          desc: "Add files to this Collection"
+        upload_files:
+          label: "Upload files"
+          desc: "Upload files to this Collection"
     mailbox:
       date:     'Date'
       subject:  'Subject'

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -212,6 +212,25 @@ describe 'collection', type: :feature do
     end
   end
 
+  describe 'upload files to collection' do
+    let(:upload_to_collection) { true }
+    let!(:gf1) { gfs[0] }
+    let!(:gf2) { gfs[1] }
+
+    before do
+      Sufia.config.upload_to_collection = upload_to_collection
+      collection1 # create collections by referencing them
+      collection2
+      sign_in user
+    end
+
+    it "preselects the collection we are uploading files to" do
+      visit "/collections/#{collection1.id}"
+      click_link 'Upload files'
+      expect(page).to have_select('collection', selected: title1)
+    end
+  end
+
   describe 'edit collection' do
     let!(:collection) do
       Collection.create(title: 'collection title', description: 'collection description',

--- a/sufia-models/app/actors/sufia/generic_file/actor.rb
+++ b/sufia-models/app/actors/sufia/generic_file/actor.rb
@@ -41,8 +41,9 @@ module Sufia::GenericFile
     end
 
     def add_file_to_collection(collection_id)
-      return if collection_id.nil? || collection_id == -1
+      return if collection_id.nil? || collection_id == "-1"
       collection = Collection.find(collection_id)
+      return unless user.can? :edit, collection
       collection.add_members [generic_file.id]
       collection.save
     end


### PR DESCRIPTION
Steps to use this feature:
* On collection show page, a new action was added (under thumbnail) to 'Upload files' into the current collection being viewed

![upload_files_from_collection](https://cloud.githubusercontent.com/assets/6855473/9775905/32782ae4-5721-11e5-9c67-e3f216311b7a.png)

* Clicking 'Upload file' goes to the batch upload page and pre-selects the calling collection in the 'Upload to' selection menu.

![batch_upload_to_collection](https://cloud.githubusercontent.com/assets/6855473/9776045/4524b530-5722-11e5-8154-2a37fa7b12af.png)

* Both 'Upload files' action on collection show page and 'Upload to' selection menu on batch upload page only appear when the upload_to_collection=true
* Text for actions on collection page and upload selection menu are configurable in sufia.en.yml

Changes also include...
* includes 2 fixes for rubocop unrelated to the changes for this feature