### PR TITLE
Deposit agreement for works with files

### DIFF
--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -2,7 +2,14 @@ module Sufia::Forms
   class WorkForm < CurationConcerns::Forms::WorkForm
     delegate :depositor, :on_behalf_of, :permissions, to: :model
 
+    attr_reader :agreement_accepted
+
     self.terms += [:collection_ids]
+
+    def initialize(model, current_ability)
+      @agreement_accepted = !model.new_record?
+      super
+    end
 
     def [](key)
       return [] if key == :collection_ids

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -22,7 +22,7 @@
     <div class="panel-footer text-center">
       <% if Sufia::Engine.config.active_deposit_agreement_acceptance %>
           <label>
-            <%= check_box_tag 'agreement', 1, nil, required: true %>
+            <%= check_box_tag 'agreement', 1, f.object.agreement_accepted, required: true %>
             <%= t('sufia.active_consent_to_agreement') %><br>
             <%= link_to t('sufia.deposit_agreement'),
                         sufia.static_path('agreement'),

--- a/spec/forms/curation_concerns/work_form_spec.rb
+++ b/spec/forms/curation_concerns/work_form_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe CurationConcerns::GenericWorkForm do
-  let(:form) { described_class.new(GenericWork.new, nil) }
+  let(:work) { GenericWork.new }
+  let(:form) { described_class.new(work, nil) }
 
   describe "#primary_terms" do
     subject { form.primary_terms }
@@ -76,5 +77,17 @@ describe CurationConcerns::GenericWorkForm do
   describe "on_behalf_of" do
     subject { form.on_behalf_of }
     it { is_expected.to be nil }
+  end
+
+  describe "#agreement_accepted" do
+    subject { form.agreement_accepted }
+    it { is_expected.to eq false }
+  end
+
+  context "on a work already saved" do
+    before { allow(work).to receive(:new_record?).and_return(false) }
+    it "defaults deposit agreement to true" do
+      expect(form.agreement_accepted).to eq(true)
+    end
   end
 end

--- a/spec/views/curation_concerns/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form_progress.html.erb_spec.rb
@@ -10,7 +10,6 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
   before do
     view.lookup_context.view_paths.push 'app/views/curation_concerns'
     allow(controller).to receive(:current_user).and_return(user)
-    assign(:form, form)
   end
 
   let(:page) do
@@ -21,6 +20,8 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
   end
 
   context "for a new object" do
+    before { assign(:form, form) }
+
     let(:work) { GenericWork.new }
 
     context "with options for proxy" do
@@ -50,6 +51,7 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
       it "shows accept text" do
         expect(page).to have_content 'I have read and agree to the'
         expect(page).to have_link 'Deposit Agreement', href: '/agreement'
+        expect(page).to_not have_selector("#agreement[checked]")
       end
     end
 
@@ -62,6 +64,19 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
         expect(page).to have_content 'By saving this work I agree to the'
         expect(page).to have_link 'Deposit Agreement', href: '/agreement'
       end
+    end
+  end
+
+  context "when the work has been saved before" do
+    before do
+      allow(work).to receive(:new_record?).and_return(false)
+      assign(:form, form)
+    end
+
+    let(:work) { stub_model(GenericWork, id: '456') }
+
+    it "renders the deposit agreement already checked" do
+      expect(page).to have_selector("#agreement[checked]")
     end
   end
 end


### PR DESCRIPTION
Fixes #1870 

Defaults the deposit agreement checkbox to checked when editing a work that has already been saved.

The change in this PR is that the `work_form.rb` now initializes the value of the agreement checkbox to checked/unchecked depending on whether the Work already has already been saved (we assume that on a saved work the user has already accepted the deposit agreement)

~~There is also some temporary code (see the `.es6` files) to highlight where we could update the JavaScript of the page to have a more sophisticated logic and force the user to re-accept the deposit agreement if they add new Files to the Work (but don't bother them if they only edit the metadata of the work)~~ (I'll push the JavaScript enhancements in a separate PR to keep things cleaner)

This is how the Work Edit looks when editing a work that already has Files associated with it.

![screen shot 2016-04-28 at 7 21 30 am](https://cloud.githubusercontent.com/assets/568286/14884448/e1ceab92-0d12-11e6-8a78-d95bce2568f4.png)
