### PR TITLE
Use sufia.root_path instead of root_path

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
 * Bump active-fedora version to 9.4 [E. Lynette Rayle]
 * Bump hydra-collections to 5.0.3 [E. Lynette Rayle]
 * Add button 'Upload files' on collection show page which goes to batch upload with collection select menu set to the calling collection [E. Lynette Rayle]
+* Use `sufia.root_path` instead of `root_path` in the navbar and the logo [Randy Coulman]
 
 ## 6.3.0
 

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -3,7 +3,7 @@
     <div class="col-xs-12 col-sm-5 col-md-6">
       <nav class="navbar navbar-default" role="navigation">
         <ul class="nav navbar-nav">
-            <li <%= 'class=active' if current_page?(root_path) %>><a href="<%= root_path %>">Home</a></li>
+            <li <%= 'class=active' if current_page?(sufia.root_path) %>><a href="<%= sufia.root_path %>">Home</a></li>
             <li <%= 'class=active' if current_page?(sufia.about_path) %>><a href="<%= sufia.about_path %>">About</a></li>
             <li <%= 'class=active' if action_name == "help" %>><a href="<%= sufia.static_path('help') %>">Help</a></li>
             <li <%= 'class=active' if current_page?(sufia.contact_path) %>><a href="<%= sufia.contact_path %>">Contact</a></li>

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,3 +1,1 @@
-<a id="logo" href="/"><span class="glyphicon glyphicon-globe"></span></a><a href="/" class="institution_name"><%=t('sufia.product_name') %></a>
-
-
+<a id="logo" href="<%= sufia.root_path %>"><span class="glyphicon glyphicon-globe"></span></a><a href="<%= sufia.root_path %>" class="institution_name"><%=t('sufia.product_name') %></a>


### PR DESCRIPTION
In the navigation bar, the `Home` link and logo go to `root_path`.  When Sufia is mounted as an engine at a sub-path, this will take the user to the `root_path` of the host Rails application rather than back to
the main Sufia page.

This change makes it so that the Home link and logo navigate to Sufia’s `root_path` instead, so that the Sufia interface is more self-contained.

If this is not the desired behavior, that's fine.  But in that case, _logo.html.erb should be modified to use `root_path` instead of the hard-coded `/` that is there now.