### PR TITLE
Refactoring large methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,10 +29,7 @@ Metrics/AbcSize:
     - 'lib/sufia/arkivo/metadata_munger.rb'
 
 Metrics/MethodLength:
-  Max: 20
-  Exclude:
-    - 'lib/generators/sufia/templates/migrations/create_local_authorities.rb'
-    - 'app/helpers/sufia/citations_behaviors/formatters/endnote_formatter.rb'
+  Max: 15
 
 Style/BlockDelimiters:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,6 @@ Metrics/MethodLength:
   Max: 20
   Exclude:
     - 'lib/generators/sufia/templates/migrations/create_local_authorities.rb'
-    - 'app/controllers/concerns/sufia/my_controller_behavior.rb'
     - 'app/helpers/sufia/citations_behaviors/formatters/endnote_formatter.rb'
 
 Style/BlockDelimiters:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -19,6 +19,16 @@ Metrics/ModuleLength:
     - 'app/controllers/concerns/sufia/users_controller_behavior.rb'
     - 'app/helpers/sufia/sufia_helper_behavior.rb'
 
+Metrics/MethodLength:
+  Exclude:
+    - 'lib/generators/sufia/templates/migrations/create_local_authorities.rb'
+    - 'app/helpers/sufia/citations_behaviors/formatters/endnote_formatter.rb'
+    - 'app/models/concerns/sufia/solr_document/export.rb'
+    - 'app/models/local_authority.rb'
+    - 'lib/generators/sufia/install_generator.rb'
+    - 'lib/sufia/arkivo/metadata_munger.rb'
+    - 'app/controllers/concerns/sufia/batch_edits_controller_behavior.rb'
+
 Style/HashSyntax:
   Exclude:
     - 'lib/generators/sufia/templates/catalog_controller.rb'

--- a/app/controllers/concerns/sufia/my_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/my_controller_behavior.rb
@@ -30,19 +30,7 @@ module Sufia
                               end
       @filters = params[:f] || []
 
-      # set up some parameters for allowing the batch controls to show appropriately
-      @max_batch_size = 80
-      count_on_page = @document_list.count { |doc| batch.index(doc.id) }
-      @disable_select_all = @document_list.count > @max_batch_size
-      batch_size = batch.uniq.size
-      @result_set_size = @response.response["numFound"]
-      @empty_batch = batch.empty?
-      @all_checked = (count_on_page == @document_list.count)
-      @entire_result_set_selected = @response.response["numFound"] == batch_size
-      @batch_size_on_other_page = batch_size - count_on_page
-      @batch_part_on_other_page = @batch_size_on_other_page > 0
-
-      @add_files_to_collection = params.fetch(:add_files_to_collection, '')
+      prepare_instance_variables_for_batch_control_display
 
       respond_to do |format|
         format.html {}
@@ -52,6 +40,23 @@ module Sufia
     end
 
     private
+
+      # TODO: Extract a presenter object that wrangles all of these instance variables.
+      def prepare_instance_variables_for_batch_control_display
+        # set up some parameters for allowing the batch controls to show appropriately
+        @max_batch_size = 80
+        count_on_page = @document_list.count { |doc| batch.index(doc.id) }
+        @disable_select_all = @document_list.count > @max_batch_size
+        batch_size = batch.uniq.size
+        @result_set_size = @response.response["numFound"]
+        @empty_batch = batch.empty?
+        @all_checked = (count_on_page == @document_list.count)
+        @entire_result_set_selected = @response.response["numFound"] == batch_size
+        @batch_size_on_other_page = batch_size - count_on_page
+        @batch_part_on_other_page = @batch_size_on_other_page > 0
+
+        @add_files_to_collection = params.fetch(:add_files_to_collection, '')
+      end
 
       def query_solr
         search_results(params)

--- a/app/controllers/my/highlights_controller.rb
+++ b/app/controllers/my/highlights_controller.rb
@@ -21,24 +21,19 @@ module My
       end
 
       def empty_search_result
-        empty_request = {
-          responseHeader: {
-            status: 0,
-            params: {
-              wt: 'ruby',
-              rows: '11',
-              q: '*:*'
-            }
-          },
-          response: {
-            numFound: 0,
-            start: 0,
-            docs: []
-          }
-        }
         solr_response = Blacklight::Solr::Response.new(empty_request, {})
         docs = []
         [solr_response, docs]
+      end
+
+      def empty_request
+        {
+          responseHeader: {
+            status: 0,
+            params: { wt: 'ruby', rows: '11', q: '*:*' }
+          },
+          response: { numFound: 0, start: 0, docs: [] }
+        }
       end
   end
 end

--- a/app/helpers/sufia/citations_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/mla_formatter.rb
@@ -26,7 +26,17 @@ module Sufia
         def format_authors(authors_list = [])
           return "" if authors_list.blank?
           authors_list = Array.wrap(authors_list)
-          text = '' << surname_first(authors_list.first)
+          text = concatenate_authors_from(authors_list)
+          unless text.blank?
+            text << "." unless text =~ /\.$/
+            text << " "
+          end
+          text
+        end
+
+        def concatenate_authors_from(authors_list)
+          text = ''
+          text << surname_first(authors_list.first)
           if authors_list.length > 1
             if authors_list.length < 4
               authors_list[1...-1].each do |author|
@@ -37,12 +47,9 @@ module Sufia
               text << ", et al"
             end
           end
-          unless text.blank?
-            text << "." unless text =~ /\.$/
-            text << " "
-          end
           text
         end
+        private :concatenate_authors_from
 
         def format_date(pub_date)
           pub_date

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -8,6 +8,11 @@ class LocalAuthority < ActiveRecord::Base
     authority = create(name: name)
     format = opts.fetch(:format, :ntriples)
     predicate = opts.fetch(:predicate, ::RDF::Vocab::SKOS.prefLabel)
+    entries = extract_harvestable_rdf_entries_from(sources, authority, predicate, format)
+    import_or_save!(entries)
+  end
+
+  def self.extract_harvestable_rdf_entries_from(sources, authority, predicate, format)
     entries = []
     sources.each do |uri|
       ::RDF::Reader.open(uri, format: format) do |reader|
@@ -19,8 +24,9 @@ class LocalAuthority < ActiveRecord::Base
         end
       end
     end
-    import_or_save!(entries)
+    entries
   end
+  private_class_method :extract_harvestable_rdf_entries_from
 
   def self.harvest_tsv(name, sources, opts = {})
     return unless where(name: name).empty?

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -19,11 +19,7 @@ class LocalAuthority < ActiveRecord::Base
         end
       end
     end
-    if LocalAuthorityEntry.respond_to?(:import)
-      LocalAuthorityEntry.import(entries)
-    else
-      entries.each(&:save!)
-    end
+    import_or_save!(entries)
   end
 
   def self.harvest_tsv(name, sources, opts = {})
@@ -31,11 +27,7 @@ class LocalAuthority < ActiveRecord::Base
     authority = create(name: name)
     prefix = opts.fetch(:prefix, "")
     entries = extract_harvestable_tsv_entries_from(sources, authority, prefix)
-    if LocalAuthorityEntry.respond_to? :import
-      LocalAuthorityEntry.import entries
-    else
-      entries.each(&:save!)
-    end
+    import_or_save!(entries)
   end
 
   def self.extract_harvestable_tsv_entries_from(sources, authority, prefix)
@@ -54,6 +46,14 @@ class LocalAuthority < ActiveRecord::Base
   end
   private_class_method :extract_harvestable_tsv_entries_from
 
+  def self.import_or_save!(entries)
+    if LocalAuthorityEntry.respond_to?(:import)
+      LocalAuthorityEntry.import(entries)
+    else
+      entries.each(&:save!)
+    end
+  end
+  private_class_method :import_or_save!
 
   def self.register_vocabulary(model, term, name)
     authority = find_by_name(name)


### PR DESCRIPTION
## Breaking apart large method into smaller methods

Moving the commented section of instance variable declarations into
their own method. Also adding a TODO to highlight that we may want to
explore a presenter object.

## Extracing #empty_request for readability

I have a desire to maintain readability, so I don't want the hash to
span past 80 characters. I find that compacting the hash helps me scan
a bit quicker.

I also opted to extract a method for the hash declaration to draw
attention to the separation of concerns.

## Breaking apart larger method in exporter

The original method has a few complicated concepts. Attempting to
extract and break apart into smaller contexts.

## Extracting duplicated behavior into method

Instead of repeating the 5 lines creating a method to consolidate that
behavior.

## Separating two methods to ease readability

## Moving rubocop declarations to rubocop todo

In the eternal battle for small yet meaningful methods versus the
ability to see the details of what is happening, this is my attempt to
ask the future to "Aim for small yet descriptive methods."
