### PR TITLE
Hydra-Jetty should be the default service container in 6.x.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -124,6 +124,12 @@ Style/ClassVars:
 Style/SignalException:
   Enabled: false
 
+Style/ZeroLengthPredicate:
+  Exclude:
+    - 'app/controllers/concerns/sufia/files_controller_behavior.rb'
+    - 'sufia-models/app/services/sufia/generic_file_audit_service.rb'
+    - 'sufia-models/app/models/concerns/sufia/file_stat_utils.rb'
+
 Rails:
   Enabled: true
 
@@ -162,3 +168,9 @@ RSpec/DescribeClass:
     - 'spec/views/**/*'
     - 'spec/routing/**/*'
     - 'spec/inputs/**/*'
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/NotToNot:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem "simplecov", require: false
   gem 'byebug' unless ENV['CI']
   gem 'coveralls', require: false
-  gem 'rubocop', '~> 0.36', require: false
+  gem 'rubocop', '~> 0.37.2', require: false
   gem 'rubocop-rspec', require: false
 end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -43,7 +43,7 @@ describe Sufia::Ability, type: :model do
     let(:sender) { FactoryGirl.find_or_create(:jill) }
     let(:user) { FactoryGirl.find_or_create(:archivist) }
     let(:file) do
-      GenericFile.new.tap do|file|
+      GenericFile.new.tap do |file|
         file.apply_depositor_metadata(sender.user_key)
         file.save!
       end

--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activeresource', "~> 4.0" # No longer a dependency of rails 4.0
 
   spec.add_dependency "hydra-head", "< 9.6"
-  spec.add_dependency "active-fedora", "~> 9.4"
+  spec.add_dependency "active-fedora", "~> 9.4", "< 9.8"
   spec.add_dependency "hydra-collections", [">= 5.0.3", "< 6.0"]
   spec.add_dependency 'hydra-derivatives', '~> 1.0'
   spec.add_dependency 'active_fedora-noid', '~> 1.0'


### PR DESCRIPTION
Hydra-Jetty should be the default service container in 6.x. To do that, pin to AF < 9.8.0.

# Alternatives

1. We could allow AF to >= 9.8.0 and make changes to the code to fix the generated solr.yml and review/update the Sufia README.
1. We could switch 6.x to use `fcrepo_wrapper` and `solr_wrapper` by default instead of hydra-jetty.

# Rationale

A reason for not pursuing either of the alternatives is: how much time and energy do those of us not shipping production 6.x-based apps have to update Sufia 6.x now? I also can't get too excited about alternative 2 above, since it seems wrong to change how 6.x developers manage their containers this late in the 6.x lifecycle (read: it's nearing the end of its life as an independently developed component). That is, I doubt Sufia 6.x will be maintained independent of master branch for very long once 7.0 is released and an upgrade/migration path has been tested -- 6.x-stable dev has been considerably lighter than master dev. (see https://github.com/projecthydra/sufia/commits/6.x-stable vs. https://github.com/projecthydra/sufia/commits/master). I don't want to introduce any more surprises to 6.x developers.

Therefore, for now, to enable new and existing Sufia 6.x development to *just work* with the same hydra-jetty assumptions as before, I think we should pin AF to < 9.8.0.

@projecthydra/sufia-code-reviewers
