### PR TITLE
use visibility constants instead of strings

### DIFF
--- a/app/models/concerns/sufia/collection_behavior.rb
+++ b/app/models/concerns/sufia/collection_behavior.rb
@@ -8,7 +8,7 @@ module Sufia
     end
 
     def update_permissions
-      self.visibility = "open"
+      self.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
   end
 end

--- a/lib/sufia/arkivo/actor.rb
+++ b/lib/sufia/arkivo/actor.rb
@@ -65,7 +65,7 @@ module Sufia
         end
 
         def default_visibility
-          'open'
+          Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         end
 
         def attributes


### PR DESCRIPTION
Use [constants](https://github.com/projecthydra/hydra-head/blob/master/hydra-access-controls/app/models/concerns/hydra/access_controls/access_right.rb#L9-L13) from Hydra Access Controls instead of strings