### PR TITLE
Resize thumbnails of related files. Fixes #1787

### DIFF
--- a/app/assets/stylesheets/sufia/_settings.scss
+++ b/app/assets/stylesheets/sufia/_settings.scss
@@ -18,10 +18,13 @@ $icon-background-color-hover: $classic-white !default;
 $icon-border-color-hover: $gray-base !default;
 $icon-font-color-hover: $gray-base !default;
 
+// Collection Icon
+$collection-icon-search-lg: 8em !default;
+
 // File Show Page
 $file-show-term-color: $gray-dark !default;
 $file-listing-link-color: $brand-primary !default;
 $heading-border-color: $gray-light !default;
 
-// Collection Icon
-$collection-icon-search-lg: 8em !default;
+// Work Show Page
+$related-files-thumbnail-width: 150px;

--- a/app/assets/stylesheets/sufia/_sufia.scss
+++ b/app/assets/stylesheets/sufia/_sufia.scss
@@ -5,8 +5,8 @@
         'sufia/browse_everything_overrides', 'sufia/nestable',
         'sufia/collections', 'sufia/batch-edit', 'sufia/dashboard', 'sufia/home-page',
         'sufia/featured', 'sufia/usage-stats', 'sufia/catalog', 'sufia/buttons',
-        'sufia/tinymce', 'sufia/proxy-rights', 'sufia/file-show', 'sufia/modal',
-        'sufia/form-progress';
+        'sufia/tinymce', 'sufia/proxy-rights', 'sufia/file-show', 'sufia/work-show',
+        'sufia/modal', 'sufia/form-progress';
 
 /* This class is to workaround an issue in which Bootstrap requires a div to display a tooltip
  * on a disabled button. Using a span instead of a div would be ideal but unfortunately it does

--- a/app/assets/stylesheets/sufia/_work-show.scss
+++ b/app/assets/stylesheets/sufia/_work-show.scss
@@ -1,0 +1,5 @@
+.related_files {
+  .thumbnail {
+    width: $related-files-thumbnail-width;
+  }
+}


### PR DESCRIPTION
Before:
<img width="563" alt="screen shot 2016-04-07 at 7 34 03 am" src="https://cloud.githubusercontent.com/assets/92044/14351115/25199474-fc93-11e5-9059-26827ca03a71.png">

After:
<img width="668" alt="screen shot 2016-04-07 at 7 48 57 am" src="https://cloud.githubusercontent.com/assets/92044/14351537/85e639a4-fc95-11e5-917c-d865ae571cfb.png">