### PR TITLE
Make explicit the expected style guide, and address outstanding issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,8 +9,9 @@ AllCops:
   Exclude:
     - 'db/**/*'
     - 'script/**/*'
+    - 'spec/internal/**/*'
+    - 'spec/test_app_templates/**/*'
     - 'vendor/**/*'
-    - 'app/models/concerns/sufia/file_set/export.rb'
 
 Lint/ImplicitStringConcatenation:
   Exclude:
@@ -92,6 +93,8 @@ Rails/Date:
 Rails/TimeZone:
   Enabled: false
 
+RSpec/AnyInstance:
+  Enabled: false
 
 RSpec/ExampleWording:
   CustomTransform:
@@ -108,3 +111,5 @@ RSpec/FilePath:
 RSpec/InstanceVariable:
   Enabled: false
 
+RSpec/NotToNot:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require: rubocop-rspec
+inherit_from: .rubocop_todo.yml
 
 AllCops:
   DisplayCopNames: true
@@ -21,33 +22,8 @@ Metrics/LineLength:
 Metrics/AbcSize:
   Enabled: false
 
-Metrics/CyclomaticComplexity:
-  Exclude:
-    - 'lib/sufia/arkivo/metadata_munger.rb'
-    - 'app/services/sufia/file_set_audit_service.rb'
-    - 'app/controllers/concerns/sufia/files_controller_behavior.rb'
-    - 'app/helpers/sufia/sufia_helper_behavior.rb'
-
-Metrics/PerceivedComplexity:
-  Exclude:
-    - 'app/services/sufia/file_set_audit_service.rb'
-    - 'app/controllers/concerns/sufia/files_controller_behavior.rb'
-    - 'app/helpers/sufia/sufia_helper_behavior.rb'
-
 Metrics/MethodLength:
   Enabled: false
-
-Metrics/ClassLength:
-  Exclude:
-    - 'lib/generators/sufia/templates/catalog_controller.rb'
-    - 'lib/generators/sufia/install_generator.rb'
-    - 'app/actors/sufia/file_set/actor.rb'
-
-Metrics/ModuleLength:
-  Exclude:
-    - 'app/controllers/concerns/sufia/users_controller_behavior.rb'
-    - 'app/controllers/concerns/sufia/files_controller_behavior.rb'
-    - 'app/helpers/sufia/sufia_helper_behavior.rb'
 
 Performance/RedundantMerge:
   Enabled: false
@@ -93,34 +69,13 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
-Style/HashSyntax:
-  Exclude:
-    - 'lib/generators/sufia/templates/catalog_controller.rb'
-
 Style/LineEndConcatenation:
   Exclude:
     - 'spec/test_app_templates/lib/generators/**/*'
     - 'lib/generators/**/*'
 
-Style/PredicateName:
-  Exclude:
-    - 'app/helpers/sufia/sufia_helper_behavior.rb'
-    - 'app/controllers/concerns/sufia/controller.rb'
-
-Style/GlobalVars:
-  Exclude:
-    - 'spec/**/*'
-    - 'spec/jobs/event_jobs_spec.rb'
-    - 'lib/generators/sufia/templates/config/redis_config.rb'
-    - 'lib/sufia/redis_event_store.rb'
-
 Style/SingleLineBlockParams:
   Enabled: false
-
-Style/ClassVars:
-  Exclude:
-    - 'lib/sufia/models.rb'
-    - 'lib/sufia.rb'
 
 Style/SignalException:
   Enabled: false
@@ -131,21 +86,12 @@ Style/ZeroLengthPredicate:
 Rails:
   Enabled: true
 
-Rails/Output:
-  Exclude:
-    - 'lib/generators/**/*'
-    - 'app/services/sufia/user_stat_importer.rb'
-
 Rails/Date:
   Enabled: false
 
 Rails/TimeZone:
   Enabled: false
 
-Rails/HasAndBelongsToMany:
-  Exclude:
-    - 'app/models/domain_term.rb'
-    - 'app/models/local_authority.rb'
 
 RSpec/ExampleWording:
   CustomTransform:
@@ -162,14 +108,3 @@ RSpec/FilePath:
 RSpec/InstanceVariable:
   Enabled: false
 
-RSpec/DescribeClass:
-  Exclude:
-    - 'spec/javascripts/jasmine_spec.rb'
-    - 'spec/tasks/rake_spec.rb'
-    - 'spec/jobs/event_jobs_spec.rb'
-    - 'spec/config/sufia_events_spec.rb'
-    - 'spec/features/**/*'
-    - 'spec/views/**/*'
-    - 'spec/routing/**/*'
-    - 'spec/requests/**/*'
-    - 'spec/inputs/**/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,0 +1,76 @@
+Lint/ImplicitStringConcatenation:
+  Exclude:
+    - 'lib/generators/sufia/**/*'
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'lib/sufia/arkivo/metadata_munger.rb'
+    - 'app/services/sufia/file_set_audit_service.rb'
+    - 'app/controllers/concerns/sufia/files_controller_behavior.rb'
+    - 'app/helpers/sufia/sufia_helper_behavior.rb'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/services/sufia/file_set_audit_service.rb'
+    - 'app/controllers/concerns/sufia/files_controller_behavior.rb'
+    - 'app/helpers/sufia/sufia_helper_behavior.rb'
+
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/generators/sufia/templates/catalog_controller.rb'
+    - 'lib/generators/sufia/install_generator.rb'
+    - 'app/actors/sufia/file_set/actor.rb'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'app/controllers/concerns/sufia/users_controller_behavior.rb'
+    - 'app/controllers/concerns/sufia/files_controller_behavior.rb'
+    - 'app/helpers/sufia/sufia_helper_behavior.rb'
+
+Style/HashSyntax:
+  Exclude:
+    - 'lib/generators/sufia/templates/catalog_controller.rb'
+
+Style/LineEndConcatenation:
+  Exclude:
+    - 'spec/test_app_templates/lib/generators/**/*'
+    - 'lib/generators/**/*'
+
+Style/PredicateName:
+  Exclude:
+    - 'app/helpers/sufia/sufia_helper_behavior.rb'
+    - 'app/controllers/concerns/sufia/controller.rb'
+
+Style/GlobalVars:
+  Exclude:
+    - 'spec/**/*'
+    - 'spec/jobs/event_jobs_spec.rb'
+    - 'lib/generators/sufia/templates/config/redis_config.rb'
+    - 'lib/sufia/redis_event_store.rb'
+
+Style/ClassVars:
+  Exclude:
+    - 'lib/sufia/models.rb'
+    - 'lib/sufia.rb'
+
+Rails/Output:
+  Exclude:
+    - 'lib/generators/**/*'
+    - 'app/services/sufia/user_stat_importer.rb'
+
+Rails/HasAndBelongsToMany:
+  Exclude:
+    - 'app/models/domain_term.rb'
+    - 'app/models/local_authority.rb'
+
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/javascripts/jasmine_spec.rb'
+    - 'spec/tasks/rake_spec.rb'
+    - 'spec/jobs/event_jobs_spec.rb'
+    - 'spec/config/sufia_events_spec.rb'
+    - 'spec/features/**/*'
+    - 'spec/views/**/*'
+    - 'spec/routing/**/*'
+    - 'spec/requests/**/*'
+    - 'spec/inputs/**/*'

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -76,7 +76,7 @@ class ProxyDepositRequest < ActiveRecord::Base
   end
 
   def canceled?
-    self.status == 'canceled'
+    status == 'canceled'
   end
 
   def deleted_work?

--- a/app/presenters/sufia/file_set_presenter.rb
+++ b/app/presenters/sufia/file_set_presenter.rb
@@ -39,7 +39,7 @@ module Sufia
     def processing?
       # TODO: Refactor this away per https://github.com/projecthydra/sufia/pull/1592
     end
-    
+
     def stats_path
       Sufia::Engine.routes.url_helpers.stats_file_path(self)
     end

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -43,7 +43,7 @@ describe ProxyDepositRequest, type: :model do
       its(:to_s) { is_expected.to eq 'work not found' }
       its(:deleted_work?) { is_expected.to be true }
     end
-  
+
     describe "and the work transfer is canceled" do
       before do
         subject.cancel!
@@ -53,7 +53,6 @@ describe ProxyDepositRequest, type: :model do
       its(:fulfillment_date) { is_expected.not_to be_nil }
       its(:canceled?) { is_expected.to be true }
     end
-  
   end
 
   context "After rejection" do

--- a/spec/models/system_stats_spec.rb
+++ b/spec/models/system_stats_spec.rb
@@ -55,7 +55,6 @@ describe ::SystemStats, type: :model do
     context "when requested count is too big" do
       let(:depositor_count) { 99 }
       let(:actual_count) { 20 }
-      :w
 
       it "queries for 20 items" do
         expect(stats).to receive(:open).with("#{ActiveFedora.solr.conn.uri}terms?terms.fl=depositor_tesim&terms.sort=count&terms.limit=#{actual_count}&wt=json&omitHeader=true").and_return(StringIO.new('{"terms":{"depositor_tesim":["example.com",4,"user2",3,"archivist1",1]}}'))

--- a/spec/views/my/_list_works.html.erb_spec.rb
+++ b/spec/views/my/_list_works.html.erb_spec.rb
@@ -2,9 +2,14 @@ require 'spec_helper'
 
 describe 'my/_index_partials/_list_works.html.erb' do
   let(:id) { "3197z511f" }
-  let(:work_data) { { "has_model_ssim"=>["GenericWork"],
-                       id: id,
-                       "title_tesim"=>["Work Title"] } }
+  let(:work_data) do
+    {
+      id: id,
+      "has_model_ssim" => ["GenericWork"],
+      "title_tesim" => ["Work Title"]
+    }
+  end
+
   let(:doc) { SolrDocument.new(work_data) }
   let(:collection) { mock_model(Collection) }
   let(:config) { My::WorksController.blacklight_config }


### PR DESCRIPTION
I've tried to adapt the existing rubocop rules to distinguish between the style guide we want and the styles we're (not) enforcing because of legacy code. I've also added new styles rules that match existing practice (in e43b3ee). And, finally, in 826c55a, I've addressed the 9 outstanding style violations. 

@projecthydra/sufia-code-reviewers
