### PR TITLE
Revised file_set presenter and show per @jcoyne's suggestion

### DIFF
--- a/app/presenters/sufia/file_set_presenter.rb
+++ b/app/presenters/sufia/file_set_presenter.rb
@@ -17,6 +17,14 @@ module Sufia
       end
     end
 
+    def display_feature_link?
+      false
+    end
+
+    def display_unfeature_link?
+      false
+    end
+
     def rights
       return if solr_document.rights.nil?
       solr_document.rights.first


### PR DESCRIPTION
1. Added new show_actions partial under views/curation_concerns/file_sets directory.
2. Disabled (for now): @stats = FileUsage.new(params[:id]), in stats_controller.rb.
Result: when analytics button is clicked on the file_sets show page, one is taken to a mostly blank analytics page for file_sets.