### PR TITLE
FileSetPresenter can handle integer values

### DIFF
--- a/app/presenters/sufia/characterization_behavior.rb
+++ b/app/presenters/sufia/characterization_behavior.rb
@@ -44,9 +44,9 @@ module Sufia
     # @param [Symbol] term found in the characterization_metadata hash
     # @return [Array] of truncated values
     def primary_characterization_values(term)
-      values = Array(characterization_metadata[term])
+      values = values_for(term)
       values.slice!(Sufia.config.fits_message_length, (values.length - Sufia.config.fits_message_length))
-      values.map { |v| v.truncate(250) }
+      truncate_all(values)
     end
 
     # Returns an array of characterization values truncated to 250 characters that are in
@@ -54,12 +54,21 @@ module Sufia
     # @param [Symbol] term found in the characterization_metadata hash
     # @return [Array] of truncated values
     def secondary_characterization_values(term)
-      values = Array(characterization_metadata[term])
-      additional_values = values.slice!(Sufia.config.fits_message_length, (values.length - Sufia.config.fits_message_length))
-      Array(additional_values).map! { |v| v.truncate(250) }
+      values = values_for(term)
+      additional_values = values.slice(Sufia.config.fits_message_length, values.length - Sufia.config.fits_message_length)
+      return [] unless additional_values
+      truncate_all(additional_values)
     end
 
     private
+
+      def values_for(term)
+        Array(characterization_metadata[term])
+      end
+
+      def truncate_all(values)
+        values.map { |v| v.to_s.truncate(250) }
+      end
 
       def build_characterization_metadata
         self.class.characterization_terms.each do |term|

--- a/spec/presenters/sufia/file_set_presenter_spec.rb
+++ b/spec/presenters/sufia/file_set_presenter_spec.rb
@@ -68,6 +68,7 @@ describe Sufia::FileSetPresenter do
 
     describe "characterization values" do
       before { allow(presenter).to receive(:characterization_metadata).and_return(mock_metadata) }
+
       context "with a limited set of short values" do
         let(:mock_metadata) { { term: ["asdf", "qwer"] } }
         describe "#primary_characterization_values" do
@@ -79,6 +80,7 @@ describe Sufia::FileSetPresenter do
           it { is_expected.to be_empty }
         end
       end
+
       context "with a value set exceeding the configured amount" do
         let(:mock_metadata) { { term: ["1", "2", "3", "4", "5", "6", "7", "8"] } }
         describe "#primary_characterization_values" do
@@ -90,6 +92,7 @@ describe Sufia::FileSetPresenter do
           it { is_expected.to contain_exactly("6", "7", "8") }
         end
       end
+
       context "with values exceeding 250 characters" do
         let(:mock_metadata) { { term: [("a" * 251), "2", "3", "4", "5", "6", ("b" * 251)] } }
         describe "#primary_characterization_values" do
@@ -101,6 +104,7 @@ describe Sufia::FileSetPresenter do
           it { is_expected.to contain_exactly("6", (("b" * 247) + "...")) }
         end
       end
+
       context "with a string as a value" do
         let(:mock_metadata) { { term: "string" } }
         describe "#primary_characterization_values" do
@@ -110,6 +114,14 @@ describe Sufia::FileSetPresenter do
         describe "#secondary_characterization_values" do
           subject { presenter.secondary_characterization_values(:term) }
           it { is_expected.to be_empty }
+        end
+      end
+
+      context "with an integer as a value" do
+        let(:mock_metadata) { { term: 1440 } }
+        describe "#primary_characterization_values" do
+          subject { presenter.primary_characterization_values(:term) }
+          it { is_expected.to contain_exactly("1440") }
         end
       end
     end


### PR DESCRIPTION
Previously it was raising an error on integer values such as height and width:

```
     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # ./app/presenters/sufia/characterization_behavior.rb:49:in `truncate'
```