### PR TITLE
Pin to curation_concerns 0.12.0.pre1

### DIFF
--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -4,6 +4,3 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
 end
-
-gem 'curation_concerns', github: 'projecthydra-labs/curation_concerns'
-

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.version       = version
   spec.license       = 'Apache2'
 
-  spec.add_dependency 'curation_concerns', '~> 0.11.0.rc1'
+  spec.add_dependency 'curation_concerns', '~> 0.12.0.pre1'
   spec.add_dependency 'active-fedora', '~> 9.10'
   spec.add_dependency 'hydra-works', '~> 0.7'
   spec.add_dependency 'hydra-batch-edit', '~> 1.1'


### PR DESCRIPTION
This enables you to use the master version of Sufia without having to add the master of CC as a dependency in your Gemfile.
@projecthydra/sufia-code-reviewers