### PR TITLE
Pin Sufia 6 to hydra-head 9.5

### DIFF
--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '~> 4.0'
   spec.add_dependency 'activeresource', "~> 4.0" # No longer a dependency of rails 4.0
 
-  spec.add_dependency "hydra-head", "~> 9.0"
+  spec.add_dependency "hydra-head", "< 9.6"
   spec.add_dependency "active-fedora", "~> 9.4"
   spec.add_dependency "hydra-collections", [">= 5.0.3", "< 6.0"]
   spec.add_dependency 'hydra-derivatives', '~> 1.0'


### PR DESCRIPTION
Sufia 6 is presently broken with the latest hydra-head. Fixing this presents some issues, which I discuss in #1530.