### PR TITLE
Accept resource_type in Batch Create

### DIFF
--- a/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
@@ -44,6 +44,7 @@ module Sufia
       def create_update_job
         BatchCreateJob.perform_later(current_user,
                                      params[:title],
+                                     params[:resource_type],
                                      params[:uploaded_files],
                                      attributes_for_actor)
       end

--- a/app/forms/sufia/batch_upload_form.rb
+++ b/app/forms/sufia/batch_upload_form.rb
@@ -3,7 +3,7 @@ module Sufia
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
 
-    self.terms -= [:title]
+    self.terms -= [:title, :resource_type]
 
     # On the batch upload, title is set per-file.
     def primary_terms

--- a/app/jobs/batch_create_job.rb
+++ b/app/jobs/batch_create_job.rb
@@ -8,24 +8,25 @@ class BatchCreateJob < ActiveJob::Base
 
   # This copies metadata from the passed in attribute to all of the works that
   # are members of the given upload set
-  def perform(user, titles, uploaded_files, attributes)
+  def perform(user, titles, resource_types, uploaded_files, attributes)
     @saved = []
     @success = true
 
     titles ||= {}
+    resource_types ||= {}
 
-    create(user, titles, uploaded_files, attributes)
+    create(user, titles, resource_types, uploaded_files, attributes)
     send_user_message(user)
   end
 
   private
 
-    def create(user, titles, uploaded_files, attributes)
+    def create(user, titles, resource_types, uploaded_files, attributes)
       uploaded_files.each do |upload_id|
         title = [titles[upload_id]] if titles[upload_id]
-        work = create_work(user,
-                           attributes.merge(uploaded_files: [upload_id],
-                                            title: title))
+        resource_type = [resource_types[upload_id]] if resource_types[upload_id]
+        attributes = attributes.merge(uploaded_files: [upload_id], title: title, resource_type: resource_type)
+        work = create_work(user, attributes)
         # TODO: stop assuming that files only belong to one work
         next unless work
         saved << work

--- a/app/views/sufia/batch_uploads/_form_files.html.erb
+++ b/app/views/sufia/batch_uploads/_form_files.html.erb
@@ -74,7 +74,19 @@
 </script>
 <!-- The template to display files available for download -->
 <script id="template-download" type="text/x-tmpl">
-{% for (var i=0, file; file=o.files[i]; i++) { %}
+{%
+
+    // I am not happy with this global declaration.
+    // Using "var setAllResourceTypes" or "function setAllResourceTypes()" does not work. Not sure why.
+    // Perhaps this kind of declaration is not a problem due to the way the JavaScript is executed???
+    setAllResourceTypes = function() {
+        var firstResourceType = $(".resource_type_dropdown")[0].value;
+        $(".resource_type_dropdown").each(function(index, element) {
+            element.value = firstResourceType;
+        });
+    };
+
+    for (var i=0, file; file=o.files[i]; i++) { %}
     <tr class="template-download fade">
         <td>
           <div class="row">
@@ -99,6 +111,18 @@
                 <label for="title_{%=file.id%}" class="col-sm-5 control-label">Display label</label>
                 <div class="col-sm-7">
                   <input type="text" class="form-control" name="title[{%=file.id%}]" id="title_{%=file.id%}" value="{%=file.name%}">
+                </div>
+                <label for="resource_type_{%=file.id%}" class="col-sm-5 control-label">Resource Type</label>
+                <div class="col-sm-7">
+                  <select class="form-control resource_type_dropdown" name="resource_type[{%=file.id%}]" id="resource_type_{%=file.id%}" value="{%=file.name%}">
+                    <% Sufia.config.resource_types.each do |type| %>
+                        <option value="<%= type[0] %>"><%= type[1] %></option>
+                    <% end %>
+                  </select>
+                  <!-- TODO: Why is the button drawn for all files? -->
+                  {% if (i == 0) { %}
+                    <button class="btn pull-right resource_type_button" onClick="setAllResourceTypes(); return false;">Set all to this Resource Type</button>
+                  {% } %}
                 </div>
               </div>
             </div>

--- a/spec/controllers/sufia/batch_uploads_controller_spec.rb
+++ b/spec/controllers/sufia/batch_uploads_controller_spec.rb
@@ -19,9 +19,11 @@ describe Sufia::BatchUploadsController do
         expect(BatchCreateJob).to receive(:perform_later)
           .with(user,
                 { '1' => 'foo' },
+                { '1' => 'Article' },
                 ['1'],
                 tag: [], visibility: 'open')
         post :create, title: { '1' => 'foo' },
+                      resource_type: { '1' => 'Article' },
                       uploaded_files: ['1'],
                       generic_work: { tag: [""], visibility: 'open' }
         expect(response).to redirect_to Sufia::Engine.routes.url_helpers.dashboard_works_path

--- a/spec/jobs/batch_create_job_spec.rb
+++ b/spec/jobs/batch_create_job_spec.rb
@@ -20,18 +20,19 @@ describe BatchCreateJob do
     let(:upload1) {  UploadedFile.create(user: user, file: file1) }
     let(:upload2) {  UploadedFile.create(user: user, file: file2) }
     let(:title) { { upload1.id => 'File One', upload2.id => 'File Two' } }
+    let(:resource_types) { { upload1.id => 'Article', upload2.id => 'Image' } }
     let(:metadata) { { tag: [] } }
     let(:uploaded_files) { [upload1.id, upload2.id] }
     let(:errors) { double(full_messages: "It's broke!") }
     let(:work) { double(errors: errors) }
     let(:actor) { double(curation_concern: work) }
 
-    subject { described_class.perform_now(user, title, uploaded_files, metadata) }
+    subject { described_class.perform_now(user, title, resource_types, uploaded_files, metadata) }
 
     it "updates work metadata" do
       expect(CurationConcerns::CurationConcern).to receive(:actor).and_return(actor).twice
-      expect(actor).to receive(:create).with(tag: [], title: ['File One'], uploaded_files: [1]).and_return(true)
-      expect(actor).to receive(:create).with(tag: [], title: ['File Two'], uploaded_files: [2]).and_return(true)
+      expect(actor).to receive(:create).with(tag: [], title: ['File One'], resource_type: ["Article"], uploaded_files: [1]).and_return(true)
+      expect(actor).to receive(:create).with(tag: [], title: ['File Two'], resource_type: ["Image"], uploaded_files: [2]).and_return(true)
       expect(CurationConcerns.config.callback).to receive(:run).with(:after_batch_create_success, user)
       subject
     end


### PR DESCRIPTION
Fixes #1796

Allows user to select a different resource_type for each file when using Batch Create.

![screen shot 2016-04-13 at 5 05 04 pm](https://cloud.githubusercontent.com/assets/568286/14509416/26c99aba-019a-11e6-82cb-a552b0cf381b.png)

@projecthydra/sufia-code-reviewers

I can get the screen to allow the user to select a resource type, and the selected resource type makes it to the controller, but I am having problems getting the value to the `BatchCreateJob.perform_later`. Any ideas?