### PR TITLE
Rename tag to tags

### DIFF
--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -4,7 +4,7 @@
 <%= presenter.attribute_to_html(:publisher) %>
 <%= presenter.attribute_to_html(:language) %>
 <%= presenter.attribute_to_html(:identifier) %>
-<%= presenter.attribute_to_html(:tag) %>
+<%= presenter.attribute_to_html(:tags) %>
 <%= presenter.attribute_to_html(:date_created) %>
 <%= presenter.attribute_to_html(:based_near) %>
 <%= presenter.attribute_to_html(:related_url) %>


### PR DESCRIPTION
Fixes #1983 

Present tense short summary (50 characters or less)
The keywords are not displayed by work show presenter

Changes proposed in this pull request:
* change tag to tags
* 
* 

@projecthydra/sufia-code-reviewers

