### PR TITLE
Forces users to agree to deposit agreement again only if users add files

### DIFF
--- a/app/assets/javascripts/sufia/save_work/deposit_agreement.es6
+++ b/app/assets/javascripts/sufia/save_work/deposit_agreement.es6
@@ -4,12 +4,27 @@ export class DepositAgreement {
     this.agreementCheckbox = form.find('input#agreement')
     // If true, require the accept checkbox to be checked.
     this.isActiveAgreement = this.agreementCheckbox.size() > 0
-    if (this.isActiveAgreement)
+    if (this.isActiveAgreement) {
       this.setupActiveAgreement(callback)
+    }
+
+    // Tracks whether the user needs to accept again to the depositor
+    // agreement. Once the user has manually agreed once she does not
+    // need to agree again regardless on how many files are being added.
+    this.mustAgreeAgain = this.isAccepted
   }
 
   setupActiveAgreement(callback) {
     this.agreementCheckbox.on('change', callback)
+  }
+
+  setNotAccepted() {
+    this.agreementCheckbox.prop("checked", false)
+    this.mustAgreeAgain = false
+  }
+
+  setAccepted() {
+    this.agreementCheckbox.prop("checked", true)
   }
 
   /**

--- a/app/assets/javascripts/sufia/save_work/save_work_control.es6
+++ b/app/assets/javascripts/sufia/save_work/save_work_control.es6
@@ -78,7 +78,8 @@ export class SaveWorkControl {
     // avoid short circuit evaluation. The checkboxes should be independent.
     let metadataValid = this.validateMetadata()
     let filesValid = this.validateFiles()
-    return metadataValid && filesValid && this.depositAgreement.isAccepted
+    let agreementValid = this.validateAgreement(filesValid)
+    return metadataValid && filesValid && agreementValid
   }
 
   // sets the metadata indicator to complete/incomplete
@@ -99,6 +100,15 @@ export class SaveWorkControl {
     }
     this.requiredFiles.uncheck()
     return false
+  }
+
+  validateAgreement(filesValid) {
+    if (filesValid && this.uploads.hasNewFiles && this.depositAgreement.mustAgreeAgain) {
+      // Force the user to agree again
+      this.depositAgreement.setNotAccepted()
+      return false
+    }
+    return this.depositAgreement.isAccepted
   }
 }
 

--- a/app/assets/javascripts/sufia/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/sufia/save_work/uploaded_files.es6
@@ -9,4 +9,10 @@ export class UploadedFiles {
     let fileField = this.form.find('input[name="uploaded_files[]"]')
     return fileField.size() > 0
   }
+
+  get hasNewFiles() {
+    // In a future release hasFiles will include files already on the work plus new files,
+    // but hasNewFiles() will include only the files added in this browser window.
+    return this.hasFiles
+  }
 }

--- a/spec/javascripts/save_work_spec.js
+++ b/spec/javascripts/save_work_spec.js
@@ -49,6 +49,31 @@ describe("SaveWorkControl", function() {
     });
   });
 
+  describe("validateAgreement", function() {
+    var target;
+    beforeEach(function() {
+      var fixture = setFixtures('<form id="edit_generic_work">' +
+        '<aside id="form-progress"><ul><li id="required-metadata"><li id="required-files"></ul>' +
+        '<input type="checkbox" name="agreement" id="agreement" value="1" required="required" checked="checked" />' +
+        '<input type="submit"></aside></form>');
+      target = new control.SaveWorkControl(fixture.find('#form-progress'));
+      target.activate()
+    });
+    it("forces user to agree if new files are added", function() {
+      // Agreement starts as accepted...
+      target.uploads = { hasNewFiles: false };
+      expect(target.validateAgreement(true)).toEqual(true);
+
+      // ...and becomes not accepted as soon as the user adds new files...
+      target.uploads = { hasNewFiles: true };
+      expect(target.validateAgreement(true)).toEqual(false);
+
+      // ...but allows the user to manually agree again.
+      target.depositAgreement.setAccepted();
+      expect(target.validateAgreement(true)).toEqual(true);
+    });
+  });
+
   describe("validateFiles", function() {
     var mockCheckbox = {
       check: function() { },


### PR DESCRIPTION
Fixes #1870 (part II)

When a user edits a Work that already has files the Deposit Agreement checkbox is now checked initially (see PR #1934) since users must have agreed when they first submitted the Work. This PR forces the users to agree again when they add a new file to the Work, but not if they only change the Work metadata.