### PR TITLE
Added controller test for editting works in process.

### DIFF
--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -19,7 +19,7 @@ module Sufia
 
     def edit
       work = GenericWork.find(params[:id])
-      throw "Cannot edit a work that still is being processed" if work.processing?
+      raise "Cannot edit a work that still is being processed" if work.processing?
       super
     end
 

--- a/spec/controllers/works_controller_spec.rb
+++ b/spec/controllers/works_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe CurationConcerns::GenericWorksController, type: :controller do
+  routes { Rails.application.routes }
+  let(:user) { create(:user) }
+  before { sign_in user }
+
+  describe "#edit" do
+    let(:work) {
+      GenericWork.create(creator: ["Depeche Mode"], title: ["Strangelog"], language: ['en']) do |gw|
+        gw.apply_depositor_metadata(user.email)
+      end
+    }
+
+    it "allows edit on a work" do
+      get :edit, id: work.id
+      expect(response).to be_success
+    end
+
+    it "prevents edit on a work that still is being processed" do
+      allow_any_instance_of(GenericWork).to receive(:processing?).and_return(true)
+      expect { get :edit, id: work.id }.to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Also replaced `throw` with `raise` since that's more inline with the way exceptions are handled in Ruby:
http://stackoverflow.com/questions/51021/what-is-the-difference-between-raising-exceptions-vs-throwing-exceptions-in-ruby

These changes were suggested after merging PR #1537.

@mjgiarlo as you suggested.