### PR TITLE
fix citations view data created crash

### DIFF
--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -21,7 +21,7 @@ module Sufia
     # Date created indexed as a string. This allows users to enter values like: 'Circa 1840-1844'
     # This overrides the default behavior of CurationConcerns which indexes a date
     def date_created
-      self[Solrizer.solr_name("date_created")]
+      fetch(Solrizer.solr_name("date_created"), [])
     end
 
     def create_date


### PR DESCRIPTION
Updates _citations.html.erb L22 to: 
  <meta name="citation_publication_date" content="<%= @presenter.date_created.first unless @presenter.date_created.nil? %>"/>
to prevent crash when no date_created is present.