### PR TITLE
Pin to ActiveFedora 9.9

### DIFF
--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord-import', '~> 0.5'
   spec.add_dependency 'posix-spawn'
   spec.add_dependency 'kaminari_route_prefix'
+  spec.add_dependency 'active-fedora', '= 9.9'
 
   spec.add_development_dependency 'engine_cart', '~> 0.8'
   spec.add_development_dependency 'mida', '~> 0.3'


### PR DESCRIPTION
Temporary hack to prevent issue with `valid_options=` in latest version of ActiveFedoraAggregations.

```
ActionController::RoutingError - undefined method `valid_options=' for ActiveFedora::Orders::AggregationBuilder:Class:
```

@projecthydra/sufia-code-reviewers