### PR TITLE
Add proxy deposit functionality at FileSet level

### DIFF
--- a/app/models/concerns/sufia/file_set_behavior.rb
+++ b/app/models/concerns/sufia/file_set_behavior.rb
@@ -2,5 +2,6 @@ module Sufia
   module FileSetBehavior
     extend ActiveSupport::Concern
     include Sufia::WithEvents
+    include Sufia::ProxyDeposit
   end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+# It includes the Sufia::FileSetBehavior module and nothing else
+# So this test covers both the FileSetBehavior module and the generated FileSet model
+describe FileSet, type: :model do
+  let(:user) { double(user_key: 'sarah') }
+  let(:transfer_to) { create(:user) }
+  let(:file) { build(:file_set, id: '123abc', user: user) }
+
+  describe "created for someone (proxy)" do
+    it "assigns proxy user" do
+      file.on_behalf_of = transfer_to.user_key
+      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
+      file.save!
+    end
+  end
+end


### PR DESCRIPTION
Fixes the issue of "on_behalf_of" method not found. closes #1551 