### PR TITLE
Remove GenericWork from the views

### DIFF
--- a/app/controllers/concerns/sufia/homepage_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/homepage_controller_behavior.rb
@@ -13,10 +13,13 @@ module Sufia::HomepageControllerBehavior
       Sufia::HomepageSearchBuilder
     end
 
+    class_attribute :presenter_class
+    self.presenter_class = Sufia::HomepagePresenter
     layout 'homepage'
   end
 
   def index
+    @presenter = presenter_class.new(current_ability)
     @featured_researcher = ContentBlock.featured_researcher
     @marketing_text = ContentBlock.marketing_text
     @featured_work_list = FeaturedWorkList.new

--- a/app/models/concerns/sufia/ability.rb
+++ b/app/models/concerns/sufia/ability.rb
@@ -7,7 +7,6 @@ module Sufia
     end
 
     def sufia_abilities
-      file_set_abilities
       user_abilities
       featured_work_abilities
       editor_abilities
@@ -40,10 +39,6 @@ module Sufia
 
     def featured_work_abilities
       can [:create, :destroy, :update], FeaturedWork if admin?
-    end
-
-    def file_set_abilities
-      can :view_share_work, GenericWork
     end
 
     def editor_abilities

--- a/app/presenters/sufia/homepage_presenter.rb
+++ b/app/presenters/sufia/homepage_presenter.rb
@@ -1,0 +1,16 @@
+module Sufia
+  class HomepagePresenter
+    attr_reader :current_ability
+    include CurationConcerns::AbilityHelper
+
+    def initialize(current_ability)
+      @current_ability = current_ability
+    end
+
+    delegate :can?, to: :current_ability
+
+    def display_share_button?
+      Sufia.config.always_display_share_button || can_ever_create_works?
+    end
+  end
+end

--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -31,14 +31,24 @@
       </ul>
     </li>
 
-    <% if can? :create, GenericWork %>
+    <% if can_ever_create_works? %>
       <li class="dropdown">
         <%= link_to sufia.dashboard_works_path, role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
           <span class="fa fa-cube"></span> Works <span class="caret"></span>
         <% end %>
         <ul class="dropdown-menu">
           <li><%= link_to 'My Works', sufia.dashboard_works_path %></li>
-          <li><%= link_to 'New Work', sufia.new_curation_concerns_generic_work_path %></li>
+
+          <% classification = CurationConcerns::QuickClassificationQuery.new(current_user) %>
+          <% classification.each do |concern| %>
+            <li><%= link_to(
+                  "New #{concern.human_readable_type}",
+                  new_polymorphic_path([sufia, concern]),
+                  class: "item-option contextual-quick-classify #{dom_class(concern, 'new').gsub('_', '-')}",
+                  role: 'menuitem'
+                ) %>
+            </li>
+          <% end %>
           <li><%= link_to 'Batch Create', sufia.new_batch_upload_path %></li>
         </ul>
       </li>

--- a/app/views/collections/_show_document_list_row.html.erb
+++ b/app/views/collections/_show_document_list_row.html.erb
@@ -1,5 +1,4 @@
 <% id = document.id %>
-<% presenter = document.is_a?(GenericWork) ? Sufia::WorkShowPresenter.new(document, nil) : nil %>
 <tr id="document_<%= id %>">
   <td>&nbsp;
     <% if current_user and document.depositor != current_user.user_key %>

--- a/app/views/dashboard/_index_partials/_heading_actions.html.erb
+++ b/app/views/dashboard/_index_partials/_heading_actions.html.erb
@@ -1,9 +1,15 @@
 <div class="col-xs-12 heading-row">
   <% if can?(:create, GenericWork) %>
     <div class="col-xs-6 col-sm-2 heading-tile">
-      <%= link_to new_curation_concerns_generic_work_path do %>
-          <span class="glyphicon glyphicon-upload"></span>
-          <%= I18n.t("sufia.dashboard.create_work") %>
+      <% classification = CurationConcerns::QuickClassificationQuery.new(current_user) %>
+      <% classification.each do |concern| %>
+        <%= link_to(new_polymorphic_path([sufia, concern]),
+              class: "item-option contextual-quick-classify #{dom_class(concern, 'new').gsub('_', '-')}",
+              role: 'menuitem'
+            ) do %>
+            <span class="glyphicon glyphicon-upload"></span>
+            <%= I18n.t("sufia.dashboard.create_work", work_type: concern.human_readable_type) %>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/my/_index_partials/_default_group.html.erb
+++ b/app/views/my/_index_partials/_default_group.html.erb
@@ -14,12 +14,10 @@
   <tbody>
   <% docs.each_with_index do |document,counter| %>
     <% case document.hydra_model %>
-    <% when "GenericWork" %>
-      <%= render partial: 'my/_index_partials/list_works', locals: { document: document, counter: counter, presenter: Sufia::WorkShowPresenter.new(document, current_ability) } %>
     <% when "Collection" %>
-      <%= render partial: 'my/_index_partials/list_collections', locals: {document: document, counter: counter} %>
+      <%= render 'my/_index_partials/list_collections', document: document, counter: counter %>
     <% else %>
-      <tr><td colspan='6'><%= document.hydra_model %> : <%= document.id %></td></tr>
+      <%= render 'my/_index_partials/list_works', document: document, counter: counter, presenter: Sufia::WorkShowPresenter.new(document, current_ability) %>
     <% end %>
   <% end %>
   </tbody>

--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -25,7 +25,7 @@
     <%= render_visibility_label(document) %>
   </td>
   <td class="text-center">
-    <%= render partial:'collection_action_menu', locals: { id: id } %>
+    <%= render 'collection_action_menu', id: id %>
    </td>
 </tr>
 <tr id="detail_<%= id %>"> <!--  collection detail"> -->

--- a/app/views/sufia/homepage/_home_header.html.erb
+++ b/app/views/sufia/homepage/_home_header.html.erb
@@ -1,5 +1,5 @@
 <div class="home_call_action col-xs-12 col-sm-4 pull-right">
-  <% if can? :view_share_work, GenericWork %>
+  <% if @presenter.display_share_button? %>
     <div class="home_share_work">
       <%= link_to sufia.new_curation_concerns_generic_work_path, class: "btn btn-primary btn-lg btn-block", id: "contribute_link" do %>
         <i class="glyphicon glyphicon-upload"></i> <%= t('sufia.share_button') %>
@@ -7,7 +7,7 @@
       <p class="text-center"><a href="/terms/">Terms of Use</a></p>
     </div>
   <% end %>
-</div><!-- /.col-xs-3 -->
+</div>
 <div class="col-xs-12 col-sm-8">
-  <%= render partial: "marketing" %>
+  <%= render "marketing" %>
 </div>

--- a/lib/generators/sufia/templates/config/sufia.rb
+++ b/lib/generators/sufia/templates/config/sufia.rb
@@ -132,6 +132,9 @@ Sufia.config do |config|
   # The default is true.
   # config.active_deposit_agreement_acceptance = true
 
+  # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
+  # config.always_display_share_button = true
+
   # If browse-everything has been configured, load the configs.  Otherwise, set to nil.
   begin
     if defined? BrowseEverything

--- a/lib/sufia/engine.rb
+++ b/lib/sufia/engine.rb
@@ -85,6 +85,9 @@ module Sufia
     config.geonames_username = ""
     config.active_deposit_agreement_acceptance = true
 
+    # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
+    config.always_display_share_button = true
+
     # Noid identifiers
     config.enable_noids = true
     config.noid_template = '.reeddeeddk'

--- a/spec/controllers/homepage_controller_spec.rb
+++ b/spec/controllers/homepage_controller_spec.rb
@@ -79,6 +79,12 @@ describe Sufia::HomepageController, type: :controller do
       end
     end
 
+    it "sets the presenter" do
+      get :index
+      expect(response).to be_success
+      expect(assigns(:presenter)).to be_kind_of Sufia::HomepagePresenter
+    end
+
     context "with featured works" do
       let!(:my_work) { FactoryGirl.create(:work, user: user) }
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -10,7 +10,6 @@ describe Sufia::Ability, type: :model do
     it { is_expected.not_to be_able_to(:create, ContentBlock) }
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
     it { is_expected.to be_able_to(:read, ContentBlock) }
-    it { is_expected.to be_able_to(:view_share_work, GenericWork) }
     it { is_expected.to be_able_to(:read, GenericWork) }
     it { is_expected.to be_able_to(:stats, GenericWork) }
     it { is_expected.to be_able_to(:citation, GenericWork) }
@@ -24,7 +23,6 @@ describe Sufia::Ability, type: :model do
     it { is_expected.not_to be_able_to(:create, ContentBlock) }
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
     it { is_expected.to be_able_to(:read, ContentBlock) }
-    it { is_expected.to be_able_to(:view_share_work, GenericWork) }
   end
 
   describe "a user in the admin group" do
@@ -36,7 +34,6 @@ describe Sufia::Ability, type: :model do
     it { is_expected.to be_able_to(:create, ContentBlock) }
     it { is_expected.to be_able_to(:update, ContentBlock) }
     it { is_expected.to be_able_to(:read, ContentBlock) }
-    it { is_expected.to be_able_to(:view_share_work, GenericWork) }
   end
 
   describe "proxies and transfers" do

--- a/spec/presenters/sufia/homepage_presenter_spec.rb
+++ b/spec/presenters/sufia/homepage_presenter_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Sufia::HomepagePresenter do
+  let(:presenter) { described_class.new(ability) }
+  let(:ability) { instance_double("Ability") }
+
+  describe "#display_share_button?" do
+    subject { presenter.display_share_button? }
+    context "when config is set to always_display_share_button" do
+      it { is_expected.to be true }
+    end
+    context "when config is not set to always_display_share_button" do
+      before do
+        allow(Sufia.config).to receive(:always_display_share_button).and_return(false)
+        allow(ability).to receive(:can?).with(:create, GenericWork).and_return(false)
+      end
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/views/homepage/_home_header.html.erb_spec.rb
+++ b/spec/views/homepage/_home_header.html.erb_spec.rb
@@ -3,21 +3,24 @@ require 'spec_helper'
 describe "sufia/homepage/_home_header.html.erb" do
   let(:groups) { [] }
   let(:ability) { instance_double("Ability") }
+  let(:presenter) { Sufia::HomepagePresenter.new(ability) }
+
   describe "share your work button" do
     before do
+      assign(:presenter, presenter)
       allow(controller).to receive(:current_ability).and_return(ability)
-      allow(ability).to receive(:can?).with(:view_share_work, GenericWork).and_return(can_view_share_work)
+      allow(presenter).to receive(:display_share_button?).and_return(display_share_button)
       stub_template "sufia/homepage/_marketing.html.erb" => "marketing"
       render
     end
-    context "when the user can view" do
-      let(:can_view_share_work) { true }
+    context "when the button always displays" do
+      let(:display_share_button) { true }
       it "displays" do
         expect(rendered).to have_content t("sufia.share_button")
       end
     end
-    context "when the user can't view" do
-      let(:can_view_share_work) { false }
+    context "when the button displays for users with rights" do
+      let(:display_share_button) { false }
       it "does not display" do
         expect(rendered).not_to have_content t("sufia.share_button")
       end


### PR DESCRIPTION
This positions us to offer more work types besides `GenericWork`
@projecthydra/sufia-code-reviewers

