### PR TITLE
Display Multiple Work Titles and Descriptions on Work Show Page

### DIFF
--- a/app/views/curation_concerns/base/_work_description.erb
+++ b/app/views/curation_concerns/base/_work_description.erb
@@ -1,0 +1,3 @@
+<% presenter.description.each do |description| %>
+    <p class="work_description"><%= description %></p>
+<% end %>

--- a/app/views/curation_concerns/base/_work_title.erb
+++ b/app/views/curation_concerns/base/_work_title.erb
@@ -1,0 +1,7 @@
+<% presenter.title.each_with_index do |title, index| %>
+    <% if index == 0 %>
+        <h1><%= title %> <%= presenter.permission_badge %></h1>
+    <% else %>
+        <h1><%= title %></h1>
+    <% end %>
+<% end %>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -2,11 +2,11 @@
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>
-      <h1><%= @presenter %> <%= @presenter.permission_badge %></h1>
+      <%= render 'work_title', presenter: @presenter %>
     </header>
   </div>
   <div class="col-sm-8">
-    <p class="work_description"><%= @presenter.description %></p>
+    <%= render 'work_description', presenter: @presenter %>
     <%= render 'relationships', presenter: @presenter %>
     <%= render 'metadata', presenter: @presenter %>
   </div>


### PR DESCRIPTION
Fixes #1979 

Override Curation Concerns calling .first on title and description by creating new methods that loop through all titles and descriptions to display on the work show page. Added `<%= render %>` for work title and work description and created new partials for each to loop through and display contents.

Changes proposed in this pull request:
*  Added new `<%= render %>` to show page
* New Work description partial
* New Work title partial
* ~~New Methods specific to works and not break solr title and description throughout app~~
* ~~Delegate methods in work show presenter~~

@projecthydra/sufia-code-reviewers

Added work title and description partial, looped through page title and description, ~~removed .first from title in solr_document_behavior. Added correct code for displaying multiple descriptions. Switch to new methods for title and description and not break it for others that use solr title and description~~