### PR TITLE
add processing method skeleton to FileSet Presenter

### DIFF
--- a/app/presenters/sufia/file_set_presenter.rb
+++ b/app/presenters/sufia/file_set_presenter.rb
@@ -36,6 +36,10 @@ module Sufia
       'http://schema.org/CreativeWork'
     end
 
+    def processing?
+      # TODO: Refactor this away per https://github.com/projecthydra/sufia/pull/1592
+    end
+    
     def stats_path
       Sufia::Engine.routes.url_helpers.stats_file_path(self)
     end

--- a/spec/presenters/sufia/file_set_presenter_spec.rb
+++ b/spec/presenters/sufia/file_set_presenter_spec.rb
@@ -6,6 +6,11 @@ describe Sufia::FileSetPresenter do
   let(:presenter) { described_class.new(solr_document, ability) }
   let(:file) { build(:file_set, id: '123abc', user: user) }
 
+  describe 'processing?' do
+    let(:user) { double(user_key: 'sarah') }
+    it { expect(presenter.processing?).to eq nil }
+  end
+
   describe 'stats_path' do
     let(:user) { double(user_key: 'sarah') }
     it { expect(presenter.stats_path).to eq Sufia::Engine.routes.url_helpers.stats_file_path(id: file) }


### PR DESCRIPTION
Fixes error: 
undefined method `processing?' for #<Sufia::FileSetPresenter:0x007ff9b4532ab8>

Present tense short summary (50 characters or less)
The processing method was added for UploadSet but not for FileSet. I have added a method, with comments as TODO, for now the app will not crash on viewing FileSets 

Error generated on this line: https://github.com/projecthydra/sufia/blob/master/app/views/curation_concerns/base/_show_actions.html.erb#L8

Changes proposed in this pull request:
* Add a skeleton method for processing in FileSetPresenter
* 
* 

@projecthydra/sufia-code-reviewers

