### PR TITLE
Cleanup BlacklightOverride

### DIFF
--- a/app/helpers/sufia/blacklight_override.rb
+++ b/app/helpers/sufia/blacklight_override.rb
@@ -1,26 +1,30 @@
 module Sufia
   module BlacklightOverride
-    def render_bookmarks_control?
-      false
-    end
-
-    def url_for_document(doc, _options = {})
-      if doc.is_a?(SolrDocument) && doc.hydra_model == 'Collection'
-        [collections, doc]
-      else
-        super
-      end
-    end
-
+    # TODO: we can remove this override when we can depend on https://github.com/projecthydra-labs/curation_concerns/pull/711
     def render_constraints_query(localized_params = params)
       # So simple don't need a view template, we can just do it here.
-      scope = localized_params.delete(:route_set) || self
       return "".html_safe if localized_params[:q].blank?
 
       render_constraint_element(constraint_query_label(localized_params),
                                 localized_params[:q],
                                 classes: ["query"],
-                                remove: scope.url_for(localized_params.merge(q: nil, action: 'index')))
+                                remove: remove_constraint_url(localized_params))
+    end
+
+    # TODO: we can remove this override when we can depend on https://github.com/projecthydra-labs/curation_concerns/pull/711
+    def remove_constraint_url(localized_params)
+      scope = localized_params.delete(:route_set) || self
+      options = localized_params.merge(q: nil, action: 'index')
+                                .except(*fields_to_exclude_from_constraint_element)
+      options.permit!
+      scope.url_for(options)
+    end
+
+    # This overrides curation_concerns so we aren't removing any fields.
+    # @return [Array<Symbol>] a list of fields to remove on the render_constraint_element
+    # You can override this if you have different fields to remove
+    def fields_to_exclude_from_constraint_element
+      []
     end
   end
 end

--- a/app/views/my/_constraints.html.erb
+++ b/app/views/my/_constraints.html.erb
@@ -6,6 +6,6 @@
               class: "catalog_startOverLink btn btn-sm btn-text", id: "startOverLink" %>
         </div>
         <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
-        <%= render_constraints(params.merge({route_set: sufia})) %>
+        <%= render_constraints(params.merge(route_set: sufia)) %>
       </div>
 <% end %>

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -307,4 +307,11 @@ class CatalogController < ApplicationController
     # mean") suggestion is offered.
     config.spell_max = 5
   end
+
+  # disable the bookmark control from displaying in gallery view
+  # Sufia doesn't show any of the default controls on the list view, so
+  # this method is not called in that context.
+  def render_bookmarks_control?
+    false
+  end
 end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

* Stage methods that we can remove with the next version of CC
* Move render_bookmarks_control? to the controller context.
* Remove implied hash braces