### PR TITLE
Do not depend upon components that use BL6.

### DIFF
--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,7 +1,5 @@
 # Use this file to reference specific commits of gems.
 
-gem 'curation_concerns', github: 'projecthydra-labs/curation_concerns', branch: 'master'
-
 # Required for doing pagination inside an engine. See https://github.com/amatsuda/kaminari/pull/322
 gem 'kaminari', github: 'jcoyne/kaminari', branch: 'sufia'
 

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'curation_concerns', '~> 0.4'
   spec.add_dependency 'hydra-batch-edit', '~> 1.1'
+  spec.add_dependency 'hydra-head', '< 9.6.0'
   spec.add_dependency 'browse-everything', '~> 0.4'
   spec.add_dependency 'blacklight-gallery', '~> 0.1'
   spec.add_dependency 'tinymce-rails', '~> 4.1'


### PR DESCRIPTION
Hydra-head 9.6.0 and CurationConcerns master have both migrated to Blacklight 6, which is not yet supported in Sufia. We should not depend on these new components until we've made Sufia's master branch support Blacklight 6.