### PR TITLE
Prevents rendering of the extra visibility textbox in the Generic …

### DIFF
--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -5,7 +5,7 @@ module Sufia::Forms
     def rendered_terms
       terms - [:files, :visibility_during_embargo, :embargo_release_date,
                :visibility_after_embargo, :visibility_during_lease,
-               :lease_expiration_date, :visibility_after_lease]
+               :lease_expiration_date, :visibility_after_lease, :visibility]
     end
   end
 end

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_follower', '>= 0.1.1', '< 0.3'
   spec.add_dependency 'carrierwave', '~> 0.9'
   spec.add_dependency 'oauth2', '~> 0.9'
-  spec.add_dependency 'google-api-client', '~> 0.7'
+  spec.add_dependency 'google-api-client', '~> 0.7', '< 0.9'
   spec.add_dependency 'legato', '~> 0.3'
   spec.add_dependency 'activerecord-import', '~> 0.5'
   spec.add_dependency 'posix-spawn'


### PR DESCRIPTION
…Work edit form. Visibility is already handled via the Persmissions form. Fixes #1513

Notice that this fix manually skips the visibility field when rendering `_form`. 

Another approach to fix this issue is to either remove the "visibility" field from `CurationConcerns::Forms::WorkForm` (https://github.com/projecthydra-labs/curation_concerns/blob/master/app/forms/curation_concerns/forms/work_form.rb#L17) or at least from the Sufia version of this form (https://github.com/projecthydra/sufia/blob/master/app/forms/sufia/forms/work_form.rb) 

Thoughts?


Anyway, below is how the form looks with the fix. Notice the extra visibility textbox reported on #1513 is gone. 
![screen shot 2016-01-15 at 9 41 21 am](https://cloud.githubusercontent.com/assets/568286/12355688/60985156-bb6c-11e5-81e1-bae0e5d3a146.png)
