### PR TITLE
My CSS-only interpretation of Bootstrap Affix for save/visibility

### DIFF
--- a/app/assets/stylesheets/sufia/_form-progress.scss
+++ b/app/assets/stylesheets/sufia/_form-progress.scss
@@ -1,3 +1,25 @@
+@media screen and (min-width: 400px) {
+  .affix {
+    position: static;
+    margin-top: 1em;
+  }
+}
+@media screen and (min-width: 768px) {
+  aside.form-progress {
+    margin-right: 0.5em;
+  }
+  .affix {
+    position: fixed;
+  }
+  .tab-content {
+    min-height: 55em;
+  }
+}
+@media screen and (min-width: 960px) {
+  aside.form-progress {
+    margin-right: 1.5em;
+  }
+}
 aside.form-progress {
   ul.requirements {
     list-style-type: none;

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -1,4 +1,4 @@
-    <aside class="form-progress panel panel-default" id="form-progress">
+    <aside class="form-progress panel panel-default affix" id="form-progress">
       <div class="panel-heading">
         <h2>Save Work</h2>
       </div>


### PR DESCRIPTION
Fixes #1719  ; refs #1562 

Present tense short summary (50 characters or less)

CSS-only interpretation of Bootstrap 3's affix.js to keep the save/visibility widget visible when scrolling vertically through the metadata. Has a tendency to cannonball into the footer when the *height* of the browser is short and the *width* hasn't hit the mobile media query.

Changes proposed in this pull request:
*  added affix class to <article>
*  media queries to handle viewport width
*  CSS positioning

@projecthydra/sufia-code-reviewers