### PR TITLE
Fixes render error in confirm.html view.

### DIFF
--- a/app/controllers/curation_concerns/permissions_controller.rb
+++ b/app/controllers/curation_concerns/permissions_controller.rb
@@ -1,0 +1,24 @@
+class CurationConcerns::PermissionsController < ApplicationController
+  include CurationConcerns::CurationConcernController
+
+  # This controller is only needed because we to overwrite the layout
+  # that CurationConcers sets for it. We should be able to remove this
+  # controller once we have updated CC to allow for the layout to be
+  # configured.
+  layout nil
+
+  self.curation_concern_type = ActiveFedora::Base
+
+  def confirm
+  end
+
+  def copy
+    VisibilityCopyJob.perform_later(curation_concern.id)
+    flash_message = 'Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions.'
+    redirect_to [main_app, curation_concern], notice: flash_message
+  end
+
+  def curation_concern
+    @curation_concern ||= curation_concern_type.find(params[:id], cast: true)
+  end
+end

--- a/app/views/curation_concerns/permissions/confirm.html.erb
+++ b/app/views/curation_concerns/permissions/confirm.html.erb
@@ -3,10 +3,13 @@
     <h4>Apply changes to contents?<h4>
   </div>
   <div class="panel-body">
-      <%=  I18n.t("sufia.upload.change_permissions_message_html") %>
+      <%= I18n.t("sufia.upload.change_permissions_message_html",
+        curation_concern_human_readable_type: curation_concern.human_readable_type,
+        curation_concern: curation_concern,
+        visibility_badge: visibility_badge(curation_concern.visibility)).html_safe %>
   </div>
   <div class="form-actions panel-footer">
-    <%= button_to "Yes please.", Sufia::Engine.routes.url_helpers.copy_curation_concern_permission_path([sufia,curation_concern]), class: 'btn btn-primary' %>
-    <%= link_to "No. I'll update it manually.", curation_concerns_generic_work_path([sufia, curation_concern]), class: 'btn' %>
+    <%= button_to "Yes please.", main_app.copy_curation_concerns_permission_path(curation_concern), class: 'btn btn-primary' %>
+    <%= link_to "No. I'll update it manually.", main_app.curation_concerns_generic_work_path(curation_concern), class: 'btn' %>
   </div>
 </div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -56,7 +56,7 @@ en:
         tab_label: "Network/Server Location"
       processing: "File is being processed; you may edit when processing has completed"
       permissions_message: "Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions."
-      change_permissions_message_html: "<p>You have changed the permissions on this <%= curation_concern.human_readable_type %>, <i><%= curation_concern %></i>, making it visible to <b><%= visibility_badge(curation_concern.visibility) %></b>.</p><p>Would you like change all of the files within the <%= curation_concern.human_readable_type %> to <b><%= visibility_badge(curation_concern.visibility) %></b> as well?</p>"
+      change_permissions_message_html: "<p>You have changed the permissions on this %{curation_concern_human_readable_type}, <i>%{curation_concern}</i>, making it visible to <b>%{visibility_badge}</b>.</p><p>Would you like change all of the files within the %{curation_concern_human_readable_type} to <b>%{visibility_badge}</b> as well?</p>"
       alert:
         fail_html: "There was a problem during upload, none of your files uploaded correctly. Please %{reload_href}.  Use the %{contact_href} to report the error if it persists."
         fail_restart_href_text: "start over"
@@ -239,7 +239,7 @@ en:
         publisher: "The person or group making the file available. Generally this is the institution."
         rights: "Licensing and distribution information governing access to the file. Select from the provided drop-down list. &lt;em&gt;This is a required field&lt;/em&gt;."
       collection:
-        creator_html: 'The person or group responsible for the collection. Usually this is the author of the collected content. Personal names should be entered with the last name first, e.g. "Smith, John." &lt;em&gt;This is a required field&lt;/em&gt;.' 
+        creator_html: 'The person or group responsible for the collection. Usually this is the author of the collected content. Personal names should be entered with the last name first, e.g. "Smith, John." &lt;em&gt;This is a required field&lt;/em&gt;.'
 
     aria_label:
       upload_set:

--- a/spec/views/curation_concerns/permissions/confirm.html.erb_spec
+++ b/spec/views/curation_concerns/permissions/confirm.html.erb_spec
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'curation_concerns/permissions/confirm.html.erb', :no_clean do
+  class MockCurationConcern
+    attr_reader :human_readable_type, :visibility
+    def initialize
+      @human_readable_type = "GenericWork"
+      @visibility = "public"
+    end
+  end
+
+  let!(:curation_concern) { MockCurationConcern.new }
+  before do
+    allow(view).to receive(:curation_concern).and_return(curation_concern)
+  end
+
+  it 'renders the confirmation page' do
+    render
+    page = Capybara::Node::Simple.new(rendered)
+    expect(page).to have_content("Apply changes to contents?")
+  end
+end


### PR DESCRIPTION
Fixes problem that caused this view to crash.

It also replaces ERB from YML file it with the correct syntax `%{token}` and passes the expected values to the `I18n.t()` call.

Fixes issues #1603 and #1606 

Below is how the view now renders
![screen shot 2016-03-02 at 3 24 18 pm](https://cloud.githubusercontent.com/assets/568286/13474189/de30edec-e08a-11e5-8178-8c5cc314e21f.png)

