### PR TITLE
add featured? methods to file_set_presenter

### DIFF
--- a/app/presenters/sufia/file_set_presenter.rb
+++ b/app/presenters/sufia/file_set_presenter.rb
@@ -17,6 +17,14 @@ module Sufia
       end
     end
 
+    def display_feature_link?
+      false
+    end
+
+    def display_unfeature_link?
+      false
+    end
+
     def rights
       return if solr_document.rights.nil?
       solr_document.rights.first


### PR DESCRIPTION
Add methods *display_feature_link?* and *display_unfeature_link?* to file sufia/app/presenters/sufia/file_set_presenter.rb, so that app/views/curations_concerns/base/_show_actions.html.erb not longer dies with a method not found error when viewing the file page.