### PR TITLE
Overwrite CC view to prevent the display of the big blue icon when no…

### DIFF
--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -1,0 +1,1 @@
+<%= t('sufia.generic_works.show.no_preview') %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -163,6 +163,8 @@ en:
         header: Edit Work
       progress:
         header: Save Work
+      show:
+        no_preview: No preview available
     batch_uploads:
       new:
         header: Batch Create New Works


### PR DESCRIPTION
Fixes #1860

Don't display the default big blue icon when there is no thumbnail.

This is how it used to look:
![screen shot 2016-04-15 at 11 27 05 am](https://cloud.githubusercontent.com/assets/568286/14566297/02383530-02fd-11e6-9eb6-324135440e7c.png)

This is how it looks now:
![screen shot 2016-04-15 at 11 26 07 am](https://cloud.githubusercontent.com/assets/568286/14566289/f6268508-02fc-11e6-9d90-1999a8aa5c70.png)