### PR TITLE
Gemspec: cap Curation Concerns below 0.9.0

### DIFF
--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.version       = version
   spec.license       = 'Apache2'
 
-  spec.add_dependency 'curation_concerns', '~> 0.7'
+  spec.add_dependency 'curation_concerns', '< 0.9.0'
   spec.add_dependency 'hydra-works', '~> 0.7'
   spec.add_dependency 'hydra-batch-edit', '~> 1.1'
   spec.add_dependency 'browse-everything', '~> 0.4'


### PR DESCRIPTION
Sufia is still using the `fits_to_desc_mapping` method which was removed in https://github.com/projecthydra-labs/curation_concerns/commit/a7a7c898883af146f234f9382ece502d6a1afca5.
Cap the version of CC to a compatible version until this can be fixed.

With CC 0.9.0, the following error occurs when starting `rails s`: https://gist.github.com/anonymous/1018c66fbaa126c12200

@projecthydra/sufia-code-reviewers