### PR TITLE
Import jasmine rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,15 @@ end
 
 Bundler::GemHelper.install_tasks
 
+import "#{Gem.loaded_specs['jasmine'].full_gem_path}/lib/jasmine/tasks/jasmine.rake"
+
+# Set up the test application prior to running jasmine tasks.
+task 'jasmine:require' => :setup_test_server
+task :setup_test_server do
+  require 'engine_cart'
+  EngineCart.load_application!
+end
+
 Dir.glob('tasks/*.rake').each { |r| import r }
 
 task default: :ci

--- a/spec/javascripts/save_work_spec.js
+++ b/spec/javascripts/save_work_spec.js
@@ -1,0 +1,37 @@
+describe("A suite", function() {
+  var callback;
+  var requiredBlankElements = [];
+  var classes;
+
+  beforeEach(function() {
+    requiredMetadataCheckbox = {
+      removeClass: function () {},
+      addClass: function(klass) { classes = klass }
+    };
+    requiredFields = { change: function(cb) { callback = cb; },
+                       filter: function() { return requiredBlankElements; }
+                     };
+    form = { find: function() { return requiredFields; } }
+    element = { closest: function() { return form; },
+                find: function() { return requiredMetadataCheckbox; }
+              };
+  });
+
+  describe("when none of the required fields are blank", function() {
+    it("is complete", function() {
+      requiredBlankElements = [];
+      target = new SaveWorkControl(element);
+      expect(classes).toEqual('complete');
+    });
+  });
+
+  describe("when a required fields is blank", function() {
+    it("is incomplete", function() {
+      requiredBlankElements = [true];
+      target = new SaveWorkControl(element);
+      expect(classes).toEqual('incomplete');
+    });
+  });
+});
+
+


### PR DESCRIPTION
This allows us to directly run `rake jasmine:ci` or `rake jasmine:server`