### PR TITLE
Option to show collection facet in Dashboard and search results

### DIFF
--- a/app/controllers/concerns/sufia/collections_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/collections_controller_behavior.rb
@@ -30,6 +30,12 @@ module Sufia
       presenter
     end
 
+    def update
+      super
+      new_members = ActiveFedora::Base.find(params[:batch_document_ids])
+      new_members.each(&:update_index)
+    end
+
     protected
 
       def presenter

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -1,0 +1,13 @@
+module FacetsHelper
+  include Blacklight::FacetsHelperBehavior
+
+  def display_collection_facet
+    if Sufia.config.collection_facet == :public
+      return true
+    elsif Sufia.config.collection_facet == :user && current_user
+      return true
+    else
+      return false
+    end
+  end
+end

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -57,6 +57,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("based_near", :facetable), label: "Location", limit: 5
     config.add_facet_field solr_name("publisher", :facetable), label: "Publisher", limit: 5
     config.add_facet_field solr_name("file_format", :facetable), label: "File Format", limit: 5
+    config.add_facet_field solr_name("collection", :facetable), label: "Collection", helper_method: :collection_name, limit: 5, show: :display_collection_facet
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/spec/features/collection_facet_spec.rb
+++ b/spec/features/collection_facet_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+describe "Collection Facet", type: :feature do
+  def visit_dashboard_my_files
+    visit '/dashboard/files'
+    expect(page.title).to eq 'Files listing'
+    expect(page).to have_link('My Files')
+    expect(page).to have_link('My Collections')
+    expect(page).to have_link('Fake PDF Title')
+    expect(page).to have_css('h3', text: 'Filter your files')
+  end
+
+  def search_for_files
+    visit '/'
+    fill_in('search-field-header', with: 'pdf')
+    click_button('search-submit-header')
+    expect(page.title).to eq 'Keyword: pdf - Blacklight Search Results'
+    expect(page).to have_link('Fake PDF Title')
+    expect(page).to have_css('h4', text: 'Limit your search')
+  end
+
+  def facet?(page)
+    f = page.all('a', text: /\ACollection\z/)
+    return true if f.size == 1
+    false
+  end
+
+  let(:auser) { FactoryGirl.create(:curator) }
+
+  let!(:fixtures) do
+    create_file_fixtures(auser.user_key, [:public_pdf]) do |f|
+      f.tag = ['pdf']
+      f.apply_depositor_metadata(auser.user_key)
+    end
+  end
+
+  let(:collection1) do
+    Collection.create(title: 'Test Collection 1', description: 'Description for collection 1',
+                      members: []) { |c| c.apply_depositor_metadata(auser.user_key) }
+  end
+
+  context "with collection having a member" do
+    before do
+      collection1.add_members([fixtures[0].id])
+      collection1.save
+      fixtures[0].update_index
+    end
+
+    context "and collection_facet config == nil" do
+      before do
+        Sufia.config.collection_facet = nil
+      end
+
+      it "does NOT show collection facet in Dashboard -> My Files" do
+        login_as auser
+        visit_dashboard_my_files
+        expect(facet?(page)).to eq false
+      end
+
+      it "does NOT show collection facet in pubic search with user logged in" do
+        login_as auser
+        search_for_files
+        expect(facet?(page)).to eq false
+      end
+
+      it "does NOT show collection facet in pubic search with user NOT logged in" do
+        search_for_files
+        expect(facet?(page)).to eq false
+      end
+    end
+
+    context "and collection_facet config == :user" do
+      before do
+        Sufia.config.collection_facet = :user
+      end
+
+      it "shows collection facet in Dashboard -> My Files" do
+        login_as auser
+        visit_dashboard_my_files
+        expect(facet?(page)).to eq true
+      end
+
+      it "does show collection facet in pubic search with user logged in" do
+        login_as auser
+        search_for_files
+        expect(facet?(page)).to eq true
+      end
+
+      it "does NOT show collection facet in pubic search with user NOT logged in" do
+        search_for_files
+        expect(facet?(page)).to eq false
+      end
+    end
+
+    context "and collection_facet config == :public" do
+      before do
+        Sufia.config.collection_facet = :public
+      end
+
+      it "shows collection facet in Dashboard -> My Files" do
+        login_as auser
+        visit_dashboard_my_files
+        expect(facet?(page)).to eq true
+      end
+
+      it "shows collection facet in pubic search with user logged in" do
+        login_as auser
+        search_for_files
+        expect(facet?(page)).to eq true
+      end
+
+      it "shows collection facet in pubic search with user NOT logged in" do
+        search_for_files
+        expect(facet?(page)).to eq true
+      end
+    end
+  end
+end

--- a/sufia-models/app/services/sufia/generic_file_indexing_service.rb
+++ b/sufia-models/app/services/sufia/generic_file_indexing_service.rb
@@ -13,6 +13,7 @@ module Sufia
         # between files on disk (in fcrepo.binary-store-path) and objects
         # in the repository.
         solr_doc[Solrizer.solr_name('digest', :symbol)] = digest_from_content
+        object.index_collection_ids(solr_doc)
       end
     end
 

--- a/sufia-models/lib/generators/sufia/models/collection_facet_config_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/collection_facet_config_generator.rb
@@ -1,0 +1,26 @@
+require 'rails/generators'
+
+class Sufia::Models::CollectionFacetConfigGenerator < Rails::Generators::Base
+  source_root File.expand_path('../templates', __FILE__)
+
+  desc """
+This Generator makes the following changes to your application:
+  1. Updates existing sufia.rb initializer to include a collection_facet configuration
+       """
+
+  def banner
+    say_status("info", "ADDING COLLECTION_FACET OPTION TO SUFIA CONFIG", :blue)
+  end
+
+  def inject_config_initializer
+    inject_into_file 'config/initializers/sufia.rb', before: "# Where to store tempfiles, leave blank for the system temp directory (e.g. /tmp)" do
+      "  # Add a collection facet to search results.  Possible values are...\n" +
+        "  #   nil (default) - do not include collection facet\n" +
+        "  #   :user - show for logged in users\n" +
+        "  #   :public - show for everyone (e.g. logged in and non-logged in users)\n" +
+        "  config.collection_facet = nil\n" +
+        "  # config.collection_facet = :user\n" +
+        "  # config.collection_facet = :public\n"
+    end
+  end
+end

--- a/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
@@ -95,6 +95,14 @@ Sufia.config do |config|
   # Default is false
   # config.citations = false
 
+  # Add a collection facet to search results.  Possible values are...
+  #   nil (default) - do not include collection facet
+  #   :user - show for logged in users
+  #   :public - show for everyone (e.g. logged in and non-logged in users)
+  # config.collection_facet = nil
+  # config.collection_facet = :user
+  # config.collection_facet = :public
+
   # Enables a select menu on the batch upload page to select a collection into which to add newly uploaded files.
   # Default is false
   # config.upload_to_collection = false

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -25,6 +25,7 @@ module Sufia
       config.enable_local_ingest = nil
       config.analytics = false
       config.citations = false
+      config.collection_facet = nil
       config.upload_to_collection = false
       config.lock_retry_count = 600 # Up to 2 minutes of trying at intervals up to 200ms
       config.lock_time_to_live = 60_000 # milliseconds


### PR DESCRIPTION
Option: Sufia.config.collection_facet
Values:
* nil - do not show collection facets
* :user - show for logged in users
* :public - show for everyone (e.g. logged in and non-logged in users)