### PR TITLE
Include the name of the file if it fails to upload

### DIFF
--- a/app/controllers/concerns/sufia/files_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller_behavior.rb
@@ -106,7 +106,7 @@ module Sufia
       end
     rescue => error
       logger.error "GenericFilesController::create rescued #{error.class}\n\t#{error}\n #{error.backtrace.join("\n")}\n\n"
-      json_error "Error occurred while creating generic file."
+      json_error "Error occurred while creating generic file.", file.original_filename
     ensure
       # remove the tempfile (only if it is a temp file)
       file.tempfile.delete if file.respond_to?(:tempfile)

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -133,7 +133,7 @@ describe GenericFilesController do
 
           file = fixture_file_upload('/world.png', 'image/png')
           xhr :post, :create, files: [file], Filename: "The world", batch_id: "sample_batch_id", permission: { "group" => { "public" => "read" } }, terms_of_service: "1"
-          expect(response.body).to include("Error occurred while creating generic file.")
+          expect(response.body).to include("Error occurred while creating generic file.", "world.png")
         end
       end
     end


### PR DESCRIPTION
Minor issue, but it would fix an issue in another project. As far as I can tell, there's no corresponding change required in Sufia 7 or in Curation Concerns.