### PR TITLE
Rubocop-related updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+require: rubocop-rspec
 inherit_from: .rubocop_todo.yml
 
 AllCops:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'lib/sufia/arkivo/metadata_munger.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ gemspec
 group :development, :test do
   gem "simplecov", require: false
   gem 'byebug' unless ENV['CI']
-  gem 'rubocop', '~> 0.38.0', require: false
-  gem 'rubocop-rspec', require: false
   gem 'coveralls', require: false
 end
 

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -60,4 +60,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_girl_rails", '~> 4.4'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'
   spec.add_development_dependency "jasmine", '~> 2.3'
+  spec.add_development_dependency 'rubocop', '~> 0.39'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.4'
 end

--- a/tasks/sufia-dev.rake
+++ b/tasks/sufia-dev.rake
@@ -6,7 +6,6 @@ require 'engine_cart/rake_task'
 require 'rubocop/rake_task'
 require 'active_fedora/rake_support'
 
-
 desc 'Run style checker'
 RuboCop::RakeTask.new(:rubocop) do |task|
   task.requires << 'rubocop-rspec'
@@ -19,10 +18,8 @@ task :spec do
 end
 
 desc 'Spin up hydra-jetty and run specs'
-task ci: ['engine_cart:generate'] do
+task ci: ['rubocop', 'engine_cart:generate'] do
   puts 'running continuous integration'
-
-  Rake::Task['rubocop'].invoke
 
   # No need to maintain minter state on Travis
   reset_statefile! if ENV['TRAVIS'] == 'true'


### PR DESCRIPTION
Changes proposed in this pull request:

1. Restore rubocop-rspec (**yes, this must be in both .yml files -- I verified this**)
1. Pin versions more tightly in gemspec
1. Fail build earlier if there are style issues

@projecthydra/sufia-code-reviewers