### PR TITLE
Forces users to agree to deposit agreement again only if users add files

### DIFF
--- a/app/assets/javascripts/sufia/save_work/deposit_agreement.es6
+++ b/app/assets/javascripts/sufia/save_work/deposit_agreement.es6
@@ -4,12 +4,23 @@ export class DepositAgreement {
     this.agreementCheckbox = form.find('input#agreement')
     // If true, require the accept checkbox to be checked.
     this.isActiveAgreement = this.agreementCheckbox.size() > 0
-    if (this.isActiveAgreement)
+    if (this.isActiveAgreement) {
       this.setupActiveAgreement(callback)
+    }
+    this.mustAgreeAgain = this.isAccepted
   }
 
   setupActiveAgreement(callback) {
     this.agreementCheckbox.on('change', callback)
+  }
+
+  setNotAccepted() {
+    this.agreementCheckbox.prop("checked", false)
+    this.mustAgreeAgain = false
+  }
+
+  setAccepted() {
+    this.agreementCheckbox.prop("checked", true)
   }
 
   /**

--- a/app/assets/javascripts/sufia/save_work/save_work_control.es6
+++ b/app/assets/javascripts/sufia/save_work/save_work_control.es6
@@ -78,7 +78,8 @@ export class SaveWorkControl {
     // avoid short circuit evaluation. The checkboxes should be independent.
     let metadataValid = this.validateMetadata()
     let filesValid = this.validateFiles()
-    return metadataValid && filesValid && this.depositAgreement.isAccepted
+    let agreementValid = this.validateAgreement(filesValid)
+    return metadataValid && filesValid && agreementValid
   }
 
   // sets the metadata indicator to complete/incomplete
@@ -99,6 +100,15 @@ export class SaveWorkControl {
     }
     this.requiredFiles.uncheck()
     return false
+  }
+
+  validateAgreement(filesValid) {
+    if (filesValid && this.uploads.hasFiles && this.depositAgreement.mustAgreeAgain) {
+      // Force the user to agree again
+      this.depositAgreement.setNotAccepted()
+      return false
+    }
+    return this.depositAgreement.isAccepted
   }
 }
 

--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -2,7 +2,14 @@ module Sufia::Forms
   class WorkForm < CurationConcerns::Forms::WorkForm
     delegate :depositor, :on_behalf_of, :permissions, to: :model
 
+    attr_reader :agreement_accepted
+
     self.terms += [:collection_ids]
+
+    def initialize(model, current_ability)
+      @agreement_accepted = !model.new_record?
+      super
+    end
 
     def [](key)
       return [] if key == :collection_ids

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -22,7 +22,7 @@
     <div class="panel-footer text-center">
       <% if Sufia::Engine.config.active_deposit_agreement_acceptance %>
           <label>
-            <%= check_box_tag 'agreement', 1, nil, required: true %>
+            <%= check_box_tag 'agreement', 1, f.object.agreement_accepted, required: true %>
             <%= t('sufia.active_consent_to_agreement') %><br>
             <%= link_to t('sufia.deposit_agreement'),
                         sufia.static_path('agreement'),

--- a/spec/forms/curation_concerns/work_form_spec.rb
+++ b/spec/forms/curation_concerns/work_form_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe CurationConcerns::GenericWorkForm do
-  let(:form) { described_class.new(GenericWork.new, nil) }
+  let(:work) { GenericWork.new }
+  let(:form) { described_class.new(work, nil) }
 
   describe "#primary_terms" do
     subject { form.primary_terms }
@@ -76,5 +77,17 @@ describe CurationConcerns::GenericWorkForm do
   describe "on_behalf_of" do
     subject { form.on_behalf_of }
     it { is_expected.to be nil }
+  end
+
+  describe "#agreement_accepted" do
+    subject { form.agreement_accepted }
+    it { is_expected.to eq false }
+  end
+
+  context "on a work already saved" do
+    before { allow(work).to receive(:new_record?).and_return(false) }
+    it "defaults deposit agreement to true" do
+      expect(form.agreement_accepted).to eq(true)
+    end
   end
 end

--- a/spec/javascripts/save_work_spec.js
+++ b/spec/javascripts/save_work_spec.js
@@ -49,6 +49,31 @@ describe("SaveWorkControl", function() {
     });
   });
 
+  describe("validateAgreement", function() {
+    var target;
+    beforeEach(function() {
+      var fixture = setFixtures('<form id="edit_generic_work">' +
+        '<aside id="form-progress"><ul><li id="required-metadata"><li id="required-files"></ul>' +
+        '<input type="checkbox" name="agreement" id="agreement" value="1" required="required" checked="checked" />' +
+        '<input type="submit"></aside></form>');
+      target = new control.SaveWorkControl(fixture.find('#form-progress'));
+      target.activate()
+    });
+    it("forces user to agree if new files are added", function() {
+      // Agreement starts as accepted...
+      target.uploads = { hasFiles: false };
+      expect(target.validateAgreement(true)).toEqual(true);
+
+      // ...but toogles to not accepted as soon as the user adds new files...
+      target.uploads = { hasFiles: true };
+      expect(target.validateAgreement(true)).toEqual(false);
+
+      // ...and allows the user to manually agree again
+      target.depositAgreement.setAccepted();
+      expect(target.validateAgreement(true)).toEqual(true);
+    });
+  });
+
   describe("validateFiles", function() {
     var mockCheckbox = {
       check: function() { },

--- a/spec/views/curation_concerns/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form_progress.html.erb_spec.rb
@@ -10,7 +10,6 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
   before do
     view.lookup_context.view_paths.push 'app/views/curation_concerns'
     allow(controller).to receive(:current_user).and_return(user)
-    assign(:form, form)
   end
 
   let(:page) do
@@ -21,6 +20,8 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
   end
 
   context "for a new object" do
+    before { assign(:form, form) }
+
     let(:work) { GenericWork.new }
 
     context "with options for proxy" do
@@ -50,6 +51,7 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
       it "shows accept text" do
         expect(page).to have_content 'I have read and agree to the'
         expect(page).to have_link 'Deposit Agreement', href: '/agreement'
+        expect(page).to_not have_selector("#agreement[checked]")
       end
     end
 
@@ -62,6 +64,19 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
         expect(page).to have_content 'By saving this work I agree to the'
         expect(page).to have_link 'Deposit Agreement', href: '/agreement'
       end
+    end
+  end
+
+  context "when the work has been saved before" do
+    before do
+      allow(work).to receive(:new_record?).and_return(false)
+      assign(:form, form)
+    end
+
+    let(:work) { stub_model(GenericWork, id: '456') }
+
+    it "renders the deposit agreement already checked" do
+      expect(page).to have_selector("#agreement[checked]")
     end
   end
 end


### PR DESCRIPTION
Fixes #1870 (part II)

When a user edits a Work that already has files the Deposit Agreement checkbox is now checked initially (see PR #1934) since users must have agreed when they first submitted the Work. This PR forces the users to agree again when they add a new file to the Work, but not if they only change the Work metadata.

@projecthydra/sufia-code-reviewers

