### PR TITLE
Prevents users from submitting a fileset without a title

### DIFF
--- a/app/views/curation_concerns/file_sets/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_form.html.erb
@@ -3,7 +3,7 @@
     <span class="control-label">
       <%= label_tag 'file_set[title][]', 'Title',  class: "string optional" %>
     </span>
-    <%= text_field_tag 'file_set[title][]', curation_concern.title.first, class: 'form-control' %>
+    <%= text_field_tag 'file_set[title][]', curation_concern.title.first, class: 'form-control', required: true %>
   </fieldset>
 
   <div class="row">


### PR DESCRIPTION
Fixes #1737

Prevents user from submitting a fileset without a title.

Trying to submit a fileset without a title now warns the user as shown in this screenshot

![screen shot 2016-04-05 at 12 19 41 pm](https://cloud.githubusercontent.com/assets/568286/14289433/bebfbbb0-fb28-11e5-9240-137fbadde448.png)

@projecthydra/sufia-code-reviewers

