### PR TITLE
Add Sufia::FormBuilder

### DIFF
--- a/app/builders/sufia/form_builder.rb
+++ b/app/builders/sufia/form_builder.rb
@@ -1,0 +1,16 @@
+module Sufia
+  class FormBuilder < SimpleForm::FormBuilder
+    def input_label(attribute_name, options = {})
+      options = options.dup
+      options[:input_html] = options.except(:as, :boolean_style, :collection, :label_method, :value_method, *ATTRIBUTE_COMPONENTS)
+      options = @defaults.deep_dup.deep_merge(options) if @defaults
+
+      input      = find_input(attribute_name, options)
+      wrapper    = find_wrapper(input.input_type, options)
+      components = (wrapper.components.map(&:namespace) & ATTRIBUTE_COMPONENTS) + [:input]
+      components.map { |component| SimpleForm::Wrappers::Leaf.new(component) }
+
+      input.label.html_safe
+    end
+  end
+end

--- a/app/views/batch_edits/edit.html.erb
+++ b/app/views/batch_edits/edit.html.erb
@@ -18,7 +18,7 @@
         <% @terms.each do |term| %>
           <div class="row">
             <%= simple_form_for @generic_work, url: batch_edits_path, method: :put, remote: true,
-              builder: CurationConcerns::FormBuilder, html: { id: "form_#{term.to_s}", class: "ajax-form"} do |f| %>
+              builder: Sufia::FormBuilder, html: { id: "form_#{term.to_s}", class: "ajax-form"} do |f| %>
               <div class="col-xs-12 col-sm-4">
                 <a class="accordion-toggle grey glyphicon-chevron-right-helper collapsed" data-toggle="collapse" href="#collapse_<%= term %>" id="expand_link_<%=term.to_s%>">
                   <%= f.input_label term %> <span class="chevron"></span>

--- a/app/views/upload_sets/edit.html.erb
+++ b/app/views/upload_sets/edit.html.erb
@@ -10,7 +10,7 @@
   <%= link_to "<i class='glyphicon glyphicon-dashboard'></i> #{t('curation_concerns.bread_crumb.works_list')}".html_safe, main_app.curation_concerns_generic_works_path %>
   once this step is finished. <span class="required"><abbr title="required">*</abbr></span> indicates required fields.
 </p>
-<%= simple_form_for [main_app, @form], html: { multipart: true }, builder: CurationConcerns::FormBuilder do |f| %>
+<%= simple_form_for [main_app, @form], html: { multipart: true }, builder: Sufia::FormBuilder do |f| %>
 
   <%= render 'metadata', f: f %>
 

--- a/spec/views/upload_sets/_metadata.html.erb_spec.rb
+++ b/spec/views/upload_sets/_metadata.html.erb_spec.rb
@@ -10,7 +10,7 @@ describe 'upload_sets/_metadata.html.erb' do
 
   let(:f) do
     allow(upload_set).to receive(:works).and_return([work1, work2])
-    view.simple_form_for(form, url: '/update', builder: CurationConcerns::FormBuilder) do |fs_form|
+    view.simple_form_for(form, url: '/update', builder: Sufia::FormBuilder) do |fs_form|
       return fs_form
     end
   end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Previously the CurationConcerns::FormBuilder was used, but Sufia was the
only consumer of that class.  This moves the class into Sufia so it may
be removed from CurationConcerns.