### PR TITLE
Do not automatically install PhantomJS

### DIFF
--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -9,7 +9,6 @@
 # end
 #
 # Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
-# Jasmine.configure do |config|
-#   config.prevent_phantom_js_auto_install = true
-# end
-#
+Jasmine.configure do |config|
+  config.prevent_phantom_js_auto_install = true
+end


### PR DESCRIPTION
I'm not sure we need to, and the auto-install process is failing builds here and there. The problem: intermittent outages and rate limiting at BitBucket (where PhantomJS is hosted) cause the download and thus the build to fail.

@projecthydra/sufia-code-reviewers