### PR TITLE
Reformatting the statistics page to only have one date filter form

### DIFF
--- a/app/controllers/concerns/sufia/admin/depositor_stats.rb
+++ b/app/controllers/concerns/sufia/admin/depositor_stats.rb
@@ -19,7 +19,7 @@ module Sufia::Admin::DepositorStats
     start_datetime = DateTime.parse(deposit_stats[:start_date]) unless deposit_stats[:start_date].blank?
     end_datetime = DateTime.parse(deposit_stats[:end_date]).end_of_day unless deposit_stats[:end_date].blank?
 
-    query = GenericFile.build_date_query(start_datetime, end_datetime) unless start_datetime.blank?
+    query = ::GenericFile.build_date_query(start_datetime, end_datetime) unless start_datetime.blank?
     sb = DepositSearchBuilder.new([:include_depositor_facet], self)
     facet_results = repository.search(sb.merge(q: query).query)
     facets = facet_results["facet_counts"]["facet_fields"]["depositor_ssim"]

--- a/app/controllers/concerns/sufia/admin/stats_behavior.rb
+++ b/app/controllers/concerns/sufia/admin/stats_behavior.rb
@@ -8,12 +8,14 @@ module Sufia
       end
 
       def index
+        stats_filters = params.fetch(:stats_filters, {})
+
         # initialize the presenter
-        @presenter = AdminStatsPresenter.new(params.fetch(:users_stats, {}), params.fetch([:dep_count], "5").to_i)
+        @presenter = AdminStatsPresenter.new(stats_filters, params.fetch(:limit, "5").to_i)
 
         # get deposit stats
-        @presenter.deposit_stats = params.fetch(:deposit_stats, {})
-        @presenter.depositors = depositors(@presenter.deposit_stats)
+        @presenter.deposit_stats = stats_filters
+        @presenter.depositors = depositors(stats_filters)
 
         render 'index'
       end

--- a/app/presenters/sufia/admin_stats_presenter.rb
+++ b/app/presenters/sufia/admin_stats_presenter.rb
@@ -1,10 +1,12 @@
 module Sufia
   class AdminStatsPresenter
     attr_accessor :depositors, :deposit_stats
-    attr_reader :users_stats, :limit
+    attr_reader :limit, :start_date, :end_date, :stats_filters
 
-    def initialize(user_stats, limit)
-      @users_stats = user_stats
+    def initialize(stats_filters, limit)
+      @stats_filters = stats_filters
+      @start_date = stats_filters[:start_date]
+      @end_date = stats_filters[:end_date]
       @limit = limit
     end
 
@@ -21,21 +23,27 @@ module Sufia
     end
 
     def files_count
-      @files_count ||= file_stats.document_by_permission
+      @files_count ||= stats.document_by_permission
     end
 
     def users_count
       @users_count ||= stats.users_count
     end
 
+    def date_filter_string
+      if start_date.blank?
+        "unfiltered"
+      elsif end_date.blank?
+        "#{start_date} to #{Date.current}"
+      else
+        "#{start_date} to #{end_date}"
+      end
+    end
+
     private
 
       def stats
-        @stats ||= ::SystemStats.new(limit, users_stats[:start_date], users_stats[:end_date])
-      end
-
-      def file_stats
-        @file_stats ||= ::SystemStats.new(limit, users_stats[:file_start_date], users_stats[:file_end_date])
+        @stats ||= ::SystemStats.new(limit, start_date, end_date)
       end
   end
 end

--- a/app/views/admin/stats/_date_form.html.erb
+++ b/app/views/admin/stats/_date_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_for "stats_filters", url: sufia.admin_stats_path, method: "GET" do |f| %>
+  <%= f.label "Start *" %>
+  <input type="date" name="stats_filters[start_date]" value="<%= @presenter.stats_filters[:start_date] %>" placeholder="yyyy-mm-dd" ></input>
+  <%= f.label "end [defaults to now]" %>
+  <input type="date" name="stats_filters[end_date]" value="<%= @presenter.stats_filters[:end_date] %>" placeholder="yyyy-mm-dd" ></input>
+  <%= f.submit "Load Stats" %>
+<%- end %>
+

--- a/app/views/admin/stats/_deposits.html.erb
+++ b/app/views/admin/stats/_deposits.html.erb
@@ -1,12 +1,4 @@
-<h3>Deposits By Users</h3>
-<%= form_for "deposit_stats", url: sufia.admin_stats_path, method: "GET" do |f| %>
-  <%= f.label "#{ t("sufia.admin.stats.deposited_form.heading") } #{ t("sufia.admin.stats.deposited_form.start_label") }" %>
-  <input type="date" name="deposit_stats[start_date]" value="<%= @presenter.deposit_stats[:start_date] %>"></input>
-  <%= f.label t("sufia.admin.stats.deposited_form.end_label") %>
-  <input type="date" name="deposit_stats[end_date]" value="<%= @presenter.deposit_stats[:end_date] %>"></input>
-  <%= f.submit "Load Stats" %>
-<%- end %>
-
+<h3>Deposits By Users (<%= @presenter.date_filter_string %>)</h3>
 <ul>
   <% @presenter.depositors.each do |usr| %>
     <li>

--- a/app/views/admin/stats/_files.html.erb
+++ b/app/views/admin/stats/_files.html.erb
@@ -1,14 +1,6 @@
-<h2>File Statistics</h2>
-<%= form_for "users_stats", url: sufia.admin_stats_path, method: "GET" do |f| %>
-<%= f.label "#{ t("sufia.admin.stats.deposited_form.heading") } #{ t("sufia.admin.stats.deposited_form.start_label") }" %>
-<input type="date" name="users_stats[file_start_date]" value="<%= @presenter.users_stats[:file_start_date] %>"></input>
-<%= f.label t("sufia.admin.stats.deposited_form.end_label") %>
-<input type="date" name="users_stats[file_end_date]" value="<%= @presenter.users_stats[:file_end_date] %>"></input>
-<%= f.submit "Load Stats" %>
-<h3>Total Files: <%= @presenter.files_count[:total] %> </h3>
-<br/>
-<%- end %>
-<h3>Totals by Visibility</h3>
+<h3>File Statistics (<%= @presenter.date_filter_string %>)</h3>
+<h4>Total Files: <%= @presenter.files_count[:total] %> </h4>
+<h4>Totals by Visibility</h4>
 <ul>
   <li>Open Access <span class="count">(<%= @presenter.files_count[:public] %>)</span></li>
   <li><%= t("sufia.admin.stats.registered") %> <span class="count">(<%= @presenter.files_count[:registered] %>)</span></li>

--- a/app/views/admin/stats/_new_users.html.erb
+++ b/app/views/admin/stats/_new_users.html.erb
@@ -1,18 +1,11 @@
-<h3>Newest Users</h3>
-<%= form_for "users_stats", url: sufia.admin_stats_path, method: "GET" do |f| %>
-  <%= f.label "Display users registered: Start" %>
-  <input type="date" name="users_stats[start_date]" value="<%= @presenter.users_stats[:start_date] %>"></input>
-  <%= f.label "end [defaults to now]" %>
-  <input type="date" name="users_stats[end_date]" value="<%= @presenter.users_stats[:end_date] %>"></input>
-  <%= f.submit "Load Stats" %>
-<%- end %>
-
-<%- if @presenter.users_stats[:start_date] %>
-  <div>Total: <%= @presenter.recent_users.count %></div>
+<h3>Newest Users (<%= @presenter.date_filter_string %>)</h3>
+<h4>
+<%- if !@presenter.start_date.blank? %>
+  Total: <%= @presenter.recent_users.count %></div>
 <%- else %>
-  Five most recent users:
+    <%= @presenter.recent_users.count %> most recent users:
 <%- end %>
-
+</h4>
 <ul>
   <% @presenter.recent_users.each do |usr| %>
     <li>

--- a/app/views/admin/stats/_stats_by_date.html.erb
+++ b/app/views/admin/stats/_stats_by_date.html.erb
@@ -1,0 +1,8 @@
+<h2>Statistics By Date</h2>
+<h3>Statistics in this section are filtered by the dates entered in the form below.
+  The data is unfiltered unless the date form has been filled in. Start date is required and the deafult end is now.
+</h3>
+<%= render "admin/stats/date_form" %>
+<%= render "admin/stats/files" %>
+<%= render "admin/stats/new_users" %>
+<%= render "admin/stats/deposits" %>

--- a/app/views/admin/stats/_top_data.html.erb
+++ b/app/views/admin/stats/_top_data.html.erb
@@ -1,0 +1,24 @@
+<h2>Top File Formats and Users</h2>
+<h3>Statistics in this section shows the top <%= @presenter.limit %> items for each category</h3>
+<% if @presenter.limit == 5 %>
+  <p><%= link_to "View top 20", Sufia::Engine.routes.url_for(controller: "admin/stats", action:"index", limit: "20", only_path: true) %> </p>
+<% else %>
+  <p><%= link_to "View top 5", Sufia::Engine.routes.url_for(controller: "admin/stats", action:"index", only_path: true) %> </p>
+<% end %>
+
+<h3>Top File Formats (top <%= @presenter.top_formats.count %>)</h3>
+<ul>
+  <% @presenter.top_formats.each do |k, v| %>
+    <li><%= k %> <span class="count">(<%= v %>)</span></li>
+  <% end %>
+</ul>
+
+<br/>
+<h3>Most Active Users (top <%= @presenter.active_users.count %>)</h3>
+<ul>
+  <% @presenter.active_users.each do |k, v| %>
+    <li>
+      <%= link_to_profile(k) %> <span class="count">(<%= v %>)</span>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/stats/index.html.erb
+++ b/app/views/admin/stats/index.html.erb
@@ -1,36 +1,10 @@
 <div class="stats">
   <h1>Statistics for <%= application_name %>
     <%= Sufia::VERSION %></h1>
-  <br/>
-
-  <%= render "admin/stats/files" %>
-
-  <h3>Top File Formats</h3>
-  <ul>
-    <% @presenter.top_formats.each do |k, v| %>
-      <li><%= k %> <span class="count">(<%= v %>)</span></li>
-    <% end %>
-  </ul>
-
-  <br/>
 
   <h2>Total <%= application_name %> Users:&nbsp; <%= @presenter.users_count %> </h2>
-  <br/>
-
-  <%= render "admin/stats/new_users" %>
-
-  <br/>
-  <h3>Most Active Users (top <%= @presenter.active_users.count %>)</h3>
-  <ul>
-    <% @presenter.active_users.each do |k, v| %>
-      <li>
-        <%= link_to_profile(k) %> <span class="count">(<%= v %>)</span>
-      </li>
-    <% end %>
-    <% if !params[:dep_count] %>
-      <p><%= link_to "View top 20", sufia.admin_stats_path, controller: "stats", dep_count: "20" %> </p>
-    <% end %>
-  </ul>
-
-  <%= render "admin/stats/deposits" %>
+  <hr/>
+  <%= render "admin/stats/stats_by_date" %>
+  <hr/>
+  <%= render "admin/stats/top_data" %>
 </div>

--- a/spec/controllers/admin_stats_controller_spec.rb
+++ b/spec/controllers/admin_stats_controller_spec.rb
@@ -26,7 +26,7 @@ describe Admin::StatsController, type: :controller do
       expect(response.body).to include('Total Blacklight Users')
     end
 
-    describe "querying user_stats" do
+    describe "querying stats_filters" do
       let(:one_day_ago_date) { 1.days.ago.to_datetime }
       let(:two_days_ago_date) { 2.days.ago.to_datetime.end_of_day }
       let(:one_day_ago) { one_day_ago_date.strftime("%Y-%m-%d") }
@@ -36,15 +36,15 @@ describe Admin::StatsController, type: :controller do
         get :index
         expect(assigns[:presenter].recent_users).to eq(User.order('created_at DESC').limit(5))
       end
-      it "allows queries against user_stats without an end date " do
+      it "allows queries against stats_filters without an end date " do
         expect(User).to receive(:where).with('id' => user1.id).once.and_return([user1])
         expect(User).to receive(:recent_users).with(one_day_ago_date, nil).and_return([user2])
-        get :index, users_stats: { start_date: one_day_ago }
+        get :index, stats_filters: { start_date: one_day_ago }
         expect(assigns[:presenter].recent_users).to eq([user2])
       end
-      it "allows queries against user_stats with an end date" do
+      it "allows queries against stats_filters with an end date" do
         expect(User).to receive(:recent_users).with(two_days_ago_date, one_day_ago_date).and_return([user2])
-        get :index, users_stats: { start_date: two_days_ago, end_date: one_day_ago }
+        get :index, stats_filters: { start_date: two_days_ago, end_date: one_day_ago }
         expect(assigns[:presenter].recent_users).to eq([user2])
       end
     end
@@ -88,7 +88,7 @@ describe Admin::StatsController, type: :controller do
           expect(GenericFile).to receive(:find_by_date_created).exactly(3).times.with(1.days.ago.to_datetime, nil).and_call_original
           expect(GenericFile).to receive(:where_public).and_call_original
           expect(GenericFile).to receive(:where_registered).and_call_original
-          get :index, users_stats: { file_start_date: 1.days.ago.strftime("%Y-%m-%d") }
+          get :index, stats_filters: { start_date: 1.days.ago.strftime("%Y-%m-%d") }
         end
       end
 
@@ -97,7 +97,7 @@ describe Admin::StatsController, type: :controller do
           expect(GenericFile).to receive(:find_by_date_created).exactly(3).times.with(1.days.ago.to_datetime, 0.days.ago.to_datetime.end_of_day).and_call_original
           expect(GenericFile).to receive(:where_public).and_call_original
           expect(GenericFile).to receive(:where_registered).and_call_original
-          get :index, users_stats: { file_start_date: 1.days.ago.strftime("%Y-%m-%d"), file_end_date: 0.days.ago.strftime("%Y-%m-%d") }
+          get :index, stats_filters: { start_date: 1.days.ago.strftime("%Y-%m-%d"), end_date: 0.days.ago.strftime("%Y-%m-%d") }
         end
       end
     end
@@ -130,7 +130,7 @@ describe Admin::StatsController, type: :controller do
       end
 
       it "gathers user deposits during a date range" do
-        get :index, deposit_stats: { start_date: 1.days.ago.strftime("%Y-%m-%d"), end_date: 0.days.ago.strftime("%Y-%m-%d") }
+        get :index, stats_filters: { start_date: 1.days.ago.strftime("%Y-%m-%d"), end_date: 0.days.ago.strftime("%Y-%m-%d") }
         expect(assigns[:presenter].depositors).to include({ key: user1.user_key, deposits: 1, user: user1 }, key: user2.user_key, deposits: 1, user: user2)
       end
 

--- a/spec/views/admin/stats/index.html.erb_spec.rb
+++ b/spec/views/admin/stats/index.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe "admin/stats/index.html.erb" do
     end
     it "shows top 5 depositors and option to view more" do
       expect(rendered).to have_content("(top 5)")
-      expect(rendered).to have_content("View top 20")
+      expect(rendered).to have_link("View top 20", href: "/admin/stats?limit=20")
     end
   end
 
@@ -35,7 +35,7 @@ describe "admin/stats/index.html.erb" do
     end
     before do
       allow(presenter).to receive(:active_users).and_return(top_20_active_users)
-      params[:dep_count] = 20
+      allow(presenter).to receive(:limit).and_return(20)
       render
     end
     it "shows top 20 depositors, without an option to view more" do


### PR DESCRIPTION
currently there are 3 forms which are entirely independent and the data on the page is only partially filtered.

**Current Form with many date filters**

<img width="493" alt="screen shot 2015-09-18 at 6 48 34 am" src="https://cloud.githubusercontent.com/assets/1599081/9963284/7781dd82-5df8-11e5-944b-4adc4df55934.png">



**New form with one date filter**


![screen shot 2015-09-18 at 11 15 33 am](https://cloud.githubusercontent.com/assets/1599081/9963302/89ca48f8-5df8-11e5-83ae-cd1d52f70163.png)

