### PR TITLE
Use `config.redis_namespace` to set namespace of activity streams

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,3 @@
-require: rubocop-rspec
 inherit_from: .rubocop_todo.yml
 
 AllCops:
@@ -82,24 +81,3 @@ Style/SingleLineBlockParams:
 
 Rails:
   Enabled: true
-
-RSpec/AnyInstance:
-  Enabled: false
-
-RSpec/ExampleWording:
-  CustomTransform:
-    be: is
-    have: has
-    not: does not
-    NOT: does NOT
-  IgnoredWords:
-    - only
-
-RSpec/FilePath:
-  Enabled: false
-
-RSpec/InstanceVariable:
-  Enabled: false
-
-RSpec/NotToNot:
-  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,5 +1,3 @@
-require: rubocop-rspec
-
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'lib/sufia/arkivo/metadata_munger.rb'
@@ -52,14 +50,3 @@ Rails/HasAndBelongsToMany:
   Exclude:
     - 'app/models/domain_term.rb'
     - 'app/models/local_authority.rb'
-
-RSpec/DescribeClass:
-  Exclude:
-    - 'spec/javascripts/jasmine_spec.rb'
-    - 'spec/tasks/rake_spec.rb'
-    - 'spec/config/sufia_events_spec.rb'
-    - 'spec/features/**/*'
-    - 'spec/views/**/*'
-    - 'spec/routing/**/*'
-    - 'spec/requests/**/*'
-    - 'spec/inputs/**/*'

--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -1,5 +1,6 @@
 require 'select2-rails'
 require 'nest'
+require 'redis-namespace'
 require 'mailboxer'
 require 'acts_as_follower'
 require 'carrierwave'

--- a/lib/sufia/arkivo/metadata_munger.rb
+++ b/lib/sufia/arkivo/metadata_munger.rb
@@ -2,14 +2,12 @@ module Sufia
   module Arkivo
     CREATOR_TYPES = ['author', 'interviewer', 'director', 'scriptwriter',
                      'inventor', 'composer', 'cartographer', 'programmer', 'artist',
-                     'bookAuthor'
-                    ].freeze
+                     'bookAuthor'].freeze
 
     CONTRIBUTOR_TYPES = ['contributor', 'editor', 'translator', 'seriesEditor',
                          'interviewee', 'producer', 'castMember', 'sponsor', 'counsel',
                          'attorneyAgent', 'recipient', 'performer', 'wordsBy', 'commenter',
-                         'presenter', 'guest', 'podcaster', 'reviewedAuthor', 'cosponsor'
-                        ].freeze
+                         'presenter', 'guest', 'podcaster', 'reviewedAuthor', 'cosponsor'].freeze
 
     class MetadataMunger
       def initialize(metadata)

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -10,8 +10,7 @@ describe CollectionsController do
   let(:collection) do
     create(:public_collection, title: ["My collection"],
                                description: ["My incredibly detailed description of the collection"],
-                               user: user
-          )
+                               user: user)
   end
 
   let(:asset1)         { create(:work, title: ["First of the Assets"], user: user) }
@@ -41,7 +40,8 @@ describe CollectionsController do
     it "removes blank strings from params before creating Collection" do
       expect {
         post :create, collection: {
-          title: ["My First Collection "], creator: [""] }
+          title: ["My First Collection "], creator: [""]
+        }
       }.to change { Collection.count }.by(1)
       expect(assigns[:collection].title).to eq ["My First Collection "]
       expect(assigns[:collection].creator).to eq []
@@ -127,7 +127,8 @@ describe CollectionsController do
 
       it "removes blank strings from params before updating Collection metadata" do
         put :update, id: collection, collection: {
-          title: ["My Next Collection "], creator: [""] }
+          title: ["My Next Collection "], creator: [""]
+        }
         expect(assigns[:collection].title).to eq ["My Next Collection "]
         expect(assigns[:collection].creator).to eq []
       end

--- a/spec/controllers/file_sets_controller_spec.rb
+++ b/spec/controllers/file_sets_controller_spec.rb
@@ -147,8 +147,7 @@ describe CurationConcerns::FileSetsController do
                                 permissions_attributes: [
                                   { type: 'person', name: 'user1', access: 'edit' },
                                   { type: 'group', name: 'group1', access: 'read' }
-                                ]
-                      }
+                                ] }
 
       expect(assigns[:file_set].read_groups).to eq ["group1"]
       expect(assigns[:file_set].edit_users).to include("user1", user.user_key)
@@ -161,8 +160,7 @@ describe CurationConcerns::FileSetsController do
                     file_set: { tag: [''],
                                 permissions_attributes: [
                                   { id: file_set.permissions.last.id, type: 'group', name: 'group3', access: 'read' }
-                                ]
-                      }
+                                ] }
 
       expect(assigns[:file_set].read_groups).to eq(["group3"])
     end

--- a/spec/controllers/generic_works_controller_spec.rb
+++ b/spec/controllers/generic_works_controller_spec.rb
@@ -76,8 +76,7 @@ describe CurationConcerns::GenericWorksController do
                    "file_name" => "filepicker-demo.txt.txt" },
           "1" => { "url" => url2,
                    "expires" => "2014-03-31T20:37:36.731Z",
-                   "file_name" => "Getting+Started.pdf" }
-  }.with_indifferent_access
+                   "file_name" => "Getting+Started.pdf" } }.with_indifferent_access
       end
       let(:uploaded_files) do
         browse_everything_params.values.map { |v| v['url'] }

--- a/spec/controllers/sufia/batch_uploads_controller_spec.rb
+++ b/spec/controllers/sufia/batch_uploads_controller_spec.rb
@@ -38,7 +38,8 @@ describe Sufia::BatchUploadsController do
         post :create,
              generic_work: {
                permissions_attributes: [
-                 { type: "group", name: "public", access: "read" }],
+                 { type: "group", name: "public", access: "read" }
+               ],
                on_behalf_of: 'elrayle'
              },
              uploaded_files: ['1']

--- a/spec/forms/curation_concerns/work_form_spec.rb
+++ b/spec/forms/curation_concerns/work_form_spec.rb
@@ -48,7 +48,8 @@ describe CurationConcerns::GenericWorkForm do
       thumbnail_id: '789',
       tag: ['derp'],
       rights: ['http://creativecommons.org/licenses/by/3.0/us/'],
-      collection_ids: ['123456', 'abcdef']) }
+      collection_ids: ['123456', 'abcdef']
+    ) }
 
     subject { described_class.model_attributes(params) }
 
@@ -68,7 +69,8 @@ describe CurationConcerns::GenericWorkForm do
         tag: [''],
         rights: [''],
         collection_ids: [''],
-        on_behalf_of: 'Melissa') }
+        on_behalf_of: 'Melissa'
+      ) }
 
       it 'removes blank parameters' do
         expect(subject['title']).to be_empty

--- a/spec/lib/sufia/redis_event_store_spec.rb
+++ b/spec/lib/sufia/redis_event_store_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe Sufia::RedisEventStore do
+  let(:redis_instance) { described_class.instance }
   before do
-    Redis.current.keys('events:*').each { |key| Redis.current.del key }
+    redis_instance.keys('events:*').each { |key| redis_instance.del key }
   end
 
   describe "::create" do

--- a/spec/services/sufia/actor_factory_spec.rb
+++ b/spec/services/sufia/actor_factory_spec.rb
@@ -28,7 +28,8 @@ describe Sufia::ActorFactory do
         CurationConcerns::ApplyOrderActor,
         CurationConcerns::InterpretVisibilityActor,
         CurationConcerns::GenericWorkActor,
-        CurationConcerns::AssignIdentifierActor]
+        CurationConcerns::AssignIdentifierActor
+      ]
       expect(subject.first_actor_class).to eq Sufia::CreateWithRemoteFilesActor
     end
   end

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -6,8 +6,7 @@ describe 'catalog/_index_list_default' do
       'depositor_tesim' => ['jcoyne@justincoyne.com'],
       'proxy_depositor_ssim' => ['atz@stanford.edu'],
       'description_tesim' => ['This links to http://example.com/ What about that?'],
-      'date_uploaded_dtsi' => '2013-03-14T00:00:00Z'
-    }
+      'date_uploaded_dtsi' => '2013-03-14T00:00:00Z' }
   end
   let(:document) { SolrDocument.new(attributes) }
   let(:blacklight_configuration_context) do

--- a/spec/views/zzz_stats_file.html.erb_spec.rb
+++ b/spec/views/zzz_stats_file.html.erb_spec.rb
@@ -16,8 +16,7 @@ describe 'stats/file.html.erb', type: :view do
                  created: Date.parse('2014-01-01'),
                  total_pageviews: 0,
                  total_downloads: 0,
-                 to_flot: []
-                )
+                 to_flot: [])
     }
 
     let(:stats) {
@@ -25,8 +24,7 @@ describe 'stats/file.html.erb', type: :view do
                  created: Date.parse('2014-01-01'),
                  total_pageviews: 9,
                  total_downloads: 4,
-                 to_flot: [[1_396_422_000_000, 2], [1_396_508_400_000, 3], [1_396_594_800_000, 4]]
-                )
+                 to_flot: [[1_396_422_000_000, 2], [1_396_508_400_000, 3], [1_396_594_800_000, 4]])
     }
 
     context 'when no analytics results returned' do

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kaminari_route_prefix'
   spec.add_dependency 'jquery-ui-rails', '~> 5.0'
   spec.add_dependency 'zeroclipboard-rails', '~> 0.0.13'
+  spec.add_dependency 'redis-namespace', '~> 1.5.2'
 
   spec.add_development_dependency 'engine_cart', '~> 0.8'
   spec.add_development_dependency 'mida', '~> 0.3'

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -61,6 +61,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_girl_rails", '~> 4.4'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'
   spec.add_development_dependency "jasmine", '~> 2.3'
-  spec.add_development_dependency 'rubocop', '~> 0.39'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.4'
+  spec.add_development_dependency 'rubocop', '~> 0.40'
 end

--- a/tasks/sufia-dev.rake
+++ b/tasks/sufia-dev.rake
@@ -8,7 +8,6 @@ require 'active_fedora/rake_support'
 
 desc 'Run style checker'
 RuboCop::RakeTask.new(:rubocop) do |task|
-  task.requires << 'rubocop-rspec'
   task.fail_on_error = true
 end
 


### PR DESCRIPTION
The PR drives all of Sufia's activity stream-related Redis reads and writes through `RedisEventStore.instance` which sets its namespace based on the value of `Sufia.config.redis_namespace`

The `redis_namespace` config value is otherwise not used anymore, except in a rake task. This uses the config value for what it was intended for, and provides machinery we can use in Hydra-in-a-Box to make [activity streams multi-tenant](https://github.com/projecthydra-labs/hybox/issues/110) (via Redis namespaces).