### PR TITLE
Don't default rights

### DIFF
--- a/app/views/curation_concerns/base/_metadata.html.erb
+++ b/app/views/curation_concerns/base/_metadata.html.erb
@@ -1,12 +1,18 @@
 <h2><%= t('.header') %></h2>
-<table class="table table-striped <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
-  <thead>
-    <tr><th>Attribute Name</th><th>Values</th></tr>
-  </thead>
-  <tbody>
-    <%= render 'attribute_rows', presenter: presenter %>
-    <%= presenter.attribute_to_html(:embargo_release_date) %>
-    <%= presenter.attribute_to_html(:lease_expiration_date) %>
-    <%= presenter.attribute_to_html(:rights) %>
-  </tbody>
-</table>
+<% attributes ||= [ :embargo_release_date, :lease_expiration_date, :rights] %>
+<% presentations = attributes.map { |attribute| presenter.attribute_to_html(attribute) }.reject { |x| x.empty? } %>
+<% if presentations.empty? %>
+  <p><%= t('.no_metadata') %></p>
+<% else %>
+  <table class="table table-striped <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
+    <thead>
+      <tr><th><%= t('.attribute_name_label') %></th><th><%= t('.attribute_values_label') %></th></tr>
+    </thead>
+    <tbody>
+      <%= render 'attribute_rows', presenter: presenter %>
+      <% presentations.each do | presentation | %>
+        <%= presentation %>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -1,4 +1,6 @@
+<% opts = RightsService.select_options %>
+<% opts.unshift ['', ''] %>
 <%= f.input :rights, as: :select_with_modal_help,
-    collection: RightsService.select_options,
+    collection: opts,
     input_html: { class: 'form-control', multiple: true } %>
 <%= render "curation_concerns/file_sets/rights_modal" %>

--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -1,6 +1,5 @@
-<% opts = RightsService.select_options %>
-<% opts.unshift ['', ''] %>
 <%= f.input :rights, as: :select_with_modal_help,
-    collection: opts,
+    collection: RightsService.select_options,
+    include_blank: true,
     input_html: { class: 'form-control', multiple: true } %>
 <%= render "curation_concerns/file_sets/rights_modal" %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -267,6 +267,9 @@ en:
         collections: "In collections:"
       metadata:
         header: Metadata
+        no_metadata: "No metadata is defined for this work."
+        attribute_name_label: Attribute Name
+        attribute_values_label: Values
       items:
         header: Items
         empty:  "This %{type} has no files associated with it. You can add one using the \"Attach a File\" button below."


### PR DESCRIPTION
Allow non-selection of rights and collapse metadata display when empty.

Uses translation.

Fixes #1862