### PR TITLE
Export endnote format from work, not file set, fixes #1420

### DIFF
--- a/app/controllers/concerns/sufia/file_sets_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/file_sets_controller_behavior.rb
@@ -40,11 +40,6 @@ module Sufia
     def citation
     end
 
-    # Called by CurationConcerns::FileSetsControllerBehavior#show
-    def additional_response_formats(format)
-      format.endnote { render text: presenter.solr_document.export_as_endnote }
-    end
-
     protected
 
       def _prefixes

--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -24,5 +24,18 @@ module Sufia
       def show_presenter
         Sufia::WorkShowPresenter
       end
+
+      # Called by CurationConcerns::FileSetsControllerBehavior#show
+      def additional_response_formats(format)
+        # TODO: This duplicates the same process in CurationConcerns::CurationConcernController.show
+        # for assigning a presenter. It could be extracted into a common method.
+        format.endnote do
+          _, document_list = search_results(params, CatalogController.search_params_logic + [:find_one])
+          curation_concern = document_list.first
+          raise CanCan::AccessDenied.new(nil, :show) unless curation_concern
+          presenter = show_presenter.new(curation_concern, current_ability)
+          render text: presenter.solr_document.export_as_endnote
+        end
+      end
   end
 end

--- a/spec/controllers/file_sets_controller_spec.rb
+++ b/spec/controllers/file_sets_controller_spec.rb
@@ -498,11 +498,6 @@ describe CurationConcerns::FileSetsController do
         expect(assigns[:presenter].events).to be_kind_of Array
         expect(assigns[:presenter].audit_status).to eq 'Audits have not yet been run on this file.'
       end
-
-      it 'renders an endnote file' do
-        get :show, id: file_set, format: 'endnote'
-        expect(response).to be_successful
-      end
     end
   end
 

--- a/spec/controllers/generic_works_controller_spec.rb
+++ b/spec/controllers/generic_works_controller_spec.rb
@@ -39,5 +39,9 @@ describe CurationConcerns::GenericWorksController do
       expect(response).to be_successful
       expect(assigns(:presenter)).to be_kind_of Sufia::WorkShowPresenter
     end
+    it 'renders an endnote file' do
+      get :show, id: work, format: 'endnote'
+      expect(response).to be_successful
+    end
   end
 end


### PR DESCRIPTION
We can DRY this up a bit, as noted in the TODO, if we tweak curation concerns a bit, but otherwise, this should be OK.