### PR TITLE
Switched fixed position from top to bottom for better results…

### DIFF
--- a/app/assets/javascripts/sufia.js
+++ b/app/assets/javascripts/sufia.js
@@ -19,6 +19,7 @@
 //= require jquery.validate
 //= require zeroclipboard
 //= require select2
+//= require fixedsticky
 
 //= require flot/excanvas
 //= require flot/jquery.flot

--- a/app/assets/javascripts/sufia/app.js
+++ b/app/assets/javascripts/sufia/app.js
@@ -1,45 +1,54 @@
 // Once, javascript is written in a modular format, all initialization
 // code should be called from here.
 Sufia = {
-  initialize: function() {
-    this.saveWorkControl();
-    this.popovers();
-    this.permissions();
-    this.notifications();
-    this.transfers();
-  },
+    initialize: function () {
+        this.saveWorkControl();
+        this.saveWorkFixed();
+        this.popovers();
+        this.permissions();
+        this.notifications();
+        this.transfers();
+    },
 
-  saveWorkControl: function() {
-    var sw = require('sufia/save_work/save_work_control');
-    new sw.SaveWorkControl($("#form-progress")).activate();
-  },
+    saveWorkControl: function () {
+        var sw = require('sufia/save_work/save_work_control');
+        new sw.SaveWorkControl($("#form-progress")).activate();
+    },
 
-  // initialize popover helpers
-  popovers: function() {
-    $("a[data-toggle=popover]").popover({ html: true })
-				 .click(function() { return false; });
-  },
+    saveWorkFixed: function () {
+        // Setting test to false to skip native and go right to polyfill
+        FixedSticky.tests.sticky = false;
+        $('#savewidget').fixedsticky();
+    },
 
-  permissions: function() {
-    var perm = require('sufia/permissions/control');
-    new perm.PermissionsControl($("#share"), 'generic_work', 'tmpl-work-grant');
-    new perm.PermissionsControl($("#permission"), 'file_set', 'tmpl-file-set-grant');
-  },
+    // initialize popover helpers
+    popovers: function () {
+        $("a[data-toggle=popover]").popover({html: true})
+            .click(function () {
+                return false;
+            });
+    },
 
-  notifications: function() {
-    var note = require('sufia/notifications');
-    $('[data-update-poll-url]').each(function() {
-      var interval = $(this).data('update-poll-interval');
-      var url = $(this).data('update-poll-url');
-      new note.Notifications(url, interval);
-    });
-  },
+    permissions: function () {
+        var perm = require('sufia/permissions/control');
+        new perm.PermissionsControl($("#share"), 'generic_work', 'tmpl-work-grant');
+        new perm.PermissionsControl($("#permission"), 'file_set', 'tmpl-file-set-grant');
+    },
 
-  transfers: function() {
-    $("#proxy_deposit_request_transfer_to").userSearch();
-  }
+    notifications: function () {
+        var note = require('sufia/notifications');
+        $('[data-update-poll-url]').each(function () {
+            var interval = $(this).data('update-poll-interval');
+            var url = $(this).data('update-poll-url');
+            new note.Notifications(url, interval);
+        });
+    },
+
+    transfers: function () {
+        $("#proxy_deposit_request_transfer_to").userSearch();
+    }
 };
 
-Blacklight.onLoad(function() {
-  Sufia.initialize();
+Blacklight.onLoad(function () {
+    Sufia.initialize();
 });

--- a/app/assets/stylesheets/sufia/_fixedsticky.scss
+++ b/app/assets/stylesheets/sufia/_fixedsticky.scss
@@ -1,0 +1,26 @@
+.fixedsticky {
+  position: -webkit-sticky;
+  position: -moz-sticky;
+  position: -ms-sticky;
+  position: -o-sticky;
+  position: sticky;
+}
+
+/* When position: sticky is supported but native behavior is ignored */
+.fixedsticky-withoutfixedfixed .fixedsticky-off,
+.fixed-supported .fixedsticky-off {
+  position: static;
+}
+
+.fixedsticky-withoutfixedfixed .fixedsticky-on,
+.fixed-supported .fixedsticky-on {
+  position: fixed;
+}
+
+.fixedsticky-dummy {
+  display: none;
+}
+
+.fixedsticky-on + .fixedsticky-dummy {
+  display: block;
+}

--- a/app/assets/stylesheets/sufia/_form-progress.scss
+++ b/app/assets/stylesheets/sufia/_form-progress.scss
@@ -1,3 +1,14 @@
+.fixedsticky {
+  top: 0; /* Required to get consistent results in Safari and Chrome */
+}
+
+.fixedsticky-withoutfixedfixed .fixedsticky-on,
+.fixed-supported .fixedsticky-on {
+  left: $save-viz-widget-left;
+  /* Required so that the widget doesn't pop back to top when public desc long */
+  bottom: $save-viz-widget-bottom;
+}
+
 aside.form-progress {
   ul.requirements {
     list-style-type: none;

--- a/app/assets/stylesheets/sufia/_settings.scss
+++ b/app/assets/stylesheets/sufia/_settings.scss
@@ -28,3 +28,7 @@ $heading-border-color: $gray-light !default;
 
 // Work Show Page
 $related-files-thumbnail-width: 150px;
+
+// Save Visibility Widget
+$save-viz-widget-bottom: 8.57em;
+$save-viz-widget-left: 66.66666667%;

--- a/app/assets/stylesheets/sufia/_sufia.scss
+++ b/app/assets/stylesheets/sufia/_sufia.scss
@@ -6,7 +6,7 @@
         'sufia/collections', 'sufia/batch-edit', 'sufia/dashboard', 'sufia/home-page',
         'sufia/featured', 'sufia/usage-stats', 'sufia/catalog', 'sufia/buttons',
         'sufia/tinymce', 'sufia/proxy-rights', 'sufia/file-show', 'sufia/work-show',
-        'sufia/modal', 'sufia/form-progress';
+        'sufia/modal', 'sufia/form-progress', 'sufia/fixedsticky';
 
 /* This class is to workaround an issue in which Bootstrap requires a div to display a tooltip
  * on a disabled button. Using a span instead of a div would be ideal but unfortunately it does

--- a/app/views/curation_concerns/base/_form.html.erb
+++ b/app/views/curation_concerns/base/_form.html.erb
@@ -1,35 +1,40 @@
-<%= simple_form_for [main_app, @form], html: { multipart: true } do |f| %>
-  <div class="col-xs-12 col-sm-8" role="main">
+<%= simple_form_for [main_app, @form], html: {multipart: true} do |f| %>
+    <div class="row">
+      <div class="col-xs-12 col-sm-8" role="main">
 
-    <!-- Nav tabs -->
-    <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active"><a href="#metadata" aria-controls="metadata" role="tab" data-toggle="tab">Metadata</a></li>
-      <li role="presentation"><a href="#files" aria-controls="files" role="tab" data-toggle="tab">Files</a></li>
-      <li role="presentation"><a href="#relationships" aria-controls="relationships" role="tab" data-toggle="tab">Relationships</a></li>
-      <li role="presentation"><a href="#share" aria-controls="share" role="tab" data-toggle="tab">Share</a></li>
-    </ul>
+        <!-- Nav tabs -->
+        <ul class="nav nav-tabs" role="tablist">
+          <li role="presentation" class="active">
+            <a href="#metadata" aria-controls="metadata" role="tab" data-toggle="tab">Metadata</a></li>
+          <li role="presentation"><a href="#files" aria-controls="files" role="tab" data-toggle="tab">Files</a></li>
+          <li role="presentation">
+            <a href="#relationships" aria-controls="relationships" role="tab" data-toggle="tab">Relationships</a></li>
+          <li role="presentation"><a href="#share" aria-controls="share" role="tab" data-toggle="tab">Share</a></li>
+        </ul>
 
-    <!-- Tab panes -->
-    <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="metadata">
-        <% unless f.object.persisted? %>
-          <p class="switch-upload-type">To create a separate work for each of the files, go to <%= link_to "Batch upload", sufia.new_batch_upload_path %></p>
-        <% end %>
-        <%= render 'form_metadata', f: f %>
+        <!-- Tab panes -->
+        <div class="tab-content">
+          <div role="tabpanel" class="tab-pane active" id="metadata">
+            <% unless f.object.persisted? %>
+                <p class="switch-upload-type">To create a separate work for each of the files, go
+                  to <%= link_to "Batch upload", sufia.new_batch_upload_path %></p>
+            <% end %>
+            <%= render 'form_metadata', f: f %>
+          </div>
+          <div role="tabpanel" class="tab-pane" id="files">
+            <%= render 'form_files', f: f %>
+          </div>
+          <div role="tabpanel" class="tab-pane" id="relationships">
+            <%= render 'form_relationships', f: f %>
+          </div>
+          <div role="tabpanel" class="tab-pane" id="share">
+            <%= render 'form_share', f: f %>
+          </div>
+        </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="files">
-        <%= render 'form_files', f: f %>
-      </div>
-      <div role="tabpanel" class="tab-pane" id="relationships">
-        <%= render 'form_relationships', f: f %>
-      </div>
-      <div role="tabpanel" class="tab-pane" id="share">
-        <%= render 'form_share', f: f %>
+
+      <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
+        <%= render 'form_progress', f: f %>
       </div>
     </div>
-  </div>
-
-  <div class="col-xs-12 col-sm-4" role="complementary">
-    <%= render 'form_progress', f: f %>
-  </div>
 <% end %>

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -1,44 +1,44 @@
-    <aside class="form-progress panel panel-default" id="form-progress">
-      <div class="panel-heading">
-        <h2><%= t("sufia.#{controller_name}.progress.header") %></h2>
-      </div>
-      <div class="list-group">
-        <div class="list-group-item">
-          <h3>Requirements</h3>
-          <ul class="requirements">
-            <li class="incomplete" id="required-metadata">Enter required metadata</li>
-            <li class="incomplete" id="required-files">Add files</li>
-          </ul>
-        </div>
+<aside id="form-progress" class="form-progress panel panel-default">
+  <div class="panel-heading">
+    <h2><%= t("sufia.#{controller_name}.progress.header") %></h2>
+  </div>
+  <div class="list-group">
+    <div class="list-group-item">
+      <h3>Requirements</h3>
+      <ul class="requirements">
+        <li class="incomplete" id="required-metadata">Enter required metadata</li>
+        <li class="incomplete" id="required-files">Add files</li>
+      </ul>
+    </div>
 
+    <div class="list-group-item">
+      <%= render 'form_visibility_component', f: f %>
+    </div>
+    <% unless current_user.can_make_deposits_for.empty? %>
         <div class="list-group-item">
-          <%= render 'form_visibility_component', f: f %>
+          <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
         </div>
-        <% unless current_user.can_make_deposits_for.empty? %>
-          <div class="list-group-item">
-	    <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
-          </div>
-        <% end %>
-        <div class="panel-footer text-center">
-          <% if Sufia::Engine.config.active_deposit_agreement_acceptance %>
-            <label>
-              <%= check_box_tag 'agreement', 1, nil, required: true %>
-              <%= t('sufia.active_consent_to_agreement') %><br>
-              <%= link_to t('sufia.deposit_agreement'),
-                          sufia.static_path('agreement'),
-                          target: '_blank' %>
-            </label>
-          <% else %>
-            <%= t('sufia.passive_consent_to_agreement') %><br>
+    <% end %>
+    <div class="panel-footer text-center">
+      <% if Sufia::Engine.config.active_deposit_agreement_acceptance %>
+          <label>
+            <%= check_box_tag 'agreement', 1, nil, required: true %>
+            <%= t('sufia.active_consent_to_agreement') %><br>
             <%= link_to t('sufia.deposit_agreement'),
                         sufia.static_path('agreement'),
                         target: '_blank' %>
-          <% end %>
-          <br>
-          <%= link_to t(:'helpers.action.cancel'),
-                      sufia.dashboard_index_path,
-                      class: 'btn btn-default' %>
-          <%= f.submit 'Save', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
-        </div>
-      </div>
-    </aside>
+          </label>
+      <% else %>
+          <%= t('sufia.passive_consent_to_agreement') %><br>
+          <%= link_to t('sufia.deposit_agreement'),
+                      sufia.static_path('agreement'),
+                      target: '_blank' %>
+      <% end %>
+      <br>
+      <%= link_to t(:'helpers.action.cancel'),
+                  sufia.dashboard_index_path,
+                  class: 'btn btn-default' %>
+      <%= f.submit 'Save', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+    </div>
+  </div>
+</aside>

--- a/vendor/assets/javascripts/fixedsticky.js
+++ b/vendor/assets/javascripts/fixedsticky.js
@@ -1,0 +1,193 @@
+;(function( win, $ ) {
+
+	function featureTest( property, value, noPrefixes ) {
+		// Thanks Modernizr! https://github.com/phistuck/Modernizr/commit/3fb7217f5f8274e2f11fe6cfeda7cfaf9948a1f5
+		var prop = property + ':',
+			el = document.createElement( 'test' ),
+			mStyle = el.style;
+
+		if( !noPrefixes ) {
+			mStyle.cssText = prop + [ '-webkit-', '-moz-', '-ms-', '-o-', '' ].join( value + ';' + prop ) + value + ';';
+		} else {
+			mStyle.cssText = prop + value;
+		}
+		return mStyle[ property ].indexOf( value ) !== -1;
+	}
+
+	function getPx( unit ) {
+		return parseInt( unit, 10 ) || 0;
+	}
+
+	var uniqueIdCounter = 0;
+
+	var S = {
+		classes: {
+			plugin: 'fixedsticky',
+			active: 'fixedsticky-on',
+			inactive: 'fixedsticky-off',
+			clone: 'fixedsticky-dummy',
+			withoutFixedFixed: 'fixedsticky-withoutfixedfixed'
+		},
+		keys: {
+			offset: 'fixedStickyOffset',
+			position: 'fixedStickyPosition',
+			id: 'fixedStickyId'
+		},
+		tests: {
+			sticky: featureTest( 'position', 'sticky' ),
+			fixed: featureTest( 'position', 'fixed', true )
+		},
+		// Thanks jQuery!
+		getScrollTop: function() {
+			var prop = 'pageYOffset',
+				method = 'scrollTop';
+			return win ? (prop in win) ? win[ prop ] :
+				win.document.documentElement[ method ] :
+				win.document.body[ method ];
+		},
+		bypass: function() {
+			// Check native sticky, check fixed and if fixed-fixed is also included on the page and is supported
+			return ( S.tests.sticky && !S.optOut ) ||
+				!S.tests.fixed ||
+				win.FixedFixed && !$( win.document.documentElement ).hasClass( 'fixed-supported' );
+		},
+		update: function( el ) {
+			if( !el.offsetWidth ) { return; }
+
+			var $el = $( el ),
+				height = $el.outerHeight(),
+				initialOffset = $el.data( S.keys.offset ),
+				scroll = S.getScrollTop(),
+				isAlreadyOn = $el.is( '.' + S.classes.active ),
+				toggle = function( turnOn ) {
+					$el[ turnOn ? 'addClass' : 'removeClass' ]( S.classes.active )
+						[ !turnOn ? 'addClass' : 'removeClass' ]( S.classes.inactive );
+				},
+				viewportHeight = $( window ).height(),
+				position = $el.data( S.keys.position ),
+				skipSettingToFixed,
+				elTop,
+				elBottom,
+				$parent = $el.parent(),
+				parentOffset = $parent.offset().top,
+				parentHeight = $parent.outerHeight();
+
+			if( initialOffset === undefined ) {
+				initialOffset = $el.offset().top;
+				$el.data( S.keys.offset, initialOffset );
+				$el.after( $( '<div>' ).addClass( S.classes.clone ).height( height ) );
+			} else {
+				$el.next( '.' + S.classes.clone ).height( height );
+			}
+
+			if( !position ) {
+				// Some browsers require fixed/absolute to report accurate top/left values.
+				skipSettingToFixed = $el.css( 'top' ) !== 'auto' || $el.css( 'bottom' ) !== 'auto';
+
+				if( !skipSettingToFixed ) {
+					$el.css( 'position', 'fixed' );
+				}
+
+				position = {
+					top: $el.css( 'top' ) !== 'auto',
+					bottom: $el.css( 'bottom' ) !== 'auto'
+				};
+
+				if( !skipSettingToFixed ) {
+					$el.css( 'position', '' );
+				}
+
+				$el.data( S.keys.position, position );
+			}
+
+			function isFixedToTop() {
+				var offsetTop = scroll + elTop;
+
+				// Initial Offset Top
+				return initialOffset < offsetTop &&
+					// Container Bottom
+					offsetTop + height <= parentOffset + parentHeight;
+			}
+
+			function isFixedToBottom() {
+				// Initial Offset Top + Height
+				return initialOffset + ( height || 0 ) > scroll + viewportHeight - elBottom &&
+					// Container Top
+					scroll + viewportHeight - elBottom >= parentOffset + ( height || 0 );
+			}
+
+			elTop = getPx( $el.css( 'top' ) );
+			elBottom = getPx( $el.css( 'bottom' ) );
+
+			if( position.top && isFixedToTop() || position.bottom && isFixedToBottom() ) {
+				if( !isAlreadyOn ) {
+					toggle( true );
+				}
+			} else {
+				if( isAlreadyOn ) {
+					toggle( false );
+				}
+			}
+		},
+		destroy: function( el ) {
+			var $el = $( el );
+			if (S.bypass()) {
+				return $el;
+			}
+
+			return $el.each(function() {
+				var $this = $( this );
+				var id = $this.data( S.keys.id );
+				$( win ).unbind( '.fixedsticky' + id );
+
+				$this
+					.removeData( [ S.keys.offset, S.keys.position, S.keys.id ] )
+					.removeClass( S.classes.active )
+					.removeClass( S.classes.inactive )
+					.next( '.' + S.classes.clone ).remove();
+			});
+		},
+		init: function( el ) {
+			var $el = $( el );
+
+			if( S.bypass() ) {
+				return $el;
+			}
+
+			return $el.each(function() {
+				var _this = this;
+				var id = uniqueIdCounter++;
+				$( this ).data( S.keys.id, id );
+
+				$( win ).bind( 'scroll.fixedsticky' + id, function() {
+					S.update( _this );
+				}).trigger( 'scroll.fixedsticky' + id );
+
+				$( win ).bind( 'resize.fixedsticky' + id , function() {
+					if( $el.is( '.' + S.classes.active ) ) {
+						S.update( _this );
+					}
+				});
+			});
+		}
+	};
+
+	win.FixedSticky = S;
+
+	// Plugin
+	$.fn.fixedsticky = function( method ) {
+		if ( typeof S[ method ] === 'function') {
+			return S[ method ].call( S, this);
+		} else if ( typeof method === 'object' || ! method ) {
+			return S.init.call( S, this );
+		} else {
+			throw new Error( 'Method `' +  method + '` does not exist on jQuery.fixedsticky' );
+		}
+	};
+
+	// Add fallback when fixed-fixed is not available.
+	if( !win.FixedFixed ) {
+		$( win.document.documentElement ).addClass( S.classes.withoutFixedFixed );
+	}
+
+})( window, jQuery );


### PR DESCRIPTION
Fixes #1719  ; refs #1562 


Adds polyfill JS to the sidebar to fix or stick save/visibility widget to the bottom of the browser. Best on desktop. Needs more work with responsiveness of overall design. 

Changes proposed in this pull request:
*  Add JS to apps.js
*  Adds additional JS to handle rendering
*  Makes save/visibility sidebar stick to the bottom of the browser

@projecthydra/sufia-code-reviewers

...and matchched column width for left offset from Bootstrap. Removed extra class and replaced pixel values with em and percent and created variables for the values in settings.scs. TODO address responsive media queriess