### PR TITLE
Add files button stays enabled even on small screens

### DIFF
--- a/app/jobs/batch_create_job.rb
+++ b/app/jobs/batch_create_job.rb
@@ -1,6 +1,5 @@
 class BatchCreateJob < ActiveJob::Base
   include Hydra::PermissionsQuery
-  include CurationConcerns::Messages
 
   queue_as :batch_create
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -30,7 +30,7 @@
 <div class="row">
   <div class="col-xs-12">
     <h2 class="col-xs-6 col-md-7 col-lg-6"><%= header_title %></h2>
-    <div class="col-xs-6 col-md-5 col-lg-6"><%= render 'search_form' %></div>
+    <div class="col-xs-6 col-md-5 col-lg-6"><%= render 'search_form', presenter: @presenter %></div>
   </div>
 </div>
 

--- a/app/views/curation_concerns/base/_form_files.html.erb
+++ b/app/views/curation_concerns/base/_form_files.html.erb
@@ -3,7 +3,7 @@
         <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"></noscript>
         <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
         <div class="row fileupload-buttonbar">
-            <div class="col-lg-7">
+            <div class="col-xs-7">
                 <!-- The fileinput-button span is used to style the file input field as button -->
                 <span class="btn btn-success fileinput-button">
                     <i class="glyphicon glyphicon-plus"></i>
@@ -18,7 +18,7 @@
                 <span class="fileupload-process"></span>
             </div>
             <!-- The global progress state -->
-            <div class="col-lg-5 fileupload-progress fade">
+            <div class="col-xs-5 fileupload-progress fade">
                 <!-- The global progress bar -->
                 <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
                     <div class="progress-bar progress-bar-success" style="width:0%;"></div>

--- a/app/views/sufia/batch_uploads/_form_files.html.erb
+++ b/app/views/sufia/batch_uploads/_form_files.html.erb
@@ -3,7 +3,7 @@
         <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"></noscript>
         <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
         <div class="row fileupload-buttonbar">
-            <div class="col-lg-7">
+            <div class="col-xs-7">
                 <!-- The fileinput-button span is used to style the file input field as button -->
                 <span class="btn btn-success fileinput-button">
                     <i class="glyphicon glyphicon-plus"></i>
@@ -26,7 +26,7 @@
                 <span class="fileupload-process"></span>
             </div>
             <!-- The global progress state -->
-            <div class="col-lg-5 fileupload-progress fade">
+            <div class="col-xs-5 fileupload-progress fade">
                 <!-- The global progress bar -->
                 <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
                     <div class="progress-bar progress-bar-success" style="width:0%;"></div>

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.version       = Sufia::VERSION
   spec.license       = 'Apache2'
 
-  spec.add_dependency 'curation_concerns', '~> 0.12.0.pre7'
+  spec.add_dependency 'curation_concerns', '~> 0.12.0.pre8'
   spec.add_dependency 'active-fedora', '~> 9.10'
   spec.add_dependency 'hydra-works', '~> 0.7'
   spec.add_dependency 'hydra-batch-edit', '~> 1.1'


### PR DESCRIPTION
If I used `sm` instead of `xs`, then it only punted the problem (i.e., button still disabled at a smaller size).  

Fixes #1873

I hit both templates to minimize interface drift.