### PR TITLE
Check the uploaded checkbox even if metadata isn't complete

### DIFF
--- a/app/assets/javascripts/sufia/save_work/save_work_control.es6
+++ b/app/assets/javascripts/sufia/save_work/save_work_control.es6
@@ -56,7 +56,10 @@ export class SaveWorkControl {
   }
 
   formChanged() {
-    let valid = this.validateMetadata() && this.validateFiles() && this.depositAgreement.isAccepted
+    // avoid short circuit evaluation. The checkboxes should be independent.
+    let metadataValid = this.validateMetadata()
+    let filesValid = this.validateFiles()
+    let valid = metadataValid && filesValid && this.depositAgreement.isAccepted
     this.saveButton.prop("disabled", !valid);
   }
 

--- a/app/assets/javascripts/sufia/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/sufia/save_work/uploaded_files.es6
@@ -5,7 +5,7 @@ export class UploadedFiles {
     $('#fileupload').bind('fileuploadcompleted', callback)
   }
 
-  get hasFiles(){
+  get hasFiles() {
     let fileField = this.form.find('input[name="uploaded_files[]"]')
     return fileField.size() > 0
   }


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Previously when you uploaded files it would not show the checkbox
showing you have completed the requirement to upload files unless you
had previously entered metadata.