### PR TITLE
Add test coverage for RedisEventStore and resque approriately

### DIFF
--- a/lib/sufia/redis_event_store.rb
+++ b/lib/sufia/redis_event_store.rb
@@ -1,5 +1,29 @@
 module Sufia
   class RedisEventStore
+    class << self
+      def for(key)
+        new(key)
+      end
+
+      # @return [Fixnum] the id of the event
+      def create(action, timestamp)
+        event_id = Redis.current.incr("events:latest_id")
+        Redis.current.hmset("events:#{event_id}", "action", action, "timestamp", timestamp)
+        event_id
+      rescue Redis::CommandError => e
+        logger.error("unable to create event: #{e}")
+        nil
+      end
+
+      def logger
+        Rails.logger || CurationConcerns::NullLogger.new
+      end
+    end
+
+    def initialize(key)
+      @key = key
+    end
+
     def fetch(size)
       Redis.current.lrange(@key, 0, size).map do |event_id|
         {
@@ -7,32 +31,14 @@ module Sufia
           timestamp: Redis.current.hget("events:#{event_id}", "timestamp")
         }
       end
-    rescue
+    rescue Redis::CommandError
       []
     end
 
     # Adds a value to the end of a list identified by key
     def push(value)
       Redis.current.lpush(@key, value)
-    rescue
-      nil
-    end
-
-    def initialize(key)
-      @key = key
-    end
-
-    def self.for(key)
-      new(key)
-    end
-
-    # @return [Fixnum] the id of the event
-    def self.create(action, timestamp)
-      event_id = Redis.current.incr("events:latest_id")
-      Redis.current.hmset("events:#{event_id}", "action", action, "timestamp", timestamp)
-      event_id
-    rescue => e
-      logger.error("unable to create event: #{e}") if logger
+    rescue Redis::CommandError
       nil
     end
   end

--- a/spec/lib/sufia/redis_event_store_spec.rb
+++ b/spec/lib/sufia/redis_event_store_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Sufia::RedisEventStore do
+  before do
+    Redis.current.keys('events:*').each { |key| Redis.current.del key }
+  end
+
+  describe "::create" do
+    subject { described_class.create("some action", "1234") }
+    context "when it is successful" do
+      it { is_expected.to eq(1) }
+    end
+    context "when the Redis command fails" do
+      before { allow(Redis).to receive(:current).and_raise(Redis::CommandError) }
+      context "without a logger" do
+        before { allow(Rails).to receive(:logger).and_return(false) }
+        it { is_expected.to be_nil }
+      end
+      context "with a logger" do
+        it "logs the error" do
+          expect(Rails.logger).to receive(:error).exactly(:once).with("unable to create event: Redis::CommandError")
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+
+  describe "#fetch" do
+    subject { described_class.new("key").fetch("size") }
+    context "when the Redis command fails" do
+      before { allow(Redis).to receive(:current).and_raise(Redis::CommandError) }
+      it { is_expected.to eq([]) }
+    end
+  end
+
+  describe "#push" do
+    subject { described_class.new("key").push("some value") }
+    context "when the Redis command fails" do
+      before { allow(Redis).to receive(:current).and_raise(Redis::CommandError) }
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1629

`Sufia::RedisEventStore` doesn't have any test coverage, so we're adding some. Let's also resque from the appropriate error and always have some kind of logger.

@projecthydra/sufia-code-reviewers
