### PR TITLE
Preferring `Array.wrap()` over `Array()`

### DIFF
--- a/app/helpers/sufia/citations_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/apa_formatter.rb
@@ -30,7 +30,7 @@ module Sufia
         end
 
         def format_authors(authors_list = [])
-          authors_list = Array(authors_list).collect { |name| abbreviate_name(surname_first(name)).strip }
+          authors_list = Array.wrap(authors_list).collect { |name| abbreviate_name(surname_first(name)).strip }
           text = ''
           text << authors_list.first if authors_list.first
           authors_list[1..-1].each do |author|

--- a/app/helpers/sufia/citations_behaviors/formatters/endnote_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/endnote_formatter.rb
@@ -11,7 +11,7 @@ module Sufia
             else
               values = work.send(mapping[0]) if work.respond_to? mapping[0]
               values = mapping[1].call(values) if mapping.length == 2
-              values = Array(values)
+              values = Array.wrap(values)
             end
             next if values.empty? || values.first.nil?
             spaced_values = values.join("; ")

--- a/app/helpers/sufia/citations_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/mla_formatter.rb
@@ -25,7 +25,7 @@ module Sufia
 
         def format_authors(authors_list = [])
           return "" if authors_list.blank?
-          authors_list = Array(authors_list)
+          authors_list = Array.wrap(authors_list)
           text = '' << surname_first(authors_list.first)
           if authors_list.length > 1
             if authors_list.length < 4

--- a/app/models/concerns/sufia/solr_document/export.rb
+++ b/app/models/concerns/sufia/solr_document/export.rb
@@ -11,7 +11,7 @@ module Sufia
           else
             values = send(mapping[0]) if respond_to? mapping[0]
             values = mapping[1].call(values) if mapping.length == 2
-            values = Array(values)
+            values = Array.wrap(values)
           end
           next if values.blank? || values.first.nil?
           spaced_values = values.join("; ")

--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -38,23 +38,23 @@ module Sufia
     end
 
     def resource_type
-      Array(self[Solrizer.solr_name("resource_type")])
+      Array.wrap(self[Solrizer.solr_name("resource_type")])
     end
 
     def read_groups
-      Array(self[::Ability.read_group_field])
+      Array.wrap(self[::Ability.read_group_field])
     end
 
     def edit_groups
-      Array(self[::Ability.edit_group_field])
+      Array.wrap(self[::Ability.edit_group_field])
     end
 
     def edit_people
-      Array(self[::Ability.edit_user_field])
+      Array.wrap(self[::Ability.edit_user_field])
     end
 
     def collection_ids
-      Array(self['collection_ids_tesim'])
+      Array.wrap(self['collection_ids_tesim'])
     end
 
     # Find the solr documents for the collections this object belongs to

--- a/app/presenters/sufia/characterization_behavior.rb
+++ b/app/presenters/sufia/characterization_behavior.rb
@@ -63,7 +63,7 @@ module Sufia
     private
 
       def values_for(term)
-        Array(characterization_metadata[term])
+        Array.wrap(characterization_metadata[term])
       end
 
       def truncate_all(values)

--- a/app/services/sufia/file_set_csv_service.rb
+++ b/app/services/sufia/file_set_csv_service.rb
@@ -25,7 +25,7 @@ module Sufia
       ::CSV.generate do |csv|
         csv << terms.map do |term|
           values = file_set.send(term)
-          values = Array(values) # make sure we have an array
+          values = Array.wrap(values) # make sure we have an array
           values.join(multi_value_separator)
         end
       end

--- a/lib/sufia/arkivo/metadata_munger.rb
+++ b/lib/sufia/arkivo/metadata_munger.rb
@@ -21,7 +21,7 @@ module Sufia
 
         # First, normalize camelCase symbols to underscore strings
         @metadata.each do |key, value|
-          munged[key.to_s.underscore] = Array(value)
+          munged[key.to_s.underscore] = Array.wrap(value)
         end
 
         # Then, rename the url key to related_url

--- a/spec/lib/sufia/arkivo/actor_spec.rb
+++ b/spec/lib/sufia/arkivo/actor_spec.rb
@@ -52,7 +52,7 @@ describe Sufia::Arkivo::Actor do
       work = subject.create_work_from_item
       # TODO: Figure out why this is needed if the Resque job is running synchronously
       reloaded = work.reload
-      expect(reloaded.title).to eq Array(item['metadata']['title'])
+      expect(reloaded.title).to eq Array.wrap(item['metadata']['title'])
     end
 
     it 'returns a GF instance' do
@@ -90,7 +90,7 @@ describe Sufia::Arkivo::Actor do
         # For some reason, "expect to change from to" wasn't working here
         expect(work.title).to eq title
         subject.update_work_from_item(work)
-        expect(work.title).to eq Array(item['metadata']['title'])
+        expect(work.title).to eq Array.wrap(item['metadata']['title'])
       end
 
       it 'wipes out the description' do


### PR DESCRIPTION
## Preferring `Array.wrap()` over `Array()`

`Array()` is a Ruby core method for coercing objects into an Array.
`Array.wrap()` is an ActiveSupport method that behaves a bit more as
expected.

The primary example of why to prefer `Array.wrap` is the following:

```ruby
now = Time.now
Array.wrap(now) == [now]
=> true
Array(now) == [now]
=> false
Array(now)
=> [43, 53, 13, 5, 5, 2016, 4, 126, true, "EDT"]
```
