### PR TITLE
Resolve CSS issues with permissions form

### DIFF
--- a/app/assets/stylesheets/sufia/_file_sets.scss
+++ b/app/assets/stylesheets/sufia/_file_sets.scss
@@ -49,3 +49,25 @@ h1.visibility span.label {
 table.files td.preview img {
     height: 50px;
 }
+
+/* From curation_concerns */
+#set-access-controls {
+  label { font-weight: normal; }
+  & > .form-group { padding: 0 1.75em; }
+
+  .form-inline {
+    .control-label, label {
+      padding-left: 0;
+      display: inline;
+      &:after {
+        content: ' ';
+      }
+    }
+    .help-block {
+      display: inline;
+      &:before {
+        content: ' ';
+      }
+    }
+  }
+}

--- a/app/views/curation_concerns/file_sets/_permission.html.erb
+++ b/app/views/curation_concerns/file_sets/_permission.html.erb
@@ -1,5 +1,5 @@
   <div id="permissions_display" class="tab-pane">
-    <%= simple_form_for [main_app, file_set], html: { multipart: true, class: 'form-horizontal', id: 'permission' } do |f| %>
+    <%= simple_form_for [main_app, file_set], html: { multipart: true, id: 'permission' } do |f| %>
       <%= hidden_field_tag('redirect_tab', 'permissions') %>
       <%= render "curation_concerns/base/permission_form", f: f %>
       <div id="permissions_submit">
@@ -9,4 +9,3 @@
       </div>
   <% end %>
 </div><!-- /#permissions_display -->
-


### PR DESCRIPTION
Closes #1649 

Form is not horizontal and horizontal class skews layout.

The necessary CSS from Curation Concerns is from here:
https://github.com/projecthydra-labs/curation_concerns/blob/c61d6e4cb9c27b1dfde590540bbed9d9ba192b89/app/assets/stylesheets/curation_concerns/modules/forms.scss#L41

This prevents the overlapping and out-of-bounds radio buttons.

Future TODO: get the radio buttons to vertically center in the larger
more complex rows.