### PR TITLE
Remove extraneous legend element

### DIFF
--- a/app/views/curation_concerns/file_sets/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_form.html.erb
@@ -1,6 +1,5 @@
 <%= simple_form_for [main_app, curation_concern], html: { multipart: true } do |f| %>
   <fieldset class="required">
-    <legend>Your File&#8217;s Title</legend>
     <span class="control-label">
       <%= label_tag 'file_set[title][]', 'Title',  class: "string optional" %>
     </span>


### PR DESCRIPTION
Relates to #1649 

Legends are *potentially* useful for accessibility.  They are not *automatically* beneficial.  This one is **detrimental** to accessibility, reiterating the one label of the one input field in the form.  Employing a screenreader does not make that helpful.

Tons more work to do here, but cutting cruft is a start.