### PR TITLE
Scope description styles to only when it is in a page header

### DIFF
--- a/app/assets/stylesheets/sufia/_collections.scss
+++ b/app/assets/stylesheets/sufia/_collections.scss
@@ -1,10 +1,12 @@
-.collection_description, .fileset_description {
-  color: #333;
-  font-family: $headings-font-family;
-  font-size: 1.15em;
-  font-weight: 300;
-  line-height: 1.25em;
-  letter-spacing: .10em;
+header {
+  .collection_description, .fileset_description {
+    color: #333;
+    font-family: $headings-font-family;
+    font-size: 1.15em;
+    font-weight: 300;
+    line-height: 1.25em;
+    letter-spacing: .10em;
+  }
 }
 
 .metadata-collections  {


### PR DESCRIPTION
Before:

![screen shot 2016-03-31 at 7 18 02 am](https://cloud.githubusercontent.com/assets/111218/14178743/d74a0b52-f710-11e5-8fc6-0ad8b923fe1d.png)

After:

![screen shot 2016-03-31 at 7 17 50 am](https://cloud.githubusercontent.com/assets/111218/14178745/db94c58a-f710-11e5-8464-fc41360fc58e.png)