### PR TITLE
Makes OpenUrlFormatter more forgiving when the work... 

### DIFF
--- a/app/helpers/sufia/citations_behaviors/formatters/open_url_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/open_url_formatter.rb
@@ -21,6 +21,7 @@ module Sufia
             rights: 'rights'
           }
           field_map.each do |element, kev|
+            next unless work.respond_to?(element)
             values = work.send(element)
             next if values.blank? || values.first.nil?
             Array(values).each do |value|

--- a/app/views/curation_concerns/base/_show_actions.html.erb
+++ b/app/views/curation_concerns/base/_show_actions.html.erb
@@ -18,8 +18,6 @@
     <%= link_to 'Export to Zotero', sufia.static_path('zotero'), id: 'zoteroLink', name: 'zotero', class: 'btn btn-default' %>
     <%= link_to 'Export to Mendeley', sufia.static_path('mendeley'), id: 'mendeleyLink', name: 'mendeley', class: 'btn btn-default' %>
     <!-- COinS hook for Zotero -->
-    <!-- TODO: Fix issue with export_as_openurl_ctx_kev
-         See  https://github.com/projecthydra/sufia/issues/1479 -->
-      <span class="Z3988" title="<%= 'TODO: export_as_openurl_ctx_kev(@presenter)' %>"></span>
+    <span class="Z3988" title="<%= export_as_openurl_ctx_kev(@presenter) %>"></span>
   </div>
 <% end %>


### PR DESCRIPTION
...does not have all the fields. In particular `resource_type`, `identifier`, and `based_near` are not in FileSets. Fixes #1479
