### PR TITLE
Update sufia dependencies

### DIFF
--- a/spec/forms/upload_set_form_spec.rb
+++ b/spec/forms/upload_set_form_spec.rb
@@ -44,6 +44,7 @@ describe Sufia::UploadSetForm do
                             :lease_expiration_date,
                             :visibility_after_lease,
                             :visibility,
+                            :ordered_member_ids,
                             :resource_type] }
   end
 

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
   spec.version       = version
   spec.license       = 'Apache2'
 
-  spec.add_dependency 'curation_concerns', '~> 0.6'
-  spec.add_dependency 'hydra-works', '~> 0.6.0' # Because 0.7 breaks the build
+  spec.add_dependency 'curation_concerns', '~> 0.7'
+  spec.add_dependency 'hydra-works', '~> 0.7'
   spec.add_dependency 'hydra-batch-edit', '~> 1.1'
   spec.add_dependency 'browse-everything', '~> 0.4'
   spec.add_dependency 'blacklight-gallery', '~> 0.1'

--- a/tasks/curation_concerns.rake
+++ b/tasks/curation_concerns.rake
@@ -1,8 +1,0 @@
-require 'curation_concerns'
-
-# Pull in jetty-related tasks from CurationConcerns rather than duplicate them
-spec = Gem::Specification.find_by_name 'curation_concerns'
-load "#{spec.gem_dir}/tasks/jetty.rake"
-
-spec = Gem::Specification.find_by_name 'curation_concerns-models'
-load "#{spec.gem_dir}/lib/tasks/curation_concerns-models_tasks.rake"


### PR DESCRIPTION
update sufia.gemspec to point to curation_concerns 0.7 and Hydra-Works 0.7 

Changes proposed in this pull request:
* update CC to latest (0.8)
* update hydra-works to 0.7
* 

@projecthydra/sufia-code-reviewers

