### PR TITLE
[WIP] Add list of previously uploaded files to the edit files tab.

### DIFF
--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -4,6 +4,7 @@ module Sufia::Forms
     include HydraEditor::Form::Permissions
 
     attr_reader :agreement_accepted
+    attr_accessor :file_sets
 
     self.terms += [:collection_ids]
     self.required_fields = [:title, :creator, :tag, :rights]

--- a/app/views/curation_concerns/base/_form_files.html.erb
+++ b/app/views/curation_concerns/base/_form_files.html.erb
@@ -8,7 +8,7 @@
                          <th>Filename</th>
                          <th>Display Label</th>
                      </tr>
-                     <% f.object.file_sets.each { |file| %>
+                     <% f.object.file_sets.each do |file| %>
                          <tr>
                              <td>
                                  <span><%= file.solr_document.label %></span>
@@ -17,7 +17,7 @@
                                  <span><%= file.title %></span>
                              </td>
                          </tr>
-                     <% } %>
+                     <% end %>
                      </tbody>
                  </table>
              </fieldset>

--- a/app/views/curation_concerns/base/_form_files.html.erb
+++ b/app/views/curation_concerns/base/_form_files.html.erb
@@ -1,4 +1,27 @@
      <div id="fileupload">
+         <% if f.object.file_sets.present? > 0 %>
+             <fieldset id="uploaded-files">
+                 <legend>Previously Uploaded Files</legend>
+                 <table role="presentation" class="table table-striped uploaded-files">
+                     <tbody>
+                     <tr>
+                         <th>Filename</th>
+                         <th>Display Label</th>
+                     </tr>
+                     <% f.object.file_sets.each { |file| %>
+                         <tr>
+                             <td>
+                                 <span><%= file.solr_document.label %></span>
+                             </td>
+                             <td>
+                                 <span><%= file.title %></span>
+                             </td>
+                         </tr>
+                     <% } %>
+                     </tbody>
+                 </table>
+             </fieldset>
+         <% end %>
         <!-- Redirect browsers with JavaScript disabled to the origin page -->
         <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"></noscript>
         <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->


### PR DESCRIPTION
Lists previously uploaded files on the edit page.

The edit page has a tab marked "Files" and it previously only had buttons to upload new files. Users who had previously uploaded files and returned to the edit page couldn't tell if their files were still there or whether they had successfully uploaded them.

(This is also a precursor to the request to modify the displayed label of a file in the "Files" tab. That's why I'm displaying both the file name and the title here.)

@projecthydra/sufia-code-reviewers
