### PR TITLE
Single 'Save' button on Work Edit page

### DIFF
--- a/app/views/curation_concerns/base/_form.html.erb
+++ b/app/views/curation_concerns/base/_form.html.erb
@@ -14,8 +14,7 @@
     <%= render 'curation_concerns/base/permission_form', f: f %>
 
     <div class="primary-actions">
-      <%= f.submit 'Save and Add Files', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
-      <%= f.submit 'Save without Files', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "without_files_submit", name: "save_without_files" %>
+      <%= f.submit 'Save', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
       <%= link_to t(:'helpers.action.cancel'), main_app.root_path, class: 'btn btn-link' %>
     </div>
 


### PR DESCRIPTION
The Work Edit page currently has two save buttons (save and add files + save without files).  However, we always send the user to the Work Show page after saving a work. This PR uses a single "Save" button instead. This makes the Work Edit page much clear since "save without files" on a work that has already files is rather confusing. 

Work Edit before this change: 
<img width="940" alt="screen shot 2015-12-11 at 11 23 54 am" src="https://cloud.githubusercontent.com/assets/568286/11749157/20d65e74-9ffa-11e5-8b16-3c2c8c3cac72.png">

Work Edit with this change:

<img width="753" alt="screen shot 2015-12-11 at 11 21 45 am" src="https://cloud.githubusercontent.com/assets/568286/11749163/29bdebc4-9ffa-11e5-867c-a6fdff547cf7.png">


