### PR TITLE
Use default bootstrap navbar styling instead of custom masthead

### DIFF
--- a/app/assets/stylesheets/sufia/_header.scss
+++ b/app/assets/stylesheets/sufia/_header.scss
@@ -1,49 +1,10 @@
-#masthead {
-  background: $header-bg;
-  min-height: 4em;
-
-  #logo span.glyphicon {
-    color: #FFF;
-    font-size: 4em;
-    margin: .25em 0 0 .25em;
-  }
-
-  .institution_name {
-    font-family: $headings-font-family;
-    font-size: 4em;
-    font-weight: 300;
-    margin: 0 0 0 .25em;
-  }
-
-  .institution_name, .institution_name a:link, .institution_name a:visited {
-    color: #FFF;
-    text-decoration: none;
-  }
-
-  #user_utility_links {
-    margin-top: 1.75em;
-
-    &.open {
-      > a {
-        border-color: #ccc;
-
-        &.dropdown-toggle {
-          background-color: $gray-lighter;
-          border-color: #428bca;
-        }
-      }
-    }
-  }
-
-  #profile_link {
-    margin-left: -1px;
-  }
-}
-
-.login_button {
-  margin: 1.75em 3em 0 0;
-}
-
 #search-form-header {
   margin-top: 6px;
+}
+
+.navbar-static-top {
+  .btn-group {
+    padding-left: 15px;
+    padding-right: 15px;
+  }
 }

--- a/app/assets/stylesheets/sufia/_variables.scss
+++ b/app/assets/stylesheets/sufia/_variables.scss
@@ -17,3 +17,6 @@ $header-bg: $blue-dark !default;
 
 $footer-color: $classic-white !default;
 $footer-bg: $blue-dark !default;
+
+$navbar-inverse-color: $classic-white !default;
+$navbar-inverse-bg: $blue-dark !default;

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,1 +1,4 @@
-<a id="logo" href="<%= sufia.root_path %>"><span class="glyphicon glyphicon-globe"></span></a><a href="<%= sufia.root_path %>" class="institution_name"><%=t('sufia.product_name') %></a>
+<a id="logo" class="navbar-brand" href="<%= sufia.root_path %>">
+  <span class="glyphicon glyphicon-globe"></span>
+  <span class="institution_name"><%=t('sufia.product_name') %></span>
+</a>

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,11 +1,21 @@
-<div id="masthead" class="container-fluid">
-  <div class="row">
-    <div class="col-xs-6 col-sm-7">
+<nav class="navbar navbar-inverse navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <!-- Brand and toggle get grouped for better mobile display -->
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
       <%= render partial: '/logo' %>
-    </div><!-- /.col-xs-5 -->
-    <div class="col-xs-6 col-sm-5 text-right">
-        <%= render partial: '/user_util_links' %>
-    </div><!-- /.col-xs-7 -->
-  </div><!-- /.row -->
-</div> <!-- /masthead -->
+    </div>
+
+    <div class="collapse navbar-collapse" id="top-navbar-collapse">
+      <ul class="nav navbar-nav navbar-right">
+        <li><%= render partial: '/user_util_links' %></li>
+      </ul>
+    </div>
+  </div>
+</nav>
 

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,5 +1,5 @@
 <% if user_signed_in? %>
-    <div class="btn-group" id="user_utility_links">
+    <div class="btn-group navbar-btn" id="user_utility_links">
       <%= render partial: 'users/notify_link' %>
       <%= link_to sufia.dashboard_index_path, class: "btn btn-default", id: "dashboard_link" do %>
         <span class="glyphicon glyphicon-dashboard"></span>
@@ -23,7 +23,9 @@
       </ul>
     </div><!-- /.btn-group -->
 <% else %>
-    <div class="btn-group login_button pull-right">
-    <%= link_to raw('<span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> Login'), main_app.new_user_session_path, class: "btn btn-default btn-group", title: "Login" %>
+    <div class="btn-group navbar-btn login_button">
+    <%= link_to main_app.new_user_session_path, class: "btn btn-default btn-group", title: "Login" do %>
+      <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> Login
+    <% end %>
     </div>
 <% end %>


### PR DESCRIPTION
First steps toward #1583.

![screen shot 2016-03-31 at 2 44 46 pm](https://cloud.githubusercontent.com/assets/111218/14191904/3c30d738-f74f-11e5-8063-7f7e55bcebe4.png)

![screen shot 2016-03-31 at 2 44 41 pm](https://cloud.githubusercontent.com/assets/111218/14191923/5a5bc150-f74f-11e5-94db-4ad8a6c3d762.png)

