### PR TITLE
Fixes empty white space being clickable when the intrinsic value of the thumb image is...

### DIFF
--- a/app/assets/stylesheets/sufia/_file-show.scss
+++ b/app/assets/stylesheets/sufia/_file-show.scss
@@ -22,3 +22,7 @@
   -webkit-column-width: 20em;
   column-width: 20em;
 }
+
+.img-responsive, figure {
+  display: inline-block;
+}

--- a/app/helpers/generic_file_helper.rb
+++ b/app/helpers/generic_file_helper.rb
@@ -13,7 +13,7 @@ module GenericFileHelper
     if title.nil?
       link_to download_image_tag, sufia.download_path(@generic_file), target: "_blank", title: "Download the document", id: "file_download", data: { label: @generic_file.id }
     else
-      label = download_image_tag(title) + title
+      label = download_image_tag(title)
       link_to label, sufia.download_path(@generic_file), target: "_blank", title: title, id: "file_download", data: { label: @generic_file.id }
     end
   end
@@ -34,10 +34,13 @@ module GenericFileHelper
   private
 
     def download_image_tag(title = nil)
-      if title.nil?
-        image_tag "default.png", alt: "No preview available", class: "img-responsive"
-      else
-        image_tag sufia.download_path(@generic_file, file: 'thumbnail'), class: "img-responsive", alt: "#{title} of #{@generic_file.title.first}"
+      content_tag :figure do
+        if title.nil?
+          concat image_tag "default.png", alt: "No preview available", class: "img-responsive"
+        else
+          concat image_tag sufia.download_path(@generic_file, file: 'thumbnail'), class: "img-responsive", alt: "#{title} of #{@generic_file.title.first}"
+        end
+        concat content_tag :figcaption, "Download the full sized image"
       end
     end
 

--- a/spec/controllers/admin_stats_controller_spec.rb
+++ b/spec/controllers/admin_stats_controller_spec.rb
@@ -27,7 +27,7 @@ describe Admin::StatsController, type: :controller do
     end
 
     describe "querying stats_filters" do
-      let(:one_day_ago_date) { 1.days.ago.to_datetime }
+      let(:one_day_ago_date) { 1.day.ago.to_datetime }
       let(:two_days_ago_date) { 2.days.ago.to_datetime.end_of_day }
       let(:one_day_ago) { one_day_ago_date.strftime("%Y-%m-%d") }
       let(:two_days_ago) { two_days_ago_date.strftime("%Y-%m-%d") }
@@ -85,19 +85,19 @@ describe Admin::StatsController, type: :controller do
 
       context "when start date set" do
         it "queries by start date" do
-          expect(GenericFile).to receive(:find_by_date_created).exactly(3).times.with(1.days.ago.to_datetime, nil).and_call_original
+          expect(GenericFile).to receive(:find_by_date_created).exactly(3).times.with(1.day.ago.to_datetime, nil).and_call_original
           expect(GenericFile).to receive(:where_public).and_call_original
           expect(GenericFile).to receive(:where_registered).and_call_original
-          get :index, stats_filters: { start_date: 1.days.ago.strftime("%Y-%m-%d") }
+          get :index, stats_filters: { start_date: 1.day.ago.strftime("%Y-%m-%d") }
         end
       end
 
       context "when date range set" do
         it "queries by start and date" do
-          expect(GenericFile).to receive(:find_by_date_created).exactly(3).times.with(1.days.ago.to_datetime, 0.days.ago.to_datetime.end_of_day).and_call_original
+          expect(GenericFile).to receive(:find_by_date_created).exactly(3).times.with(1.day.ago.to_datetime, 0.days.ago.to_datetime.end_of_day).and_call_original
           expect(GenericFile).to receive(:where_public).and_call_original
           expect(GenericFile).to receive(:where_registered).and_call_original
-          get :index, stats_filters: { start_date: 1.days.ago.strftime("%Y-%m-%d"), end_date: 0.days.ago.strftime("%Y-%m-%d") }
+          get :index, stats_filters: { start_date: 1.day.ago.strftime("%Y-%m-%d"), end_date: 0.days.ago.strftime("%Y-%m-%d") }
         end
       end
     end
@@ -130,7 +130,7 @@ describe Admin::StatsController, type: :controller do
       end
 
       it "gathers user deposits during a date range" do
-        get :index, stats_filters: { start_date: 1.days.ago.strftime("%Y-%m-%d"), end_date: 0.days.ago.strftime("%Y-%m-%d") }
+        get :index, stats_filters: { start_date: 1.day.ago.strftime("%Y-%m-%d"), end_date: 0.days.ago.strftime("%Y-%m-%d") }
         expect(assigns[:presenter].depositors).to include({ key: user1.user_key, deposits: 1, user: user1 }, key: user2.user_key, deposits: 1, user: user2)
       end
 

--- a/spec/models/file_download_stat_spec.rb
+++ b/spec/models/file_download_stat_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe FileDownloadStat, type: :model do
     describe "cache empty" do
       let(:stats) do
         expect(described_class).to receive(:ga_statistics).and_return(sample_download_statistics)
-        described_class.statistics(file_id, Date.today - 4.day)
+        described_class.statistics(file_id, Date.today - 4.days)
       end
 
       it "includes cached ga data" do
@@ -59,17 +59,17 @@ RSpec.describe FileDownloadStat, type: :model do
         # at this point all data should be cached
         allow(described_class).to receive(:ga_statistics).with(Date.today, file_id).and_raise("We should not call Google Analytics All data should be cached!")
 
-        stats2 = described_class.statistics(file_id, Date.today - 4.day)
+        stats2 = described_class.statistics(file_id, Date.today - 4.days)
         expect(described_class.to_flots stats2).to include(*download_output)
       end
     end
 
     describe "cache loaded" do
-      let!(:file_download_stat) { described_class.create(date: (Date.today - 5.day).to_datetime, file_id: file_id, downloads: "25") }
+      let!(:file_download_stat) { described_class.create(date: (Date.today - 5.days).to_datetime, file_id: file_id, downloads: "25") }
 
       let(:stats) do
         expect(described_class).to receive(:ga_statistics).and_return(sample_download_statistics)
-        described_class.statistics(file_id, Date.today - 5.day)
+        described_class.statistics(file_id, Date.today - 5.days)
       end
 
       it "includes cached data" do

--- a/spec/models/file_usage_spec.rb
+++ b/spec/models/file_usage_spec.rb
@@ -55,7 +55,7 @@ describe FileUsage, type: :model do
   end
 
   let(:usage) do
-    allow_any_instance_of(GenericFile).to receive(:create_date).and_return((Date.today - 4.day).to_s)
+    allow_any_instance_of(GenericFile).to receive(:create_date).and_return((Date.today - 4.days).to_s)
     expect(FileDownloadStat).to receive(:ga_statistics).and_return(sample_download_statistics)
     expect(FileViewStat).to receive(:ga_statistics).and_return(sample_pageview_statistics)
     described_class.new(file.id)
@@ -123,7 +123,7 @@ describe FileUsage, type: :model do
 
       describe "create date after earliest" do
         let(:usage) do
-          allow_any_instance_of(GenericFile).to receive(:create_date).and_return((Date.today - 4.day).to_s)
+          allow_any_instance_of(GenericFile).to receive(:create_date).and_return((Date.today - 4.days).to_s)
           expect(FileDownloadStat).to receive(:ga_statistics).and_return(sample_download_statistics)
           expect(FileViewStat).to receive(:ga_statistics).and_return(sample_pageview_statistics)
           Sufia.config.analytic_start_date = earliest

--- a/spec/models/file_view_stat_spec.rb
+++ b/spec/models/file_view_stat_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe FileViewStat, type: :model do
     describe "cache empty" do
       let(:stats) do
         expect(described_class).to receive(:ga_statistics).and_return(sample_pageview_statistics)
-        described_class.statistics(file_id, Date.today - 4.day, user_id)
+        described_class.statistics(file_id, Date.today - 4.days, user_id)
       end
 
       it "includes cached ga data" do
@@ -61,17 +61,17 @@ RSpec.describe FileViewStat, type: :model do
         # at this point all data should be cached
         allow(described_class).to receive(:ga_statistics).with(Date.today, file_id).and_raise("We should not call Google Analytics All data should be cached!")
 
-        stats2 = described_class.statistics(file_id, Date.today - 5.day)
+        stats2 = described_class.statistics(file_id, Date.today - 5.days)
         expect(described_class.to_flots stats2).to include(*view_output)
       end
     end
 
     describe "cache loaded" do
-      let!(:file_view_stat) { described_class.create(date: (Date.today - 5.day).to_datetime, file_id: file_id, views: "25") }
+      let!(:file_view_stat) { described_class.create(date: (Date.today - 5.days).to_datetime, file_id: file_id, views: "25") }
 
       let(:stats) do
         expect(described_class).to receive(:ga_statistics).and_return(sample_pageview_statistics)
-        described_class.statistics(file_id, Date.today - 5.day)
+        described_class.statistics(file_id, Date.today - 5.days)
       end
 
       it "includes cached data" do

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -643,7 +643,7 @@ describe GenericFile, type: :model do
     end
 
     context "with no end date" do
-      let(:start_date) { 1.days.ago }
+      let(:start_date) { 1.day.ago }
       let(:end_date) { nil }
       before do
         @file.save
@@ -652,7 +652,7 @@ describe GenericFile, type: :model do
     end
 
     context "with an end date" do
-      let(:start_date) { 1.days.ago }
+      let(:start_date) { 1.day.ago }
       let(:end_date) { DateTime.now }
       before do
         @file.save

--- a/spec/models/system_stats_spec.rb
+++ b/spec/models/system_stats_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ::SystemStats, type: :model do
   let(:user1) { FactoryGirl.find_or_create(:user) }
   let(:morning_two_days_ago) { 2.days.ago.to_date.to_datetime.to_s }
-  let(:yesterday) { 1.days.ago.to_datetime.to_s }
+  let(:yesterday) { 1.day.ago.to_datetime.to_s }
   let(:this_morning) { 0.days.ago.to_date.to_datetime.to_s }
 
   let(:stats) { described_class.new(depositor_count, user_stats[:start_date], user_stats[:end_date]) }
@@ -135,7 +135,7 @@ describe ::SystemStats, type: :model do
   describe "#recent_users" do
     let!(:user2) { FactoryGirl.find_or_create(:archivist) }
 
-    let(:one_day_ago_date) { 1.days.ago.to_datetime }
+    let(:one_day_ago_date) { 1.day.ago.to_datetime }
     let(:two_days_ago_date) { 2.days.ago.to_datetime.end_of_day }
     let(:one_day_ago) { one_day_ago_date.strftime("%Y-%m-%d") }
     let(:two_days_ago) { two_days_ago_date.strftime("%Y-%m-%d") }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -189,7 +189,7 @@ describe User, type: :model do
       end
 
       context "when has start and end date" do
-        subject { described_class.recent_users(Date.today - 2.days, Date.today - 1.days) }
+        subject { described_class.recent_users(Date.today - 2.days, Date.today - 1.day) }
         it "returns valid data" do
           expect(subject.count).to eq 1
           is_expected.to include(new_users[1])

--- a/spec/models/user_usage_stats_spec.rb
+++ b/spec/models/user_usage_stats_spec.rb
@@ -4,7 +4,7 @@ describe Sufia::UserUsageStats do
   subject { FactoryGirl.create(:user) }
 
   describe 'with cached stats' do
-    let!(:stat_1_day_ago) { UserStat.create!(user_id: subject.id, date: 1.days.ago, file_views: 3, file_downloads: 2) }
+    let!(:stat_1_day_ago) { UserStat.create!(user_id: subject.id, date: 1.day.ago, file_views: 3, file_downloads: 2) }
     let!(:stat_2_days_ago) { UserStat.create!(user_id: subject.id, date: 2.days.ago, file_views: 2, file_downloads: 1) }
 
     let!(:someone_elses_user_id) { subject.id + 1 }


### PR DESCRIPTION
…smaller than the width of the containing block. Overrides the Bootstrap .img-responsive display: block but inherits max-width to keep the image from pixellating.


The issue:

![screen shot 2015-10-30 at 1 35 04 pm](https://cloud.githubusercontent.com/assets/4163828/10853469/8d539382-7f0c-11e5-9e07-0fcf853e610b.png)

The solution:

![screen shot 2015-10-30 at 1 35 41 pm](https://cloud.githubusercontent.com/assets/4163828/10853476/965e387e-7f0c-11e5-9704-cf136a8f0a37.png)

