### PR TITLE
Collapse fields under lease/embargo

### DIFF
--- a/app/assets/javascripts/sufia/save_work.es6
+++ b/app/assets/javascripts/sufia/save_work.es6
@@ -3,3 +3,4 @@
 //= require sufia/save_work/uploaded_files
 //= require sufia/save_work/checklist_item
 //= require sufia/save_work/deposit_agreement
+//= require sufia/save_work/visibility_component

--- a/app/assets/javascripts/sufia/save_work/save_work_control.es6
+++ b/app/assets/javascripts/sufia/save_work/save_work_control.es6
@@ -2,6 +2,7 @@ import { RequiredFields } from './required_fields'
 import { ChecklistItem } from './checklist_item'
 import { UploadedFiles } from './uploaded_files'
 import { DepositAgreement } from './deposit_agreement'
+import { VisibilityComponent } from './visibility_component'
 
 /**
  * Polyfill String.prototype.startsWith()
@@ -50,6 +51,7 @@ export class SaveWorkControl {
 
     this.requiredMetadata = new ChecklistItem(this.element.find('#required-metadata'))
     this.requiredFiles = new ChecklistItem(this.element.find('#required-files'))
+    new VisibilityComponent(this.element.find('.visibility'))
     this.formChanged()
   }
 

--- a/app/assets/javascripts/sufia/save_work/visibility_component.es6
+++ b/app/assets/javascripts/sufia/save_work/visibility_component.es6
@@ -1,0 +1,27 @@
+export class VisibilityComponent {
+  constructor(element) {
+    this.element = element
+    $('.collapse').collapse({ toggle: false })
+    element.find("[type='radio']").on('change', () => { this.showForm() })
+    this.showForm()
+  }
+
+  showForm() {
+    this.collapseAll()
+    this.openSelected()
+  }
+
+  collapseAll() {
+    $('.collapse').collapse('hide');
+  }
+
+  openSelected() {
+    let selected = this.element.find("[type='radio']:checked")
+
+    let target = selected.data('target')
+    if (!target) {
+      return
+    }
+    $(target).collapse('show');
+  }
+}

--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -1,6 +1,9 @@
 module Sufia::Forms
   class WorkForm < CurationConcerns::Forms::WorkForm
     delegate :depositor, :permissions, to: :model
+    # Since visibility is not an attribute (it's a method), we need to explicitly delegate to it.
+    # TODO: this will be resolved by https://github.com/projecthydra-labs/curation_concerns/pull/708
+    delegate :visibility, to: :model
 
     self.terms += [:collection_ids]
 

--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -122,7 +122,7 @@ module Sufia
       if document.registered?
         content_tag :span, t('sufia.institution_name'), class: "label label-info", title: t('sufia.institution_name')
       elsif document.public?
-        content_tag :span, t('sufia.visibility.open'), class: "label label-success", title: t('sufia.visibility.open_title_attr')
+        content_tag :span, t('.visibility.open'), class: "label label-success", title: t('sufia.visibility.open_title_attr')
       else
         content_tag :span, t('sufia.visibility.private'), class: "label label-danger", title: t('sufia.visibility.private_title_attr')
       end

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -12,47 +12,7 @@
         </div>
 
         <div class="list-group-item">
-          <h3>Visibility</h3>
-          <% if f.object.embargo_release_date %>
-            <%= render 'form_permission_under_embargo', f: f %>
-          <% elsif f.object.lease_expiration_date %>
-            <%= render 'form_permission_under_lease', f: f %>
-          <% else %>
-            <div class="form-group visibility">
-              <label class="radio">
-                <input type="radio" id="visibility_open" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if f.object.open_access? %> checked="true"<% end %>/>
-                Open
-              </label>
-              <label class="radio">
-                <input type="radio" id="visibility_registered" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if f.object.authenticated_only_access? %> checked="true"<% end %> />
-                <%=t('curation_concerns.institution.name') %>
-              </label>
-              <label class="radio">
-                <input type="radio" id="visibility_embargo" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>" <% if f.object.open_access_with_embargo_release_date? %> checked="true"<% end %>/>
-                <div class="form-inline">
-                  Embargo
-                  <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
-                  <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
-                  <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
-                </div>
-
-              </label>
-              <label class="radio">
-                <input type="radio" id="visibility_lease" name="<%= f.object_name %>[visibility]" value="lease" <% if f.object.open_access_with_embargo_release_date? %> checked="true"<% end %>/>
-                <div class="form-inline">
-                  Lease
-                  <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
-                  <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
-                  <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
-                </div>
-
-              </label>
-              <label class="radio">
-                <input type="radio" id="visibility_restricted" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE%>" <% if f.object.private_access? %> checked="true"<% end %>/>
-                Private
-              </label>
-            </div>
-          <% end %>
+          <%= render 'form_visibility_component', f: f %>
         </div>
 
         <div class="panel-footer text-center">

--- a/app/views/curation_concerns/base/_form_visibility_component.html.erb
+++ b/app/views/curation_concerns/base/_form_visibility_component.html.erb
@@ -1,0 +1,60 @@
+<h3>Visibility</h3>
+<% if f.object.embargo_release_date %>
+  <%= render 'form_permission_under_embargo', f: f %>
+<% elsif f.object.lease_expiration_date %>
+  <%= render 'form_permission_under_lease', f: f %>
+<% else %>
+  <div class="form-group visibility">
+    <label class="radio">
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
+      <%= t('curation_concerns.visibility.open.label_html') %>
+      <section class="collapse" id="collapsePublic">
+        <p>
+          <strong>Please note</strong>, making something visible to the world (i.e.
+          marking this as <%= t('curation_concerns.visibility.open.label_html') %>) may be
+          viewed as publishing which could impact your ability to:
+        </p>
+        <ul>
+          <li>Patent your work</li>
+          <li>Publish your work in a journal</li>
+        </ul>
+        <p>
+          Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more
+          information about publisher copyright policies.
+        </p>
+      </section>
+    </label>
+    <label class="radio">
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+      <%= t('curation_concerns.visibility.authenticated.label_html', institution: t('curation_concerns.institution.name')) %>
+    </label>
+    <label class="radio">
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
+      <%= t('curation_concerns.visibility.embargo.label_html') %>
+      <div class="collapse" id="collapseEmbargo">
+        <div class="form-inline">
+          <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+          <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
+          <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+        </div>
+      </div>
+    </label>
+    <label class="radio">
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
+      <%= t('curation_concerns.visibility.lease.label_html') %>
+      <div class="collapse" id="collapseLease">
+        <div class="form-inline">
+          <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+          <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
+          <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+        </div>
+      </div>
+
+    </label>
+    <label class="radio">
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+      <%= t('curation_concerns.visibility.private.label_html') %>
+    </label>
+  </div>
+<% end %>
+

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -247,3 +247,16 @@ en:
         description: "Usage information for abstract or summary"
         tag: "Usage information for keyword"
         rights: "Usage information for rights"
+
+  curation_concerns:
+    visibility:
+      open:
+        label_html: Public
+      authenticated:
+        label_html: "%{institution}"
+      embargo:
+        label_html: Embargo
+      lease:
+        label_html: Lease
+      private:
+        label_html: Private

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -33,7 +33,8 @@ feature 'Creating a new Work', :js do
     click_link "Metadata" # switch tab
     fill_in('Title', with: 'My Test Work')
 
-    choose('visibility_open')
+    choose('generic_work_visibility_open')
+    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
     # attach_file('Upload a file', fixture_file_path('files/image.png'))
     check('agreement')
     click_on('Save')

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -59,4 +59,8 @@ describe CurationConcerns::GenericWorkForm do
       end
     end
   end
+  describe "#visibility" do
+    subject { form.visibility }
+    it { is_expected.to eq 'restricted' }
+  end
 end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Hide information about open access until it is selected.

Fixes #1685