### PR TITLE
Overwrite curation_concerns view to include fields added in Sufia

### DIFF
--- a/app/presenters/sufia/work_show_presenter.rb
+++ b/app/presenters/sufia/work_show_presenter.rb
@@ -1,7 +1,7 @@
 module Sufia
   class WorkShowPresenter < ::CurationConcerns::WorkShowPresenter
     # delegate fields from Sufia::Works::Metadata to solr_document
-    delegate :based_near, :depositor, :identifier, :resource_type, :tag, :upload_set_id, to: :solr_document
+    delegate :based_near, :related_url, :depositor, :identifier, :resource_type, :tag, :upload_set_id, to: :solr_document
 
     def editor?
       current_ability.can?(:edit, solr_document)

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,0 +1,13 @@
+<%= presenter.attribute_to_html(:description) %>
+<%= presenter.attribute_to_html(:creator, catalog_search_link: true ) %>
+<%= presenter.attribute_to_html(:contributor, label: 'Contributors', catalog_search_link: true) %>
+<%= presenter.attribute_to_html(:subject, catalog_search_link: true) %>
+<%= presenter.attribute_to_html(:publisher) %>
+<%= presenter.attribute_to_html(:language) %>
+<%= presenter.attribute_to_html(:identifier) %>
+<%= presenter.attribute_to_html(:tag) %>
+<%= presenter.attribute_to_html(:rights) %>
+<%= presenter.attribute_to_html(:date_created) %>
+<%= presenter.attribute_to_html(:based_near) %>
+<%= presenter.attribute_to_html(:related_url) %>
+<%= presenter.attribute_to_html(:resource_type) %>


### PR DESCRIPTION
Fixes #1600

Overwrites a curation_concerns view to include fields that are present in Sufia but not in Curation Concerns.

@projecthydra/sufia-code-reviewers