### PR TITLE
Fix for collection tag crash

### DIFF
--- a/app/presenters/sufia/collection_presenter.rb
+++ b/app/presenters/sufia/collection_presenter.rb
@@ -8,7 +8,7 @@ module Sufia
     # Terms is the list of fields displayed by app/views/collections/_show_descriptions.html.erb
     def self.terms
       [:title, :total_items, :size, :resource_type, :description, :creator,
-       :contributor, :tag, :rights, :publisher, :date_created, :subject,
+       :contributor, :tags, :rights, :publisher, :date_created, :subject,
        :language, :identifier, :based_near, :related_url]
     end
 

--- a/spec/presenters/sufia/collection_presenter_spec.rb
+++ b/spec/presenters/sufia/collection_presenter_spec.rb
@@ -4,7 +4,7 @@ describe Sufia::CollectionPresenter do
   describe ".terms" do
     subject { described_class.terms }
     it { is_expected.to eq [:title, :total_items, :size, :resource_type, :description, :creator,
-                            :contributor, :tag, :rights, :publisher, :date_created, :subject,
+                            :contributor, :tags, :rights, :publisher, :date_created, :subject,
                             :language, :identifier, :based_near, :related_url] }
   end
 


### PR DESCRIPTION
*2-18-16 UPDATE*

Okay: This fix is for the error:
undefined method `tag' for #<Sufia::CollectionPresenter:0x007fd975181a18>
where you try to create a collection with keywords.

Fix in collection_presenter.rb:
in def self.terms change
:tag to
:tags


Traceback:
Started GET "/collections/r494vk167" for 127.0.0.1 at 2016-02-18 12:42:22 -0500
Processing by CollectionsController#show as HTML
  Parameters: {"id"=>"r494vk167"}
  User Load (0.1ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = ?  ORDER BY "users"."id" ASC LIMIT 1  [["id", 1]]
   (0.1ms)  SELECT DISTINCT COUNT(DISTINCT "mailboxer_conversations"."id") FROM "mailboxer_conversations" INNER JOIN "mailboxer_notifications" ON "mailboxer_notifications"."conversation_id" = "mailboxer_conversations"."id" AND "mailboxer_notifications"."type" IN ('Mailboxer::Message') INNER JOIN "mailboxer_receipts" ON "mailboxer_receipts"."notification_id" = "mailboxer_notifications"."id" WHERE "mailboxer_notifications"."type" = 'Mailboxer::Message' AND "mailboxer_receipts"."mailbox_type" = ? AND "mailboxer_receipts"."trashed" = ? AND "mailboxer_receipts"."deleted" = ? AND "mailboxer_notifications"."type" = 'Mailboxer::Message' AND "mailboxer_receipts"."receiver_id" = ? AND "mailboxer_receipts"."receiver_type" = ? AND "mailboxer_receipts"."is_read" = ?  [["mailbox_type", "inbox"], ["trashed", "f"], ["deleted", "f"], ["receiver_id", 1], ["receiver_type", "User"], ["is_read", "f"]]
  Mailboxer::Conversation Load (0.1ms)  SELECT DISTINCT "mailboxer_conversations".* FROM "mailboxer_conversations" INNER JOIN "mailboxer_notifications" ON "mailboxer_notifications"."conversation_id" = "mailboxer_conversations"."id" AND "mailboxer_notifications"."type" IN ('Mailboxer::Message') INNER JOIN "mailboxer_receipts" ON "mailboxer_receipts"."notification_id" = "mailboxer_notifications"."id" WHERE "mailboxer_notifications"."type" = 'Mailboxer::Message' AND "mailboxer_receipts"."receiver_id" = ? AND "mailboxer_receipts"."receiver_type" = ? AND "mailboxer_receipts"."mailbox_type" = ? AND "mailboxer_receipts"."trashed" = ? AND "mailboxer_receipts"."deleted" = ?  ORDER BY mailboxer_conversations.updated_at DESC  [["receiver_id", 1], ["receiver_type", "User"], ["mailbox_type", "inbox"], ["trashed", "f"], ["deleted", "f"]]
Usergroups are ["public", "registered"]
Solr parameters: {"facet.field"=>["resource_type_sim", "creator_sim", "tag_sim", "subject_sim", "language_sim", "based_near_sim", "publisher_sim", "file_format_sim"], "facet.query"=>[], "facet.pivot"=>[], "fq"=>["edit_access_group_ssim:public OR discover_access_group_ssim:public OR read_access_group_ssim:public OR edit_access_group_ssim:registered OR discover_access_group_ssim:registered OR read_access_group_ssim:registered OR edit_access_person_ssim:gordonl@umich.edu OR discover_access_person_ssim:gordonl@umich.edu OR read_access_person_ssim:gordonl@umich.edu"], "hl.fl"=>[], "qt"=>"search", "rows"=>10, "qf"=>"title_tesim name_tesim", "facet"=>true, "f.resource_type_sim.facet.limit"=>6, "f.creator_sim.facet.limit"=>6, "f.tag_sim.facet.limit"=>6, "f.subject_sim.facet.limit"=>6, "f.language_sim.facet.limit"=>6, "f.based_near_sim.facet.limit"=>6, "f.publisher_sim.facet.limit"=>6, "f.file_format_sim.facet.limit"=>6, "sort"=>"score desc, system_create_dtsi desc"}
Solr query: get select {"qt"=>"search", "facet.field"=>["resource_type_sim", "creator_sim", "tag_sim", "subject_sim", "language_sim", "based_near_sim", "publisher_sim", "file_format_sim"], "fq"=>["edit_access_group_ssim:public OR discover_access_group_ssim:public OR read_access_group_ssim:public OR edit_access_group_ssim:registered OR discover_access_group_ssim:registered OR read_access_group_ssim:registered OR edit_access_person_ssim:gordonl@umich.edu OR discover_access_person_ssim:gordonl@umich.edu OR read_access_person_ssim:gordonl@umich.edu", "(_query_:\"{!raw f=has_model_ssim}GenericWork\" OR _query_:\"{!raw f=has_model_ssim}Collection\")", "_query_:\"{!raw f=id}r494vk167\""], "rows"=>10, "qf"=>"title_tesim name_tesim", "facet"=>true, "f.resource_type_sim.facet.limit"=>6, "f.creator_sim.facet.limit"=>6, "f.tag_sim.facet.limit"=>6, "f.subject_sim.facet.limit"=>6, "f.language_sim.facet.limit"=>6, "f.based_near_sim.facet.limit"=>6, "f.publisher_sim.facet.limit"=>6, "f.file_format_sim.facet.limit"=>6, "sort"=>"score desc, system_create_dtsi desc"}
Solr fetch (8.0ms)
Solr parameters: {"facet.field"=>["resource_type_sim", "creator_sim", "tag_sim", "subject_sim", "language_sim", "based_near_sim", "publisher_sim", "file_format_sim"], "facet.query"=>[], "facet.pivot"=>[], "fq"=>["edit_access_group_ssim:public OR discover_access_group_ssim:public OR read_access_group_ssim:public OR edit_access_group_ssim:registered OR discover_access_group_ssim:registered OR read_access_group_ssim:registered OR edit_access_person_ssim:gordonl@umich.edu OR discover_access_person_ssim:gordonl@umich.edu OR read_access_person_ssim:gordonl@umich.edu"], "hl.fl"=>[], "qt"=>"search", "rows"=>10, "qf"=>"title_tesim name_tesim", "facet"=>true, "f.resource_type_sim.facet.limit"=>6, "f.creator_sim.facet.limit"=>6, "f.tag_sim.facet.limit"=>6, "f.subject_sim.facet.limit"=>6, "f.language_sim.facet.limit"=>6, "f.based_near_sim.facet.limit"=>6, "f.publisher_sim.facet.limit"=>6, "f.file_format_sim.facet.limit"=>6, "sort"=>"score desc, system_create_dtsi desc"}
Solr query: get select {"qt"=>"search", "facet.field"=>["resource_type_sim", "creator_sim", "tag_sim", "subject_sim", "language_sim", "based_near_sim", "publisher_sim", "file_format_sim"], "fq"=>["edit_access_group_ssim:public OR discover_access_group_ssim:public OR read_access_group_ssim:public OR edit_access_group_ssim:registered OR discover_access_group_ssim:registered OR read_access_group_ssim:registered OR edit_access_person_ssim:gordonl@umich.edu OR discover_access_person_ssim:gordonl@umich.edu OR read_access_person_ssim:gordonl@umich.edu", "{!join from=member_ids_ssim to=id}id:r494vk167", "(_query_:\"{!raw f=has_model_ssim}GenericWork\" OR _query_:\"{!raw f=has_model_ssim}Collection\")"], "rows"=>10, "qf"=>"title_tesim name_tesim", "facet"=>true, "f.resource_type_sim.facet.limit"=>6, "f.creator_sim.facet.limit"=>6, "f.tag_sim.facet.limit"=>6, "f.subject_sim.facet.limit"=>6, "f.language_sim.facet.limit"=>6, "f.based_near_sim.facet.limit"=>6, "f.publisher_sim.facet.limit"=>6, "f.file_format_sim.facet.limit"=>6, "sort"=>"score desc, system_create_dtsi desc"}
Solr fetch (8.2ms)
Solr query: get select {"qt"=>nil, "facet.field"=>[], "facet.query"=>[], "facet.pivot"=>[], "fq"=>["{!join from=file_set_ids_ssim to=id}{!join from=child_object_ids_ssim to=id}id:r494vk167"], "hl.fl"=>[], "rows"=>100, "fl"=>["file_size_ssim"]}
Solr fetch (4.3ms)
Looking for show field partial collections/show_fields/_total_items
Looking for show field partial records/show_fields/_total_items
Looking for show field partial collections/show_fields/_default
Looking for show field partial records/show_fields/_default
  Rendered /Users/gordonl/d/sufia_analytics2/app/views/records/show_fields/_default.html.erb (3.2ms)
Looking for show field partial collections/show_fields/_size
Looking for show field partial records/show_fields/_size
Looking for show field partial collections/show_fields/_default
Looking for show field partial records/show_fields/_default
Solr query: get select {"qt"=>nil, "facet.field"=>[], "facet.query"=>[], "facet.pivot"=>[], "fq"=>["{!join from=file_set_ids_ssim to=id}{!join from=child_object_ids_ssim to=id}id:r494vk167"], "hl.fl"=>[], "rows"=>100, "fl"=>["file_size_ssim"]}
Solr fetch (3.8ms)
  Rendered /Users/gordonl/d/sufia_analytics2/app/views/records/show_fields/_default.html.erb (7.6ms)
Looking for show field partial collections/show_fields/_resource_type
Looking for show field partial records/show_fields/_resource_type
  Rendered /Users/gordonl/d/sufia_analytics2/app/views/records/show_fields/_resource_type.html.erb (1.4ms)
Looking for show field partial collections/show_fields/_tag
Looking for show field partial records/show_fields/_tag
  Rendered /Users/gordonl/d/sufia_analytics2/app/views/records/show_fields/_tag.html.erb (10.8ms)
  Rendered /Users/gordonl/d/sufia_analytics2/app/views/collections/_show_descriptions.html.erb (253.0ms)
  Rendered /Users/gordonl/d/sufia_analytics2/app/views/collections/show.html.erb within layouts/sufia-one-column (263.9ms)
Completed 500 Internal Server Error in 346ms (ActiveRecord: 0.3ms)

NoMethodError - undefined method `tag' for #<Sufia::CollectionPresenter:0x007fd975181a18>:
  /Users/gordonl/d/sufia_analytics2/app/views/records/show_fields/_tag.html.erb:1:in `___sers_gordonl_d_sufia_analytics__app_views_records_show_fields__tag_html_erb__3974985120109821645_70285964390560'
  actionview (4.2.5) lib/action_view/template.rb:145:in `block in render'
  activesupport (4.2.5) lib/active_support/notifications.rb:166:in `instrument'
  actionview (4.2.5) lib/action_view/template.rb:333:in `instrument'
  actionview (4.2.5) lib/action_view/template.rb:143:in `render'
  actionview (4.2.5) lib/action_view/renderer/partial_renderer.rb:339:in `render_partial'
  actionview (4.2.5) lib/action_view/renderer/partial_renderer.rb:310:in `block in render'
  actionview (4.2.5) lib/action_view/renderer/abstract_renderer.rb:39:in `block in instrument'
  activesupport (4.2.5) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.5) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.5) lib/active_support/notifications.rb:164:in `instrument'
  actionview (4.2.5) lib/action_view/renderer/abstract_renderer.rb:39:in `instrument'
  actionview (4.2.5) lib/action_view/renderer/partial_renderer.rb:309:in `render'
  actionview (4.2.5) lib/action_view/renderer/renderer.rb:47:in `render_partial'
  actionview (4.2.5) lib/action_view/helpers/rendering_helper.rb:35:in `render'
  haml (4.0.7) lib/haml/helpers/action_view_mods.rb:12:in `render_with_haml'
  /Users/gordonl/d/sufia_analytics2/app/presenters/sufia/presenter_renderer.rb:26:in `render_show_field_partial'
  /Users/gordonl/d/sufia_analytics2/app/presenters/sufia/presenter_renderer.rb:11:in `value'
  /Users/gordonl/d/sufia_analytics2/app/views/collections/_show_descriptions.html.erb:5:in `block in ___sers_gordonl_d_sufia_analytics__app_views_collections__show_descriptions_html_erb__863073925027109475_70285975097400'
  /Users/gordonl/d/sufia_analytics2/app/presenters/sufia/presenter_renderer.rb:19:in `block in fields'
  /Users/gordonl/d/sufia_analytics2/app/presenters/sufia/presenter_renderer.rb:19:in `fields'
  /Users/gordonl/d/sufia_analytics2/app/helpers/file_set_helper.rb:9:in `present_terms'
  /Users/gordonl/d/sufia_analytics2/app/views/collections/_show_descriptions.html.erb:3:in `___sers_gordonl_d_sufia_analytics__app_views_collections__show_descriptions_html_erb__863073925027109475_70285975097400'
  actionview (4.2.5) lib/action_view/template.rb:145:in `block in render'
  activesupport (4.2.5) lib/active_support/notifications.rb:166:in `instrument'
  actionview (4.2.5) lib/action_view/template.rb:333:in `instrument'
  actionview (4.2.5) lib/action_view/template.rb:143:in `render'
  actionview (4.2.5) lib/action_view/renderer/partial_renderer.rb:339:in `render_partial'
  actionview (4.2.5) lib/action_view/renderer/partial_renderer.rb:310:in `block in render'
  actionview (4.2.5) lib/action_view/renderer/abstract_renderer.rb:39:in `block in instrument'
  activesupport (4.2.5) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.5) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.5) lib/active_support/notifications.rb:164:in `instrument'
  actionview (4.2.5) lib/action_view/renderer/abstract_renderer.rb:39:in `instrument'
  actionview (4.2.5) lib/action_view/renderer/partial_renderer.rb:309:in `render'
  actionview (4.2.5) lib/action_view/renderer/renderer.rb:47:in `render_partial'
  actionview (4.2.5) lib/action_view/helpers/rendering_helper.rb:35:in `render'
  haml (4.0.7) lib/haml/helpers/action_view_mods.rb:12:in `render_with_haml'
  /Users/gordonl/d/sufia_analytics2/app/views/collections/show.html.erb:12:in `___sers_gordonl_d_sufia_analytics__app_views_collections_show_html_erb___1543847156770582193_70286174058160'
  actionview (4.2.5) lib/action_view/template.rb:145:in `block in render'
  activesupport (4.2.5) lib/active_support/notifications.rb:166:in `instrument'
  actionview (4.2.5) lib/action_view/template.rb:333:in `instrument'
  actionview (4.2.5) lib/action_view/template.rb:143:in `render'
  actionview (4.2.5) lib/action_view/renderer/template_renderer.rb:54:in `block (2 levels) in render_template'
  actionview (4.2.5) lib/action_view/renderer/abstract_renderer.rb:39:in `block in instrument'
  activesupport (4.2.5) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.5) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.5) lib/active_support/notifications.rb:164:in `instrument'
  actionview (4.2.5) lib/action_view/renderer/abstract_renderer.rb:39:in `instrument'
  actionview (4.2.5) lib/action_view/renderer/template_renderer.rb:53:in `block in render_template'
  actionview (4.2.5) lib/action_view/renderer/template_renderer.rb:61:in `render_with_layout'
  actionview (4.2.5) lib/action_view/renderer/template_renderer.rb:52:in `render_template'
  actionview (4.2.5) lib/action_view/renderer/template_renderer.rb:14:in `render'
  actionview (4.2.5) lib/action_view/renderer/renderer.rb:42:in `render_template'
  actionview (4.2.5) lib/action_view/renderer/renderer.rb:23:in `render'
  actionview (4.2.5) lib/action_view/rendering.rb:100:in `_render_template'
  actionpack (4.2.5) lib/action_controller/metal/streaming.rb:217:in `_render_template'
  actionview (4.2.5) lib/action_view/rendering.rb:83:in `render_to_body'
  actionpack (4.2.5) lib/action_controller/metal/rendering.rb:32:in `render_to_body'
  actionpack (4.2.5) lib/action_controller/metal/renderers.rb:37:in `render_to_body'
  actionpack (4.2.5) lib/abstract_controller/rendering.rb:25:in `render'
  actionpack (4.2.5) lib/action_controller/metal/rendering.rb:16:in `render'
  actionpack (4.2.5) lib/action_controller/metal/instrumentation.rb:44:in `block (2 levels) in render'
  activesupport (4.2.5) lib/active_support/core_ext/benchmark.rb:12:in `block in ms'
  /Users/gordonl/.rbenv/versions/2.2.3/lib/ruby/2.2.0/benchmark.rb:303:in `realtime'
  activesupport (4.2.5) lib/active_support/core_ext/benchmark.rb:12:in `ms'
  actionpack (4.2.5) lib/action_controller/metal/instrumentation.rb:44:in `block in render'
  actionpack (4.2.5) lib/action_controller/metal/instrumentation.rb:87:in `cleanup_view_runtime'
  activerecord (4.2.5) lib/active_record/railties/controller_runtime.rb:25:in `cleanup_view_runtime'
  actionpack (4.2.5) lib/action_controller/metal/instrumentation.rb:43:in `render'
  actionpack (4.2.5) lib/action_controller/metal/implicit_render.rb:10:in `default_render'
  actionpack (4.2.5) lib/action_controller/metal/implicit_render.rb:5:in `send_action'
  actionpack (4.2.5) lib/abstract_controller/base.rb:198:in `process_action'
  actionpack (4.2.5) lib/action_controller/metal/rendering.rb:10:in `process_action'
  actionpack (4.2.5) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
  activesupport (4.2.5) lib/active_support/callbacks.rb:117:in `call'
  activesupport (4.2.5) lib/active_support/callbacks.rb:555:in `block (2 levels) in compile'
  activesupport (4.2.5) lib/active_support/callbacks.rb:505:in `call'
  activesupport (4.2.5) lib/active_support/callbacks.rb:92:in `__run_callbacks__'
  activesupport (4.2.5) lib/active_support/callbacks.rb:778:in `_run_process_action_callbacks'
  activesupport (4.2.5) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.5) lib/abstract_controller/callbacks.rb:19:in `process_action'
  actionpack (4.2.5) lib/action_controller/metal/rescue.rb:29:in `process_action'
  actionpack (4.2.5) lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
  activesupport (4.2.5) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.5) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.5) lib/active_support/notifications.rb:164:in `instrument'
  actionpack (4.2.5) lib/action_controller/metal/instrumentation.rb:30:in `process_action'
  actionpack (4.2.5) lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
  activerecord (4.2.5) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  actionpack (4.2.5) lib/abstract_controller/base.rb:137:in `process'
  actionview (4.2.5) lib/action_view/rendering.rb:30:in `process'
  actionpack (4.2.5) lib/action_controller/metal.rb:196:in `dispatch'
  actionpack (4.2.5) lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
  actionpack (4.2.5) lib/action_controller/metal.rb:237:in `block in action'
  actionpack (4.2.5) lib/action_dispatch/routing/route_set.rb:76:in `dispatch'
  actionpack (4.2.5) lib/action_dispatch/routing/route_set.rb:45:in `serve'
  actionpack (4.2.5) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.5) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.5) lib/action_dispatch/routing/route_set.rb:817:in `call'
  railties (4.2.5) lib/rails/engine.rb:518:in `call'
  railties (4.2.5) lib/rails/railtie.rb:194:in `method_missing'
  actionpack (4.2.5) lib/action_dispatch/routing/mapper.rb:51:in `serve'
  actionpack (4.2.5) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.5) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.5) lib/action_dispatch/routing/route_set.rb:817:in `call'
  railties (4.2.5) lib/rails/engine.rb:518:in `call'
  railties (4.2.5) lib/rails/railtie.rb:194:in `method_missing'
  actionpack (4.2.5) lib/action_dispatch/routing/mapper.rb:51:in `serve'
  actionpack (4.2.5) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.5) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.5) lib/action_dispatch/routing/route_set.rb:817:in `call'
  warden (1.2.4) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.4) lib/warden/manager.rb:34:in `call'
  rack (1.6.4) lib/rack/etag.rb:24:in `call'
  rack (1.6.4) lib/rack/conditionalget.rb:25:in `call'
  rack (1.6.4) lib/rack/head.rb:13:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/flash.rb:260:in `call'
  rack (1.6.4) lib/rack/session/abstract/id.rb:225:in `context'
  rack (1.6.4) lib/rack/session/abstract/id.rb:220:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/cookies.rb:560:in `call'
  activerecord (4.2.5) lib/active_record/query_cache.rb:36:in `call'
  activerecord (4.2.5) lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
  active-fedora (9.9.0) lib/active_fedora/ldp_cache.rb:26:in `call'
  activerecord (4.2.5) lib/active_record/migration.rb:377:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  activesupport (4.2.5) lib/active_support/callbacks.rb:88:in `__run_callbacks__'
  activesupport (4.2.5) lib/active_support/callbacks.rb:778:in `_run_call_callbacks'
  activesupport (4.2.5) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.5) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/reloader.rb:73:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
  better_errors (2.1.1) lib/better_errors/middleware.rb:84:in `protected_app_call'
  better_errors (2.1.1) lib/better_errors/middleware.rb:79:in `better_errors_call'
  better_errors (2.1.1) lib/better_errors/middleware.rb:57:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  railties (4.2.5) lib/rails/rack/logger.rb:38:in `call_app'
  railties (4.2.5) lib/rails/rack/logger.rb:20:in `block in call'
  activesupport (4.2.5) lib/active_support/tagged_logging.rb:68:in `block in tagged'
  activesupport (4.2.5) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (4.2.5) lib/active_support/tagged_logging.rb:68:in `tagged'
  railties (4.2.5) lib/rails/rack/logger.rb:20:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/request_id.rb:21:in `call'
  rack (1.6.4) lib/rack/methodoverride.rb:22:in `call'
  rack (1.6.4) lib/rack/runtime.rb:18:in `call'
  activesupport (4.2.5) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
  rack (1.6.4) lib/rack/lock.rb:17:in `call'
  actionpack (4.2.5) lib/action_dispatch/middleware/static.rb:116:in `call'
  rack (1.6.4) lib/rack/sendfile.rb:113:in `call'
  railties (4.2.5) lib/rails/engine.rb:518:in `call'
  railties (4.2.5) lib/rails/application.rb:165:in `call'
  rack (1.6.4) lib/rack/lock.rb:17:in `call'
  rack (1.6.4) lib/rack/content_length.rb:15:in `call'
  rack (1.6.4) lib/rack/handler/webrick.rb:88:in `service'
  /Users/gordonl/.rbenv/versions/2.2.3/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
  /Users/gordonl/.rbenv/versions/2.2.3/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
  /Users/gordonl/.rbenv/versions/2.2.3/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'



Started POST "/__better_errors/159b7acaef68484a/variables" for 127.0.0.1 at 2016-02-18 12:42:23 -0500
