### PR TITLE
Bring consistency to the Dashboard

### DIFF
--- a/app/helpers/sufia/dashboard_helper_behavior.rb
+++ b/app/helpers/sufia/dashboard_helper_behavior.rb
@@ -40,6 +40,10 @@ module Sufia
       params[:controller].match(/^my\/works/)
     end
 
+    def number_of_works(user = current_user)
+      ::GenericWork.where(Solrizer.solr_name('depositor', :symbol) => user.user_key).count
+    end
+
     def number_of_files(user = current_user)
       ::FileSet.where(Solrizer.solr_name('depositor', :symbol) => user.user_key).count
     end

--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -79,11 +79,11 @@ module Sufia
       safe_join(values.map { |item| link_to_facet(item, facet_field) }, separator)
     end
 
-    def link_to_field(fieldname, fieldvalue, displayvalue = nil)
-      p = { search_field: 'advanced', fieldname => '"' + fieldvalue + '"' }
-      link_url = main_app.search_catalog_path(p)
-      display = displayvalue.blank? ? fieldvalue : displayvalue
-      link_to(display, link_url)
+    def link_to_field(name, value, label = nil, facet_hash = {})
+      label ||= value
+      params = { search_field: 'advanced', name => "\"#{value}\"" }
+      state = search_state_with_facets(params, facet_hash)
+      link_to(label, main_app.search_catalog_path(state))
     end
 
     # @param [String,Hash] text either the string to escape or a hash containing the
@@ -182,6 +182,13 @@ module Sufia
         else
           sufia.dashboard_works_path
         end
+      end
+
+      def search_state_with_facets(params, facet = {})
+        state = Blacklight::SearchState.new(params, CatalogController.blacklight_config)
+        return state.params if facet.none?
+        state.add_facet_params(Solrizer.solr_name(facet.keys.first, :facetable),
+                               facet.values.first)
       end
   end
 end

--- a/app/views/users/_follower_modal.html.erb
+++ b/app/views/users/_follower_modal.html.erb
@@ -1,8 +1,8 @@
+<!-- Text to trigger modal -->
+<span class="badge"><%= followers.count %></span>
+<span class="glyphicon glyphicon-hand-left"></span> <a data-toggle="modal" href="#followers">Follower(s)</a>
+
 <div class="modal-div">
-
-  <!-- Text to trigger modal -->
-  <i class="glyphicon glyphicon-hand-left"></i> <a data-toggle="modal" href="#followers">Follower(s):</a> <span class="badge"><%= followers.count %></span>
-
   <!-- Modal -->
   <div class="modal fade" id="followers" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog">

--- a/app/views/users/_following_modal.html.erb
+++ b/app/views/users/_following_modal.html.erb
@@ -1,9 +1,8 @@
+<!-- Text to trigger modal -->
+<span class="badge"><%= following.count %></span>
+<span class="glyphicon glyphicon-hand-right"></span> <a data-toggle="modal" href="#following">Following</a>
+
 <div class="modal-div">
-
-  <!-- Text to trigger modal -->
-  <i class="glyphicon glyphicon-hand-right"></i> <a data-toggle="modal" href="#following">Following:</a> <span class="badge"><%= following.count %></span>
-
-  <!-- Modal -->
   <!-- Modal -->
   <div class="modal fade" id="following" tabindex="-1" role="dialog"  aria-hidden="true">
     <div class="modal-dialog">

--- a/app/views/users/_vitals.html.erb
+++ b/app/views/users/_vitals.html.erb
@@ -1,22 +1,21 @@
 <div class="list-group-item">
-  <i class="glyphicon glyphicon-time"></i> Joined on <%= user.created_at.to_date.strftime("%b %d, %Y") %>
+  <span class="glyphicon glyphicon-time"></span> Joined on <%= user.created_at.to_date.strftime("%b %d, %Y") %>
 </div>
 
 <div class="list-group-item">
-  <span class="badge"><%= number_of_collections %></span>
-  <i class="glyphicon glyphicon-folder-open"></i> <%= t("sufia.dashboard.stats.collections") %>
+  <span class="badge"><%= number_of_collections(user) %></span>
+  <span class="glyphicon glyphicon-folder-open"></span> <%= link_to_field('depositor', user.to_s, t("sufia.dashboard.stats.collections"), human_readable_type: "Collection") %>
 </div>
-  
-<div class="list-group-item">
-  <span class="badge"><%= number_of_files(user) %></span>
-    <i class="glyphicon glyphicon-upload"></i> <%= link_to_field('depositor', user.to_s, 'Deposited Files') %>
 
-    <ul class="views-downloads-dashboard list-unstyled">
+<div class="list-group-item">
+  <span class="badge"><%= number_of_works(user) %></span>
+  <span class="glyphicon glyphicon-upload"></span> <%= link_to_field('depositor', user.to_s, 'Works created',  human_readable_type: "Work") %>
+
+  <ul class="views-downloads-dashboard list-unstyled">
       <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("sufia.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
       <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t("sufia.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
-    </ul>
+  </ul>
 </div>
-
 
 <div class="list-group-item">
   <%= render "users/follower_modal", followers: user.followers, user: user %>

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -44,6 +44,7 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
+    config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 5
     config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5
     config.add_facet_field solr_name("creator", :facetable), label: "Creator", limit: 5
     config.add_facet_field solr_name("tag", :facetable), label: "Keyword", limit: 5

--- a/spec/features/display_dashboard_spec.rb
+++ b/spec/features/display_dashboard_spec.rb
@@ -11,7 +11,7 @@ describe "The Dashboard", type: :feature do
       expect(page).to have_content "User Activity"
       expect(page).to have_content "User Notifications"
       expect(page).to have_content "Collections created"
-      expect(page).to have_content "Deposited Files"
+      expect(page).to have_content "Works created"
     end
 
     it "lets the user create collections" do

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -48,6 +48,19 @@ describe DashboardHelper, type: :helper do
     end
   end
 
+  describe "#number_of_works" do
+    let(:conn) { ActiveFedora::SolrService.instance.conn }
+    let(:user1) { User.new(email: "abc@test") }
+    let(:user2) { User.new(email: "abc@test.123") }
+    before do
+      create_models("GenericWork", user1, user2)
+    end
+
+    it "finds 3 works" do
+      expect(helper.number_of_works(user1)).to eq(3)
+    end
+  end
+
   describe "#number_of_files" do
     let(:conn) { ActiveFedora::SolrService.instance.conn }
     let(:user1) { User.new(email: "abc@test") }

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -21,7 +21,7 @@ describe "dashboard/index.html.erb", type: :view do
     allow(ability).to receive(:can?).with(:create, GenericWork).and_return(can_create_work)
     allow(ability).to receive(:can?).with(:create, Collection).and_return(can_create_collection)
     allow(ability).to receive(:can?).with(:edit, user).and_return(can_edit_user)
-    allow(view).to receive(:number_of_files).and_return("15")
+    allow(view).to receive(:number_of_works).and_return("15")
     allow(view).to receive(:number_of_collections).and_return("3")
     assign(:activity, [])
     assign(:notifications, [])
@@ -79,9 +79,9 @@ describe "dashboard/index.html.erb", type: :view do
       expect(sidebar).to have_content "3 Collections created"
       expect(sidebar).to have_content "1 View"
       expect(sidebar).to have_content "3 Downloads"
-      expect(sidebar).to have_content "15 Deposited Files"
-      expect(sidebar).to have_content "Follower(s): 2"
-      expect(sidebar).to have_content "Following: 1"
+      expect(sidebar).to have_content "15 Works created"
+      expect(sidebar).to have_content "2 Follower(s)"
+      expect(sidebar).to have_content "1 Following"
     end
 
     it "shows the statistics before the profile" do


### PR DESCRIPTION
Changes proposed in this pull request:
* Display number of works instead of files, since works are now the center of attention.
* Allow `#link_to_field` helper to take options, and rename its args to be less redundant.
* Align display of followers/following with collections & works created blocks above it.
* Link to works created should show only works, and not collections.
* Collections created should link to the catalog like works created does.
* Add `human_readable_type` as a facetable field.