### PR TITLE
Renders a user friendly message after deleting notifications

### DIFF
--- a/app/controllers/mailbox_controller.rb
+++ b/app/controllers/mailbox_controller.rb
@@ -6,8 +6,8 @@ class MailboxController < ApplicationController
   end
 
   def delete_all
-    alert = user_mailbox.delete_all
-    redirect_to sufia.notifications_path, alert: alert
+    user_mailbox.delete_all
+    redirect_to sufia.notifications_path, alert: t('sufia.mailbox.notifications_deleted')
   end
 
   def destroy

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -195,6 +195,7 @@ en:
       subject:  'Subject'
       message:  'Message'
       delete:   'Delete Message'
+      notifications_deleted: "Notifications have been deleted"
     file_set:
       browse_view: "Browse View"
     work:


### PR DESCRIPTION
Fixes #1951 

Displays a user friendly message after deleting all notifications (rather than a JSON representations of the notifications deleted)

![screen shot 2016-05-02 at 3 42 15 pm](https://cloud.githubusercontent.com/assets/568286/14965674/b7d8f51e-107c-11e6-81f0-dcf6b4225c5e.png)

@projecthydra/sufia-code-reviewers

