### PR TITLE
[DO NOT MERGE] Add option to trigger Single Use link for files

### DIFF
--- a/app/views/curation_concerns/file_sets/_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_actions.html.erb
@@ -1,0 +1,21 @@
+<% if can?(:edit, file_set.id) %>
+  <%= link_to( 'Edit', edit_polymorphic_path([main_app, file_set]),
+    { class: 'btn btn-default', title: "Edit #{file_set}" }) %>
+  <%= link_to( 'Rollback', main_app.versions_curation_concerns_file_set_path(file_set),
+    { class: 'btn btn-default', title: "Rollback to previous version" }) %>
+<% end %>
+<% if can?(:destroy, file_set.id) %>
+  <%= link_to( 'Delete', polymorphic_path([main_app, file_set]),
+    class: 'btn btn-default', method: :delete, title: "Delete #{file_set}",
+    data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"}
+  )%>
+<% end %>
+<% if can?(:read, file_set.id) %>
+  <%= link_to 'Download', main_app.download_path(file_set),
+    class: 'btn btn-default', title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
+<% end %>
+<% if can?(:edit, file_set.id) %>
+    <%= link_to 'Single-Use Link', curation_concerns.generate_show_single_use_link_url(file_set.id),
+    class: 'btn btn-default', title: "Generate a single-use link for this file", target: "_blank" %>
+<% end %>
+

--- a/spec/views/curation_concerns/file_sets/_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/_actions.html.erb_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'curation_concerns/file_sets/_actions.html.erb', type: :view do
+  let(:user) { create(:user) }
+  let(:solr_document) {
+    SolrDocument.new(
+      id: '999',
+      object_profile_ssm: ["{\"id\":\"999\"}"],
+      has_model_ssim: ['FileSet'],
+      human_readable_type_tesim: ['File'],
+      contributor_tesim: ['Frodo'],
+      creator_tesim: ['Bilbo'],
+      rights_tesim: ['http://creativecommons.org/licenses/by/3.0/us/']
+    )
+  }
+  let(:file_set) {
+    stub_model(FileSet, id: '123',
+                        depositor: 'bob',
+                        resource_type: ['Dataset'])
+  }
+  let(:ability) { Ability.new(user) }
+
+  describe 'single-use link' do
+    let(:page) { Capybara::Node::Simple.new(rendered) }
+    before do
+      allow(view).to receive(:file_set).and_return(file_set)
+      allow(controller).to receive(:can?).with(:destroy, file_set.id).and_return(true)
+      allow(controller).to receive(:can?).with(:read, file_set.id).and_return(true)
+    end
+
+    context 'when user can edit the file' do
+      before do
+        allow(controller).to receive(:can?).with(:edit, file_set.id).and_return(true)
+        render
+      end
+      it 'single-use link appears on page' do
+        expect(page).to have_link('Single-Use Link', count: 1)
+      end
+    end
+
+    context 'when user cannot edit the file' do
+      before do
+        allow(controller).to receive(:can?).with(:edit, file_set.id).and_return(false)
+        render
+      end
+      it 'single-user link does not appear on the page' do
+        expect(page).to_not have_content('Single-Use')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1750 

Adds option to allow users with Edit access to a File in Work to generate Single Use links.

This is how the option *to generate* a Single Use Link looks on the screen

![screen shot 2016-04-12 at 2 49 19 pm](https://cloud.githubusercontent.com/assets/568286/14471725/ded2508a-00bd-11e6-8ea5-83bdc62b5ec6.png)

...and the page rendered after *generating* a Single Use Link

![screen shot 2016-04-12 at 2 49 26 pm](https://cloud.githubusercontent.com/assets/568286/14471737/edb31ddc-00bd-11e6-860f-c19f31b7a6a3.png)

...and lastly the page rendered after *clicking* on the Single Use Link.

![screen shot 2016-04-12 at 2 49 37 pm](https://cloud.githubusercontent.com/assets/568286/14471765/080536de-00be-11e6-8bad-4d31d5c8b2c3.png)

@projecthydra/sufia-code-reviewers