### PR TITLE
Escape property values before presenting them with auto_link

### DIFF
--- a/app/helpers/file_set_helper.rb
+++ b/app/helpers/file_set_helper.rb
@@ -11,7 +11,7 @@ module FileSetHelper
 
   def display_multiple(value)
     return if value.nil?
-    auto_link(value.join(" | "))
+    auto_link(html_escape(value.join(" | ")))
   end
 
   private

--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -71,7 +71,7 @@ module Sufia
     def iconify_auto_link(text, showLink = true)
       # this block is only executed when a link is inserted;
       # if we pass text containing no links, it just returns text.
-      auto_link(text) do |value|
+      auto_link(html_escape(text)) do |value|
         "<i class='glyphicon glyphicon-new-window'></i>#{('&nbsp;' + value) if showLink}<br />"
       end
     end

--- a/spec/helpers/file_set_helper_spec.rb
+++ b/spec/helpers/file_set_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe FileSetHelper, type: :helper do
+  describe '#display_multiple' do
+    subject { helper.display_multiple(['Title with < 50Hz frequency. http://www.example.com. & More text', 'Other title']) }
+    it "escapes input" do
+      expect(subject).to start_with('Title with &lt; 50Hz frequency. ')
+      expect(subject).to end_with('. &amp; More text | Other title')
+    end
+    it "adds links" do
+      expect(subject).to include('<a href="http://www.example.com">')
+    end
+  end
+end

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -166,4 +166,18 @@ describe SufiaHelper, type: :helper do
       conn.commit
     end
   end
+
+  describe "#iconify_auto_link" do
+    subject { helper.iconify_auto_link('Foo < http://www.example.com. & More text') }
+    it "escapes input" do
+      expect(subject).to start_with('Foo &lt;')
+      expect(subject).to end_with('. &amp; More text')
+    end
+    it "adds links" do
+      expect(subject).to include('<a href="http://www.example.com">')
+    end
+    it "adds icons" do
+      expect(subject).to include('class="glyphicon glyphicon-new-window"')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1546 together with projecthydra-labs/curation_concerns#599.

There appears to be quite a few references to iconify_auto_link in various templates but I'm not sure if these templates are actually used anywhere. It seems that most of the broken behaviour stems from CurationConcerns instead.

The only places where I think the problem is actually in Sufia is the description field in the BlackLight generated search pages (using views/shared/_attributes.html.erb) and FileSets details page (views/curation_concerns/file_sets/show.html.erb). But FileSets details page seems to be having various other issues and is giving other errors. 

In any case, the two helpers should be fixed now so if anything uses them then they should work properly.

Also, Curation Concerns 0.6.0 and current Sufia have a gem version conflict in hydra-head so getting these two patches to work together is a bit tricky at the moment.

I will make a similar PR for the 6.x branch as well shortly.