### PR TITLE
Tidying up rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,10 +21,19 @@ Metrics/LineLength:
   Max: 400
 
 Metrics/AbcSize:
-  Max: 50
+  Max: 30
+  Exclude:
+    - 'app/controllers/concerns/sufia/admin/depositor_stats.rb'
+    - 'app/controllers/concerns/sufia/my_controller_behavior.rb'
+    - 'app/services/sufia/user_stat_importer.rb'
+    - 'lib/sufia/arkivo/metadata_munger.rb'
 
 Metrics/MethodLength:
-  Max: 30
+  Max: 20
+  Exclude:
+    - 'lib/generators/sufia/templates/migrations/create_local_authorities.rb'
+    - 'app/controllers/concerns/sufia/my_controller_behavior.rb'
+    - 'app/helpers/sufia/citations_behaviors/formatters/endnote_formatter.rb'
 
 Style/BlockDelimiters:
   Exclude:

--- a/app/helpers/sufia/citations_behaviors/formatters/open_url_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/open_url_formatter.rb
@@ -5,31 +5,36 @@ module Sufia
         def format(work)
           export_text = []
           export_text << "url_ver=Z39.88-2004&ctx_ver=Z39.88-2004&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&rfr_id=info%3Asid%2Fblacklight.rubyforge.org%3Agenerator"
-          field_map = {
-            title: 'title',
-            creator: 'creator',
-            subject: 'subject',
-            description: 'description',
-            publisher: 'publisher',
-            contributor: 'contributor',
-            date_created: 'date',
-            resource_type: 'format',
-            identifier: 'identifier',
-            language: 'language',
-            tag: 'relation',
-            based_near: 'coverage',
-            rights: 'rights'
-          }
           field_map.each do |element, kev|
             next unless work.respond_to?(element)
             values = work.send(element)
-            next if values.blank? || values.first.nil?
-            Array(values).each do |value|
+            Array.wrap(values).each do |value|
+              next if value.blank?
               export_text << "rft.#{kev}=#{CGI.escape(value.to_s)}"
             end
           end
           export_text.join('&') unless export_text.blank?
         end
+
+        private
+
+          def field_map
+            {
+              title: 'title',
+              creator: 'creator',
+              subject: 'subject',
+              description: 'description',
+              publisher: 'publisher',
+              contributor: 'contributor',
+              date_created: 'date',
+              resource_type: 'format',
+              identifier: 'identifier',
+              language: 'language',
+              tag: 'relation',
+              based_near: 'coverage',
+              rights: 'rights'
+            }
+          end
       end
     end
   end


### PR DESCRIPTION
## Extracting methods for readability

@51884765704d946ec6ec0795aa836e79792e5e7c

The `Sufia::UserStatImporter#import` had a long method (as per a
Rubocop check). Extracting the `#process_files` and `#process_works`
helps remove a violation and improve the immediate readability of the
method.

## Extracting method to reduce method length

@03c5a2f3f78c524dff44609c2f0c961f9e2dab9d

The `CitationsBehaviors::Formatters::OpenUrlFormatter#format` method
was overly long due to the field_map being defined inline. By
extracting the method, we improve the legibility and separate the
different levels of abstraction.

There is also a change in which I switched the `next` guard condition.
There was an assumption that we had a single or an array object, but
then wrap in an array. By moving the logic into an `Array.wrap` method
we tidy up the guard conditions.

Also, note that `Array(Time.now)` explodes the Time object into an
array of its constituent parts:

```ruby
Array(Time.now)
=> [1, 41, 16, 4, 5, 2016, 3, 125, true, "EDT"]
```

So prefer `Array.wrap` when we are using ActiveSupport.

## Tightening the Rubocop parameters

@b0b8c3e03a9eca7773089b209bfd99f376d48366

By adding explicit exclusions and lowering the threshold, we can help
keep future code changes tidier.
