### PR TITLE
add depositor metadata to curation_concern in controller#new

### DIFF
--- a/app/controllers/concerns/sufia/generic_works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/generic_works_controller_behavior.rb
@@ -15,6 +15,7 @@ module Sufia
     def new
       # TODO: move this to curation_concerns
       @form = form_class.new(curation_concern, current_ability)
+      curation_concern.depositor = (current_user.user_key)
       super
     end
 

--- a/spec/controllers/generic_works_controller_spec.rb
+++ b/spec/controllers/generic_works_controller_spec.rb
@@ -7,11 +7,16 @@ describe CurationConcerns::GenericWorksController do
   routes { Rails.application.routes }
 
   describe "#new" do
+    before { get :new }
     it "is successful" do
-      get :new
       expect(response).to be_successful
       expect(response).to render_template("layouts/sufia-one-column")
       expect(assigns[:curation_concern]).to be_kind_of GenericWork
+    end
+
+    it "applies depositor metadata" do
+      expect(assigns[:form].depositor).to eq user.user_key
+      expect(assigns[:curation_concern].depositor).to eq user.user_key
     end
   end
 


### PR DESCRIPTION
This solution is a bit peculiar in calling `apply_depositor_metadata` from the `generic_works_controller#new` method instead of an actor.  I'm going to see if I can track down where the call to create a new generic_work or curation_concern instance is and see if that's a more appropriate place for the apply metadata call.