### PR TITLE
Ignore visibility of files[] input, it's hidden from Capybara

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ db/*.sqlite3
 db/*.sqlite3-journal
 log/*.log
 tmp
+.byebug_history
 
 *.sqlite3
 *.log

--- a/spec/features/ingest_upload_files_spec.rb
+++ b/spec/features/ingest_upload_files_spec.rb
@@ -15,8 +15,8 @@ describe "Uploading files via web form", type: :feature do
 
   context "the terms of service", :js do
     it "is required to be checked" do
-      attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/image.jp2")
-      attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/jp2_fits.xml")
+      attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/image.jp2", visible: false)
+      attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/jp2_fits.xml", visible: false)
       expect(page).to have_css("button#main_upload_start[disabled]")
       find('#main_upload_start_span').hover
       expect(page).to have_content "Please accept Deposit Agreement before you can upload."


### PR DESCRIPTION
The files input is hidden from Capybara due to something in the css `fileinput-button` class. This gets around the problem by ignoring the visibility issue. The button is still visible with a screen-reader, so I'm not sure why it's invisible to Capybara.