### PR TITLE
Makes upload_set_id available in the WorkShowPresenter. 

### DIFF
--- a/app/controllers/concerns/sufia/files_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller_behavior.rb
@@ -29,6 +29,7 @@ module Sufia
 
     def new
       @upload_set_id = ActiveFedora::Noid::Service.new.mint
+      @presenter = Sufia::WorkShowPresenter.new(@solr_document, nil)
     end
 
     # routed to /files/:id/stats

--- a/app/presenters/sufia/work_show_presenter.rb
+++ b/app/presenters/sufia/work_show_presenter.rb
@@ -2,6 +2,7 @@ module Sufia
   class WorkShowPresenter < ::CurationConcerns::WorkShowPresenter
     # delegate fields from Sufia::Works::Metadata to solr_document
     delegate :based_near, :depositor, :identifier, :resource_type, :tag, to: :solr_document
+    attr_reader :upload_set_id
 
     def tweeter
       user = ::User.find_by_user_key(depositor)

--- a/app/views/curation_concerns/file_sets/upload/_script_templates.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_script_templates.html.erb
@@ -1,8 +1,7 @@
-<!-- TODO: make the upload_set_id available on the presenter -->
-<% if false && presenter.upload_set_id %>
+<% if @presenter.upload_set_id %>
     <div class="alert alert-info hide" id="redirect-loc" type="text/x-jquery-tmpl">
     <%# Script redirects here once the uploads are complete %>
-    <%= CurationConcerns::FileSetsController.upload_complete_path(presenter.upload_set_id) %>
+    <%= CurationConcerns::FileSetsController.upload_complete_path(@presenter.upload_set_id) %>
     </div>
 <% end %>
 

--- a/spec/presenters/sufia/work_show_presenter_spec.rb
+++ b/spec/presenters/sufia/work_show_presenter_spec.rb
@@ -5,6 +5,13 @@ describe Sufia::WorkShowPresenter do
   let(:ability) { double "Ability" }
   let(:presenter) { described_class.new(solr_document, ability) }
 
+  context "upload_set_id" do
+    let(:work) { build(:generic_work) }
+    it "exposes upload_set_id" do
+      expect(presenter.upload_set_id).to be nil
+    end
+  end
+
   describe '#itemtype' do
     let(:work) { build(:generic_work, resource_type: type) }
 


### PR DESCRIPTION
This PR replaces https://github.com/projecthydra/sufia/pull/1366 (the old one was from sufia-core but that project is now readonly and it was easier for me just to create a new PR with the same commits)