### PR TITLE
Preserve the URLs that worked in sufia < 7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -156,4 +156,5 @@ RSpec/DescribeClass:
     - 'spec/features/**/*'
     - 'spec/views/**/*'
     - 'spec/routing/**/*'
+    - 'spec/requests/**/*'
     - 'spec/inputs/**/*'

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ After running these steps, browse to http://localhost:3000/ and you should see t
 [![Coverage Status](https://coveralls.io/repos/projecthydra/sufia/badge.svg)](https://coveralls.io/r/projecthydra/sufia)
 [![Stories in Ready](https://badge.waffle.io/projecthydra/sufia.png?label=ready&title=Ready)](https://waffle.io/projecthydra/sufia)
 
+# Migrating data to PCDM / Sufia 7
+
+1. Create a GenericWork for each GenericFile. The new GenericWork should have the same id as the old GenericFile so that URLs that users have saved will route them to the appropriate location.
+2. Create a FileSet for each GenericWork and add it to the ordered_members collection on the GenericWork.
+3. Move the binary from the GenericFile#content to FileSet#original_file
+
 # Table of Contents
 
   * [What is Sufia?](#what-is-sufia)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Sufia::Engine.routes.draw do
   # Route the home page as the root
   root to: 'sufia/homepage#index'
 
+  # Handle routes that existed in Sufia < 7
+  #   e.g. https://scholarsphere.psu.edu/files/gm80hv36p
+  get '/files/:id', to: redirect('/concern/generic_works/%{id}')
+
   match 'batch_edits/clear' => 'batch_edits#clear', as: :batch_edits_clear, via: [:get, :post]
 
   # Notifications route for catalog index view

--- a/spec/requests/legacy_routing_spec.rb
+++ b/spec/requests/legacy_routing_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'Legacy GenericFile routes' do
+  it 'redirects to the work' do
+    get '/files/gm80hv36p'
+    expect(response).to redirect_to("/concern/generic_works/gm80hv36p")
+    expect(response.code).to eq '301' # Moved Permanently
+  end
+end


### PR DESCRIPTION
Fixes #1361

Doing this by issuing a redirect to the generic_work#show page with the
same id as the GenericFile had.  Added the beginnings of some data
migration instructions.