### PR TITLE
remove ordered_member_ids from rendered form

### DIFF
--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -5,7 +5,7 @@ module Sufia::Forms
     def rendered_terms
       terms - [:files, :visibility_during_embargo, :embargo_release_date,
                :visibility_after_embargo, :visibility_during_lease,
-               :lease_expiration_date, :visibility_after_lease, :visibility, :thumbnail_id, :representative_id]
+               :lease_expiration_date, :visibility_after_lease, :visibility, :thumbnail_id, :representative_id, :ordered_member_ids]
     end
   end
 end


### PR DESCRIPTION
Fixes #1593 ; 

Present tense short summary (50 characters or less)
Remove  ordered_members_ids input field from Work Form.

Changes proposed in this pull request:
* Remove ordered_member_ids from rendered terms 
* 
* 

@projecthydra/sufia-code-reviewers

