### PR TITLE
Fixes layout issues with details view in Collection items.

### DIFF
--- a/app/views/collections/_show_document_list_row.html.erb
+++ b/app/views/collections/_show_document_list_row.html.erb
@@ -31,10 +31,8 @@
 <tr id="detail_<%= id %>"> <!--  document detail"> -->
   <td colspan="6">
     <dl class="expanded-details row">
-      <dt class="col-xs-3 col-lg-2">File Name:</dt>
-      <dd class="col-xs-9 col-lg-4"><%= link_to document.label, curation_concerns_generic_work_path(document) %></dd>
       <dt class="col-xs-3 col-lg-2">Creator:</dt>
-      <dd class="col-xs-9 col-lg-4"><%= document.creator %></dd>
+      <dd class="col-xs-9 col-lg-4"><%= document.creator.to_sentence %></dd>
       <dt class="col-xs-3 col-lg-2">Depositor:</dt>
       <dd class="col-xs-9 col-lg-4"><%= link_to_profile document.depositor %></dd>
       <dt class="col-xs-3 col-lg-2">Edit Access:</dt>


### PR DESCRIPTION
Fixes #1892

Per ticket 1892 removes work title from the display, renders creators correctly, and aligns users/groups in display. 

![screen shot 2016-04-20 at 4 21 14 pm](https://cloud.githubusercontent.com/assets/568286/14689208/5bee9e32-0714-11e6-8dd1-bf2d3d60ccd8.png)

@projecthydra/sufia-code-reviewers