### PR TITLE
Removes hard coded root path on the Cancel button

### DIFF
--- a/app/views/curation_concerns/base/_form.html.erb
+++ b/app/views/curation_concerns/base/_form.html.erb
@@ -15,7 +15,7 @@
 
     <div class="primary-actions">
       <%= f.submit 'Save', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
-      <%= link_to t(:'helpers.action.cancel'), main_app.root_path, class: 'btn btn-link' %>
+      <%= link_to t(:'helpers.action.cancel'), :back, class: 'btn btn-link' %>
     </div>
 
   </div>

--- a/spec/views/curation_concerns/base/_form.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form.html.erb_spec.rb
@@ -1,30 +1,34 @@
 require 'spec_helper'
 
 describe 'curation_concerns/base/_form.html.erb', :no_clean do
+  let(:work) do
+    stub_model(GenericWork, id: '456')
+  end
+  let(:ability) { double }
+
+  let(:form) do
+    CurationConcerns::GenericWorkForm.new(work, ability)
+  end
+
+  before do
+    view.lookup_context.view_paths.push 'app/views/curation_concerns'
+    allow(view).to receive(:curation_concern).and_return(work)
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    assign(:form, form)
+  end
+
+  let(:page) do
+    render
+    Capybara::Node::Simple.new(rendered)
+  end
+
   describe 'when the work has two or more resource types' do
-    let(:work) do
-      stub_model(GenericWork, id: '456')
-    end
-    let(:ability) { double }
-
-    let(:form) do
-      CurationConcerns::GenericWorkForm.new(work, ability)
-    end
-
-    before do
-      view.lookup_context.view_paths.push 'app/views/curation_concerns'
-      allow(view).to receive(:curation_concern).and_return(work)
-      allow(controller).to receive(:current_user).and_return(stub_model(User))
-      assign(:form, form)
-    end
-
-    let(:page) do
-      render
-      Capybara::Node::Simple.new(rendered)
-    end
-
     it "only draws one resource_type multiselect" do
       expect(page).to have_selector("select#generic_work_resource_type", count: 1)
     end
+  end
+
+  it "renders the link for the Cancel button" do
+    expect(page).to have_link("Cancel", "/")
   end
 end


### PR DESCRIPTION
... and uses Rails :back to make sure the user is sent to the previous page (e.g. dashboard or work show) regardless of how they got here.

Fixes #1602 