### PR TITLE
Use the Rails path helper for the contact form

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
 * Bump hydra-collections to 5.0.3 [E. Lynette Rayle]
 * Add button 'Upload files' on collection show page which goes to batch upload with collection select menu set to the calling collection [E. Lynette Rayle]
 * Use `sufia.root_path` instead of `root_path` in the navbar and the logo [Randy Coulman]
+* Do not use a hard-coded path to the contact form URL on the terms page. [Randy Coulman]
 
 ## 6.3.0
 

--- a/app/views/static/terms.html.erb
+++ b/app/views/static/terms.html.erb
@@ -49,7 +49,7 @@
 <ul>
   <li>
 A. Copyright Complaints: We respect the intellectual property rights of others. If you believe your copyright has been violated on the Site, please notify us through <%= t('sufia.institution_name') %>'s designated agent under the Digital Millennium Copyright Act (see 17 U.S.C. Â&sect;512(c)(3).</li>
-  <li> B. Other Site Issues: Please direct all other communications to <a href="/contact/">contact form</a>.</ul>
+  <li> B. Other Site Issues: Please direct all other communications to <a href="<%= sufia.contact_path %>">contact form</a>.</ul>
 </ul>
 </p>
 


### PR DESCRIPTION
The Terms page contained a hard-coded path to `/contact/` instead of using the Rails path helper.  By using the path helper, the link to the contact form works properly when the Sufia engine is mounted somewhere other than the root path.