### PR TITLE
update rights input field selector

### DIFF
--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -7,5 +7,10 @@ module Sufia::Forms
                :visibility_after_embargo, :visibility_during_lease,
                :lease_expiration_date, :visibility_after_lease, :visibility, :thumbnail_id, :representative_id, :ordered_member_ids]
     end
+
+    def self.multiple?(term)
+      return true if term == :rights
+      super
+    end
   end
 end

--- a/spec/form/work_form_spec.rb
+++ b/spec/form/work_form_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe CurationConcerns::GenericWorkForm do
+  let(:work) { stub_model(GenericWork, id: 'abc123') }
+  let(:curation_concern) { create(:work) }
+  let(:ability) { nil }
+  let(:form) { described_class.new(curation_concern, ability) }
+
+  describe '.model_attributes' do
+    let(:params) { ActionController::Parameters.new(
+      title: ['foo'],
+      description: [''],
+      visibility: 'open',
+      admin_set_id: '123',
+      representative_id: '456',
+      thumbnail_id: '789',
+      tag: ['derp'],
+      rights: ['http://creativecommons.org/licenses/by/3.0/us/']) }
+    subject { described_class.model_attributes(params) }
+    it 'permits parameters' do
+      expect(subject['title']).to eq ['foo']
+      expect(subject['description']).to be_empty
+      expect(subject['visibility']).to eq 'open'
+      expect(subject['rights']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
+      expect(subject['tag']).to eq ['derp']
+    end
+  end
+end


### PR DESCRIPTION
Present tense short summary (50 characters or less)
The right property does not get saved when a New Work is created or edited. 

Here is the debugger output before the change
byebug
    7:     # set the @files ivar then remove the files attribute so it isn't set by default.
=>  8:     files && attributes.delete(:files)
    9:     self.raw_attributes = attributes.dup
   10:     # Files must be attached before saving in order to persist their relationship to the work
   11:     assign_pid && interpret_visibility && attach_files && super && assign_representative
   12:   end
(byebug) attributes
{"title"=>["Test Work 333"], "creator"=>[], "contributor"=>[], "description"=>[], "tag"=>[], "publisher"=>[], "date_created"=>[], "subject"=>[], "language"=>[], "identifier"=>[], "based_near"=>[], "related_url"=>[], "visibility_during_embargo"=>"restricted", "embargo_release_date"=>"2016-02-23", "visibility_after_embargo"=>"open", "visibility_during_lease"=>"open", "lease_expiration_date"=>"2016-02-23", "visibility_after_lease"=>"restricted", "visibility"=>"restricted", "resource_type"=>[]}

Here is the debugger output after the change
(byebug) attributes
{"title"=>["Test Work 333"], "creator"=>[], "contributor"=>[], "description"=>[], "tag"=>[], "rights"=>["http://creativecommons.org/licenses/by-nc/3.0/us/"], "publisher"=>[], "date_created"=>[], "subject"=>[], "language"=>[], "identifier"=>[], "based_near"=>[], "related_url"=>[], "visibility_during_embargo"=>"restricted", "embargo_release_date"=>"2016-02-23", "visibility_after_embargo"=>"open", "visibility_during_lease"=>"open", "lease_expiration_date"=>"2016-02-23", "visibility_after_lease"=>"restricted", "visibility"=>"restricted", "resource_type"=>[]}

Changes proposed in this pull request:
* override multiple? in WorkForm, set rights to true
* 
* 

@projecthydra/sufia-code-reviewers