### PR TITLE
Remove custom button hover and focus states

### DIFF
--- a/app/assets/stylesheets/sufia/_buttons.scss
+++ b/app/assets/stylesheets/sufia/_buttons.scss
@@ -16,12 +16,6 @@ ul.listing .add, ul.listing .remove {
   text-align: center;
 }
 
-.btn-primary:hover, .btn-primary:focus {
-  background-color: $add-background-hover;
-  border-color: $add-border-color;
-  color: $add-text-hover;
-}
-
 .add {
   @extend .btn-primary;
 }
@@ -33,19 +27,6 @@ ul.listing .add, ul.listing .remove {
   }
 }
 
-.btn-danger:hover, .btn-danger:focus {
-  background-color: $remove-background-hover;
-  border-color: $remove-border-color;
-  color: $remove-text-hover;
-}
-
 span.appliedFilter .remove {
   @extend .btn-danger;
 }
-
-.btn-warning:hover, .btn-warning:focus {
-  background-color: $neutral-background-hover;
-  border-color: $neutral-border-color;
-  color: $neutral-text-hover;
-}
-


### PR DESCRIPTION
Sufia's custom button effects are nice, but, I'd argue, unnecessary. This doesn't preclude local implementations adopting the current styling, of course.

After, simply using the default bootstrap hover and focus:

![after](https://cloud.githubusercontent.com/assets/111218/14151032/d14daa66-f660-11e5-96b5-d184a1d4fbce.gif)
