### PR TITLE
Add ability to upload folders

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -27,6 +27,11 @@ module Sufia
       "https://www.zotero.org/users/#{zotero_user_id}"
     end
 
+    # Only Chrome supports this
+    def browser_supports_directory_upload?
+      user_agent.include? 'Chrome'
+    end
+
     # @param [Hash] options a list of options that blacklight passes from helper_method
     #                       invocation.
     def human_readable_date(options)
@@ -168,6 +173,10 @@ module Sufia
     end
 
     private
+
+      def user_agent
+        request.user_agent || ''
+      end
 
       def search_action_for_dashboard
         case params[:controller]

--- a/app/views/curation_concerns/base/_form_files.html.erb
+++ b/app/views/curation_concerns/base/_form_files.html.erb
@@ -6,12 +6,20 @@
             <div class="col-xs-7">
                 <!-- The fileinput-button span is used to style the file input field as button -->
                 <span class="btn btn-success fileinput-button">
-                    <i class="glyphicon glyphicon-plus"></i>
+                    <span class="glyphicon glyphicon-plus"></span>
                     <span>Add files...</span>
                     <input type="file" name="files[]" multiple>
                 </span>
+                <% if browser_supports_directory_upload? %>
+                <!-- The fileinput-button span is used to style the file input field as button -->
+                <span class="btn btn-success fileinput-button">
+                    <span class="glyphicon glyphicon-plus"></span>
+                    <span>Add folder...</span>
+                    <input type="file" name="files[]" multiple directory webkitdirectory>
+                </span>
+                <% end %>
                 <button type="reset" class="btn btn-warning cancel hidden">
-                    <i class="glyphicon glyphicon-ban-circle"></i>
+                    <span class="glyphicon glyphicon-ban-circle"></span>
                     <span>Cancel upload</span>
                 </button>
                 <!-- The global file processing state -->

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -19,9 +19,10 @@ feature 'Creating a new Work', :js do
     end
 
     it 'creates the work' do
-      skip "This was failing intermitently"
+      skip "This was failing intermittently"
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
       # Capybara/poltergeist don't dependably upload files, so we'll stub out the results of the uploader:
       page.execute_script(%{$("#new_generic_work").append('<input name="uploaded_files[]" value="#{uploaded_file1.id}" type="hidden">').append('<input name="uploaded_files[]" value="#{uploaded_file2.id}" type="hidden">');})
       # attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/image.jp2", visible: false)
@@ -52,7 +53,7 @@ feature 'Creating a new Work', :js do
     end
 
     it "allows on-behalf-of deposit" do
-      skip "This was failing intermitently"
+      skip "This was failing intermittently"
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
 

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -160,6 +160,18 @@ describe SufiaHelper, type: :helper do
     end
   end
 
+  describe '#browser_supports_directory_upload?' do
+    subject { helper.browser_supports_directory_upload? }
+    context 'with Chrome' do
+      before { controller.request.env['HTTP_USER_AGENT'] = 'Chrome' }
+      it { is_expected.to be true }
+    end
+    context 'with a non-chrome browser' do
+      before { controller.request.env['HTTP_USER_AGENT'] = 'Firefox' }
+      it { is_expected.to be false }
+    end
+  end
+
   describe '#zotero_label' do
     subject { helper }
 

--- a/spec/views/curation_concerns/base/_form.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form.html.erb_spec.rb
@@ -50,6 +50,21 @@ describe 'curation_concerns/base/_form.html.erb' do
         expect(page).to have_selector('button#browse-btn')
       end
     end
+
+    describe 'uploading a folder' do
+      context 'with Chrome' do
+        before { allow(view).to receive(:browser_supports_directory_upload?) { true } }
+        it 'renders the add folder button' do
+          expect(page).to have_content('Add folder...')
+        end
+      end
+      context 'with a non-Chrome browser' do
+        before { allow(view).to receive(:browser_supports_directory_upload?) { false } }
+        it 'does not render the add folder button' do
+          expect(page).not_to have_content('Add folder...')
+        end
+      end
+    end
   end
 
   context "for a persisted object" do


### PR DESCRIPTION
Only works in Google Chrome, so don't show the button in other browsers.

This was supported in Sufia 1-6, so we should support it in Sufia 7 as well.