### PR TITLE
Refactoring event jobs to remove the continuos copying of code.

### DIFF
--- a/app/jobs/content_delete_event_job.rb
+++ b/app/jobs/content_delete_event_job.rb
@@ -1,15 +1,20 @@
+# A specific job to log a file deletion to a user's activity stream
+#
+# @attr_reader deleted_file_id The id of the file that has been deleted by the user
 class ContentDeleteEventJob < EventJob
-  def run
-    action = "User #{link_to_profile depositor_id} has deleted file '#{generic_file_id}'"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
+  attr_reader :deleted_file_id
+
+  def initialize(deleted_file_id, depositor_id)
+    super(depositor_id)
+    @deleted_file_id = deleted_file_id
+  end
+
+  def action
+    @action ||= "User #{link_to_profile depositor_id} has deleted file '#{deleted_file_id}'"
+  end
+
+  # override to log the event to the users profile stream instead of the user's stream
+  def log_user_event
     depositor.log_profile_event(event)
-    # Fan out the event to all followers
-    depositor.followers.each do |follower|
-      follower.log_event(event)
-    end
   end
 end

--- a/app/jobs/content_deposit_event_job.rb
+++ b/app/jobs/content_deposit_event_job.rb
@@ -1,18 +1,6 @@
-class ContentDepositEventJob < EventJob
-  def run
-    gf = GenericFile.find(generic_file_id)
-    action = "User #{link_to_profile depositor_id} has deposited #{link_to gf.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(gf)}"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
-    depositor.log_profile_event(event)
-    # Log the event to the GF's stream
-    gf.log_event(event)
-    # Fan out the event to all followers who have access
-    depositor.followers.select { |user| user.can? :read, gf }.each do |follower|
-      follower.log_event(event)
-    end
+# A specific job to log a file deposit to a user's activity stream
+class ContentDepositEventJob < ContentEventJob
+  def action
+    "User #{link_to_profile depositor_id} has deposited #{link_to generic_file.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(generic_file)}"
   end
 end

--- a/app/jobs/content_event_job.rb
+++ b/app/jobs/content_event_job.rb
@@ -1,0 +1,39 @@
+# A generic job for sending events about a generic files to a user and their followers.
+#
+# @attr [String] generic_file_id  the id of the file the event is specified for
+#
+class ContentEventJob < EventJob
+  attr_accessor :generic_file_id
+
+  def initialize(generic_file_id, depositor_id)
+    super(depositor_id)
+    @generic_file_id = generic_file_id
+  end
+
+  def run
+    super
+
+    log_generic_file_event
+  end
+
+  def generic_file
+    @generic_file ||= GenericFile.load_instance_from_solr(generic_file_id)
+  end
+
+  # Log the event to the GF's stream
+  def log_generic_file_event
+    generic_file.log_event(event) unless generic_file.nil?
+  end
+
+  # override to check file permissions before logging to followers
+  def log_to_followers
+    depositor.followers.select { |user| user.can?(:read, generic_file) }.each do |follower|
+      follower.log_event(event)
+    end
+  end
+
+  # log the event to the users profile stream
+  def log_user_event
+    depositor.log_profile_event(event)
+  end
+end

--- a/app/jobs/content_new_version_event_job.rb
+++ b/app/jobs/content_new_version_event_job.rb
@@ -1,18 +1,6 @@
-class ContentNewVersionEventJob < EventJob
-  def run
-    gf = GenericFile.find(generic_file_id)
-    action = "User #{link_to_profile depositor_id} has added a new version of #{link_to gf.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(gf)}"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
-    depositor.log_profile_event(event)
-    # Log the event to the GF's stream
-    gf.log_event(event)
-    # Fan out the event to all followers who have access
-    depositor.followers.select { |user| user.can? :read, gf }.each do |follower|
-      follower.log_event(event)
-    end
+# A specific job to log a file new version to a user's activity stream
+class ContentNewVersionEventJob < ContentEventJob
+  def action
+    @action ||= "User #{link_to_profile depositor_id} has added a new version of #{link_to generic_file.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(generic_file)}"
   end
 end

--- a/app/jobs/content_restored_version_event_job.rb
+++ b/app/jobs/content_restored_version_event_job.rb
@@ -1,26 +1,13 @@
-class ContentRestoredVersionEventJob < EventJob
+# A specific job to log a file restored version to a user's activity stream
+class ContentRestoredVersionEventJob < ContentEventJob
   attr_accessor :revision_id
 
   def initialize(generic_file_id, depositor_id, revision_id)
-    self.generic_file_id = generic_file_id
-    self.depositor_id = depositor_id
-    self.revision_id = revision_id
+    super(generic_file_id, depositor_id)
+    @revision_id = revision_id
   end
 
-  def run
-    gf = GenericFile.find(generic_file_id)
-    action = "User #{link_to_profile depositor_id} has restored a version '#{revision_id}' of #{link_to gf.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(gf)}"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
-    depositor.log_profile_event(event)
-    # Log the event to the GF's stream
-    gf.log_event(event)
-    # Fan out the event to all followers who have access
-    depositor.followers.select { |user| user.can? :read, gf }.each do |follower|
-      follower.log_event(event)
-    end
+  def action
+    @action ||= "User #{link_to_profile depositor_id} has restored a version '#{revision_id}' of #{link_to generic_file.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(generic_file)}"
   end
 end

--- a/app/jobs/content_update_event_job.rb
+++ b/app/jobs/content_update_event_job.rb
@@ -1,18 +1,6 @@
-class ContentUpdateEventJob < EventJob
-  def run
-    gf = GenericFile.find(generic_file_id)
-    action = "User #{link_to_profile depositor_id} has updated #{link_to gf.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(gf)}"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
-    depositor.log_profile_event(event)
-    # Log the event to the GF's stream
-    gf.log_event(event)
-    # Fan out the event to all followers who have access
-    depositor.followers.select { |user| user.can? :read, gf }.each do |follower|
-      follower.log_event(event)
-    end
+# A specific job to log a file content update to a user's activity stream
+class ContentUpdateEventJob < ContentEventJob
+  def action
+    @action ||= "User #{link_to_profile depositor_id} has updated #{link_to generic_file.title.first, Sufia::Engine.routes.url_helpers.generic_file_path(generic_file)}"
   end
 end

--- a/app/jobs/event_job.rb
+++ b/app/jobs/event_job.rb
@@ -1,3 +1,9 @@
+# A generic job for sending events to a user and their followers.
+#
+# This class does not implement a usable action, so it must be implemented in a child class
+#
+# @attr [String] depositor_id  the user the event is specified for
+#
 class EventJob
   include Rails.application.routes.url_helpers
   include ActionView::Helpers
@@ -5,14 +11,52 @@ class EventJob
   include Hydra::AccessControlsEnforcement
   include SufiaHelper
 
+  # queue to run the job on
   def queue_name
     :event
   end
 
-  attr_accessor :generic_file_id, :depositor_id
+  attr_accessor :depositor_id
 
-  def initialize(generic_file_id, depositor_id)
-    self.generic_file_id = generic_file_id
-    self.depositor_id = depositor_id
+  # @param the id of the user to create the event for
+  def initialize(depositor_id)
+    @depositor_id = depositor_id
+  end
+
+  # Method used to cause the event to be created
+  def run
+    # Log the event to the depositor's profile stream
+    log_user_event
+
+    # Fan out the event to all followers who have access
+    log_to_followers
+  end
+
+  # override to provide your specific action for the event you are logging
+  # @abstract
+  def action
+    raise(NotImplementedError, "#action should be implemented by an child class of EventJob")
+  end
+
+  # create an event with an action and a timestamp for the user
+  def event
+    @event ||= depositor.create_event(action, Time.now.to_i)
+  end
+
+  # the user that will be the subject of the event
+  def depositor
+    @depositor ||= User.find_by_user_key(depositor_id)
+  end
+
+  # log the event to the users event stream
+  def log_user_event
+    depositor.log_event(event)
+  end
+
+  # log the event to the users followers
+  def log_to_followers
+    depositor.followers.each do |follower|
+      follower.log_event(event)
+    end
   end
 end

--- a/app/jobs/user_edit_profile_event_job.rb
+++ b/app/jobs/user_edit_profile_event_job.rb
@@ -1,21 +1,8 @@
+# A specific job to log a user profile edit to a user's activity stream
 class UserEditProfileEventJob < EventJob
-  attr_accessor :editor_id
+  alias_attribute :editor_id, :depositor_id
 
-  def initialize(editor_id)
-    self.editor_id = editor_id
-  end
-
-  def run
-    action = "User #{link_to_profile editor_id} has edited his or her profile"
-    timestamp = Time.now.to_i
-    editor = User.find_by_user_key(editor_id)
-    # Create the event
-    event = editor.create_event(action, timestamp)
-    # Log the event to the editor's stream
-    editor.log_event(event)
-    # Fan out the event to all followers
-    editor.followers.each do |user|
-      user.log_event(event)
-    end
+  def action
+    @action ||= "User #{link_to_profile editor_id} has edited his or her profile"
   end
 end

--- a/app/jobs/user_follow_event_job.rb
+++ b/app/jobs/user_follow_event_job.rb
@@ -1,23 +1,21 @@
+# A specific job to log a user following another user to a user's activity stream
 class UserFollowEventJob < EventJob
-  attr_accessor :follower_id, :followee_id
+  attr_accessor :followee_id
+  alias_attribute :follower_id, :depositor_id
 
   def initialize(follower_id, followee_id)
-    self.follower_id = follower_id
-    self.followee_id = followee_id
+    super(follower_id)
+    @followee_id = followee_id
   end
 
   def run
-    # Create the event
-    follower = User.find_by_user_key(follower_id)
-    event = follower.create_event("User #{link_to_profile follower_id} is now following #{link_to_profile followee_id}", Time.now.to_i)
-    # Log the event to the follower's stream
-    follower.log_event(event)
+    super
     # Fan out the event to followee
     followee = User.find_by_user_key(followee_id)
     followee.log_event(event)
-    # Fan out the event to all followers
-    follower.followers.each do |user|
-      user.log_event(event)
-    end
+  end
+
+  def action
+    @action ||= "User #{link_to_profile follower_id} is now following #{link_to_profile followee_id}"
   end
 end

--- a/app/jobs/user_unfollow_event_job.rb
+++ b/app/jobs/user_unfollow_event_job.rb
@@ -1,25 +1,20 @@
+# A specific job to log a user unfollowing another user to a user's activity stream
 class UserUnfollowEventJob < EventJob
-  attr_accessor :unfollower_id, :unfollowee_id
+  attr_accessor :unfollowee_id
+  alias_attribute :unfollower_id, :depositor_id
 
   def initialize(unfollower_id, unfollowee_id)
-    self.unfollower_id = unfollower_id
-    self.unfollowee_id = unfollowee_id
+    super(unfollower_id)
+    @unfollowee_id = unfollowee_id
   end
 
   def run
-    action = "User #{link_to_profile unfollower_id} has unfollowed #{link_to_profile unfollowee_id}"
-    timestamp = Time.now.to_i
-    unfollower = User.find_by_user_key(unfollower_id)
-    # Create the event
-    event = unfollower.create_event(action, timestamp)
-    # Log the event to the unfollower's stream
-    unfollower.log_event(event)
-    # Fan out the event to unfollowee
+    super
     unfollowee = User.find_by_user_key(unfollowee_id)
     unfollowee.log_event(event)
-    # Fan out the event to all followers
-    unfollower.followers.each do |user|
-      user.log_event(event)
-    end
+  end
+
+  def action
+    @action ||= "User #{link_to_profile unfollower_id} has unfollowed #{link_to_profile unfollowee_id}"
   end
 end


### PR DESCRIPTION
The base class existed, but had little code.  Instead the code was copied from one job to the new one.
In addition there seemed to be two types of events, one with a user, and one with a user and a file, so I created a second base class to allow for the two types.
