### PR TITLE
Do not show 'work link' if work transfer is cancelled'

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -31,7 +31,7 @@ module Sufia
     end
 
     def show_transfer_request_title(req)
-      if req.deleted_work?
+      if req.deleted_work? || req.canceled?
         req.to_s
       else
         link_to(req.to_s, curation_concerns_generic_work_path(req.generic_work_id))

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -75,6 +75,10 @@ class ProxyDepositRequest < ActiveRecord::Base
     save!
   end
 
+  def canceled?
+    self.status == 'canceled'
+  end
+
   def deleted_work?
     !GenericWork.exists?(generic_work_id)
   end

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 describe SufiaHelper, type: :helper do
+  describe "show_transfer_request_title" do
+    let(:sender) { create(:user) }
+    let(:user) { create(:user) }
+    let(:work) do
+      GenericWork.create!(title: ["Test work"]) do |work|
+        work.apply_depositor_metadata(sender.user_key)
+      end
+    end
+
+    context "when work is canceled" do
+      let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: user, sending_user: sender, status: 'canceled') }
+      subject { helper.show_transfer_request_title request }
+      it { expect(subject).to eq 'Test work' }
+    end
+  end
+
   describe "#link_to_facet_list" do
     def search_state_double(value)
       double('SearchState', add_facet_params_and_redirect: { f: { vehicle_type_sim: [value] } })

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -43,6 +43,17 @@ describe ProxyDepositRequest, type: :model do
       its(:to_s) { is_expected.to eq 'work not found' }
       its(:deleted_work?) { is_expected.to be true }
     end
+  
+    describe "and the work transfer is canceled" do
+      before do
+        subject.cancel!
+      end
+
+      its(:status) { is_expected.to eq 'canceled' }
+      its(:fulfillment_date) { is_expected.not_to be_nil }
+      its(:canceled?) { is_expected.to be true }
+    end
+  
   end
 
   context "After rejection" do


### PR DESCRIPTION
related to #1552 