### PR TITLE
Display owner if work is transferred

### DIFF
--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -24,6 +24,10 @@ module Sufia
       fetch(Solrizer.solr_name("date_created"), [])
     end
 
+    def proxy_depositor
+      fetch(Solrizer.solr_name("proxy_depositor", :symbol), nil)
+    end
+
     def create_date
       date_field('system_create')
     end

--- a/app/views/shared/_attributes.html.erb
+++ b/app/views/shared/_attributes.html.erb
@@ -4,8 +4,18 @@
           <td><%= work.title %></td>
         </tr>
         <tr>
-          <th><span class="attribute-label h4">Depositor:</span></th>
+          <th><span class="attribute-label h4">Owner:</span></th>
           <td><%= link_to_profile work.depositor("no depositor value") %></td>
+        </tr>
+        <tr>
+          <th><span class="attribute-label h4">Depositor:</span></th>
+          <td>
+            <% if work.proxy_depositor  %>
+              <%= link_to_profile work.proxy_depositor %>
+            <% else %>
+              <%= link_to_profile work.depositor("no depositor value") %>
+            <% end %>
+          </td>
         </tr>
         <tr>
           <th><span class="attribute-label h4">Creator:</span></th>

--- a/spec/views/generic_work/_generic_work.html.erb_spec.rb
+++ b/spec/views/generic_work/_generic_work.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe 'generic_works/_generic_work.html.erb', type: :view do
                  description: "a monster work", tags: ["moster", "mash"],
                  has_model_ssim: ['GenericWork'], itemtype: ['CreativeWork'],
                  date_uploaded: Time.zone.now, collection?: false, generic_work?: true,
-                 hydra_model: "GenericWork", title_or_label: "A monster hit"
+                 hydra_model: "GenericWork", title_or_label: "A monster hit", proxy_depositor: "user2"
                 )
     end
 


### PR DESCRIPTION
refs #1646 

When a work is transferred from User A to User B, the depositor is displayed as User B. The proposed fix at DevCon was to display the User A as depositor and User B as Owner and User A as depositor.

![screen shot 2016-03-28 at 11 54 38 am](https://cloud.githubusercontent.com/assets/12487929/14083642/ce7b8c90-f4e4-11e5-9c65-4e69aae84a0f.png)
 

Changes proposed in this pull request:
* If proxy depositor is present on a work, display both owner and depositor
* 
* 

@projecthydra/sufia-code-reviewers