### PR TITLE
Use the render_visibility_* helpers where possible

### DIFF
--- a/History.md
+++ b/History.md
@@ -8,6 +8,7 @@
 * Add button 'Upload files' on collection show page which goes to batch upload with collection select menu set to the calling collection [E. Lynette Rayle]
 * Use `sufia.root_path` instead of `root_path` in the navbar and the logo [Randy Coulman]
 * Do not use a hard-coded path to the contact form URL on the terms page. [Randy Coulman]
+* Use `render_visibility_*` helpers everywhere. [Randy Coulman]
 
 ## 6.3.0
 

--- a/app/views/collections/_show_document_list_row.html.erb
+++ b/app/views/collections/_show_document_list_row.html.erb
@@ -25,15 +25,7 @@
   </td>
   <td class="text-center"><%= document.date_uploaded %> </td>
   <td class="text-center">
-    <a href="<%= sufia.generic_file_path(document) %>/edit/?tab=permissions" id="permission_<%= id %>" class="visibility-link">
-      <% if document.registered? %>
-        <span class="label label-info" title="<%= t('sufia.institution_name') %>"><%= t('sufia.institution_name') %></span>
-      <% elsif document.public? %>
-        <span class="label label-success" title="<%= t('sufia.visibility.open_title_attr') %>"><%= t('sufia.visibility.open') %></span>
-      <% else %>
-        <span class="label label-danger" title="<%= t('sufia.visibility.private_title_attr') %>"><%= t('sufia.visibility.private') %></span>
-      <% end %>
-    </a>
+    <%= render_visibility_link(document) %>
   </td>
   <td class="text-center">
     <%= render partial: 'show_document_list_menu', locals: { id: id, gf: gf } %>

--- a/app/views/homepage/_recent_document.html.erb
+++ b/app/views/homepage/_recent_document.html.erb
@@ -11,13 +11,7 @@
         <h3>
           <span class="sr-only">Title</span><%= link_to truncate(recent_document.title_or_label, length: 28, separator: ' '), sufia.generic_file_path(recent_document)  %>
           <% if display_access %>
-              <% if recent_document.registered? %>
-                 <span class="label label-info" title="<%=t('sufia.institution_name') %>"><%=t('sufia.institution_name') %></span>
-              <% elsif recent_document.public? %>
-                <span class="label label-success">Open Access</span>
-              <% else %>
-                <span class="label label-danger">Private</span>
-              <% end %>
+            <%= render_visibility_label(recent_document) %>
           <% end %>
         </h3>
         <p>

--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -23,14 +23,7 @@
   </td>
   <td width="17%" class="text-center"><%= document.create_date %> </td>
   <td width="5%" class="text-center visibility-link">
-      <% if document.registered? %>
-     <span class="label label-info" title="<%=t('sufia.institution_name') %>"><%=t('sufia.institution_name') %></span></a>
-    <% elsif document.public? %>
-      <span class="label label-success" title="Open Access">Open Access</span></a>
-    <% else %>
-      <span class="label label-danger" title="Private">Private</span></a>
-    <% end %>
-
+    <%= render_visibility_label(document) %>
   </td>
   <td class="text-center">
     <%= render partial:'collection_action_menu', locals: { id: id } %>


### PR DESCRIPTION
There are a few places in the code that have code that duplicates (or nearly duplicates) the functionality of the `render_visibility_link` and `render_visibility_label` helpers.

This change replaces those instances with calls to the appropriate helper.