### PR TITLE
Custom button styling should use bootstrap variables

### DIFF
--- a/app/assets/stylesheets/sufia.css.scss
+++ b/app/assets/stylesheets/sufia.css.scss
@@ -8,6 +8,7 @@
  *= require nestable
 */
 
+@import 'sufia/settings';
 @import 'sufia/variables';
 @import "bootstrap-sprockets";
 @import 'bootstrap';
@@ -16,7 +17,7 @@
 
 // Use import here instead of require so we can use the Sass variables defined in Bootstrap and Blacklight
 // TODO: Probably should use import throughout and move all of Sufia's stylesheets into a single named directory.
-@import 'sufia/settings', 'sufia/header', 'sufia/styles', 'sufia/file-listing',
+@import 'sufia/header', 'sufia/styles', 'sufia/file-listing',
         'sufia/collections', 'sufia/batch-edit', 'sufia/dashboard', 'sufia/home-page',
         'sufia/featured', 'sufia/tagcloud', 'sufia/usage-stats', 'sufia/catalog', 'sufia/buttons',
         'sufia/tinymce', 'sufia/proxy-rights', 'sufia/file-show', 'sufia/modal',

--- a/app/assets/stylesheets/sufia/_buttons.scss
+++ b/app/assets/stylesheets/sufia/_buttons.scss
@@ -16,16 +16,14 @@ ul.listing .add, ul.listing .remove {
   text-align: center;
 }
 
-.add, .btn-primary {
-  background-color: $add-background-color;
-  border-color: $add-border-color;
-  color: $add-text-color;
-}
-.add:hover, .add:focus,
 .btn-primary:hover, .btn-primary:focus {
   background-color: $add-background-hover;
   border-color: $add-border-color;
   color: $add-text-hover;
+}
+
+.add {
+  @extend .btn-primary;
 }
 
 #search-form-header {
@@ -35,23 +33,16 @@ ul.listing .add, ul.listing .remove {
   }
 }
 
-span.appliedFilter .remove, .btn-danger {
-  background-color: $remove-background-color;
-  border-color: $remove-border-color;
-  color: $remove-text-color;
-}
-span.appliedFilter .remove:hover, span.appliedFilter .remove:focus,
 .btn-danger:hover, .btn-danger:focus {
   background-color: $remove-background-hover;
   border-color: $remove-border-color;
   color: $remove-text-hover;
 }
 
-.btn-warning {
-  background-color: $neutral-background-color;
-  border-color: $neutral-border-color;
-  color: $neutral-text-color;
+span.appliedFilter .remove {
+  @extend .btn-danger;
 }
+
 .btn-warning:hover, .btn-warning:focus {
   background-color: $neutral-background-hover;
   border-color: $neutral-border-color;

--- a/app/assets/stylesheets/sufia/_buttons.scss
+++ b/app/assets/stylesheets/sufia/_buttons.scss
@@ -58,16 +58,3 @@ span.appliedFilter .remove:hover, span.appliedFilter .remove:focus,
   color: $neutral-text-hover;
 }
 
-.info {
-  background-color: $view-select-background-color;
-  border-color: $view-select-border-color;
-  color: $view-select-text-color;
-}
-.info:hover, .info:focus {
-  background-color: $view-select-background-hover;
-  border-color: $view-select-border-color;
-  color: $view-select-text-hover;
-}
-
-
-

--- a/app/assets/stylesheets/sufia/_variables.scss
+++ b/app/assets/stylesheets/sufia/_variables.scss
@@ -1,2 +1,14 @@
-$headings-font-family: 'Lato', Verdana, Arial, Helvetica, sans-serif;
-$headings-font-weight: 400;
+$btn-primary-color:              $add-text-color !default;
+$btn-primary-bg:                 $add-background-color !default;
+$btn-primary-border:             $add-border-color !default;
+
+$btn-warning-color:              $neutral-text-color !default;
+$btn-warning-bg:                 $neutral-background-color !default;
+$btn-warning-border:             $neutral-border-color !default;
+
+$btn-danger-color:              $remove-text-color !default;
+$btn-danger-bg:                 $remove-background-color !default;
+$btn-danger-border:             $remove-border-color !default;
+
+$headings-font-family: 'Lato', Verdana, Arial, Helvetica, sans-serif !default;
+$headings-font-weight: 400 !default;


### PR DESCRIPTION
I couldn't track down any consumers of the `.info` styling, introduced in 721ef7088100915ef2ec87b1aa08bdd7de2fc07b. Maybe it should have been `.btn-info`, but if no one has noticed in Sufia 6.x, I don't see why we'd introduce custom styling now.