### PR TITLE
Rename generic_work_id columns to work_id

### DIFF
--- a/app/assets/javascripts/sufia/trophy.js
+++ b/app/assets/javascripts/sufia/trophy.js
@@ -3,7 +3,7 @@ function toggleTrophy(url, anchor) {
      url: url,
      type: "post",
      success: function(data) {
-       gid = data.generic_work_id;
+       gid = data.work_id;
        if (anchor.hasClass("trophy-on")){
          // we've just removed the trophy
          trophyOff(anchor);

--- a/app/controllers/concerns/sufia/transfers_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/transfers_controller_behavior.rb
@@ -61,7 +61,7 @@ module Sufia
       def authorize_depositor_by_id
         @id = params[:id]
         authorize! :transfer, @id
-        @proxy_deposit_request.generic_work_id = @id
+        @proxy_deposit_request.work_id = @id
       rescue CanCan::AccessDenied
         redirect_to root_url, alert: 'You are not authorized to transfer this work.'
       end

--- a/app/controllers/concerns/sufia/users_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/users_controller_behavior.rb
@@ -57,7 +57,7 @@ module Sufia::UsersControllerBehavior
     # TODO: this should be moved to TrophiesController
     params.keys.select { |k, _v| k.starts_with? 'remove_trophy_' }.each do |smash_trophy|
       smash_trophy = smash_trophy.sub(/^remove_trophy_/, '')
-      current_user.trophies.where(generic_work_id: smash_trophy).destroy_all
+      current_user.trophies.where(work_id: smash_trophy).destroy_all
     end
     UserEditProfileEventJob.perform_later(@user)
     redirect_to sufia.profile_path(@user.to_param), notice: "Your profile has been updated"
@@ -73,12 +73,12 @@ module Sufia::UsersControllerBehavior
       redirect_to root_path, alert: "You do not have permissions to the work"
       return false
     end
-    t = current_user.trophies.where(generic_work_id: work_id).first
+    t = current_user.trophies.where(work_id: work_id).first
     if t
       t.destroy
       return false if t.persisted?
     else
-      t = current_user.trophies.create(generic_work_id: work_id)
+      t = current_user.trophies.create(work_id: work_id)
       return false unless t.persisted?
     end
     render json: t

--- a/app/controllers/featured_works_controller.rb
+++ b/app/controllers/featured_works_controller.rb
@@ -1,7 +1,7 @@
 class FeaturedWorksController < ApplicationController
   def create
     authorize! :create, FeaturedWork
-    @featured_work = FeaturedWork.new(generic_work_id: params[:id])
+    @featured_work = FeaturedWork.new(work_id: params[:id])
 
     respond_to do |format|
       if @featured_work.save
@@ -14,7 +14,7 @@ class FeaturedWorksController < ApplicationController
 
   def destroy
     authorize! :destroy, FeaturedWork
-    @featured_work = FeaturedWork.find_by(generic_work_id: params[:id])
+    @featured_work = FeaturedWork.find_by(work_id: params[:id])
     @featured_work.destroy
 
     respond_to do |format|

--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -57,7 +57,7 @@ module Sufia
       if req.deleted_work? || req.canceled?
         req.to_s
       else
-        link_to(req.to_s, curation_concerns_generic_work_path(req.generic_work_id))
+        link_to(req.to_s, curation_concerns_generic_work_path(req.work_id))
       end
     end
 

--- a/app/helpers/trophy_helper.rb
+++ b/app/helpers/trophy_helper.rb
@@ -2,7 +2,7 @@
 module TrophyHelper
   def display_trophy_link(user, id, args = {}, &_block)
     return unless user
-    trophy = user.trophies.where(generic_work_id: id).first
+    trophy = user.trophies.where(work_id: id).first
     trophyclass = trophy ? "trophy-on" : "trophy-off"
 
     args[:add_text] ||= "Highlight Work on Profile"

--- a/app/models/concerns/sufia/proxy_deposit.rb
+++ b/app/models/concerns/sufia/proxy_deposit.rb
@@ -23,7 +23,7 @@ module Sufia
     def request_transfer_to(target)
       raise ArgumentError, "Must provide a target" unless target
       deposit_user = ::User.find_by_user_key(depositor)
-      ProxyDepositRequest.create!(generic_work_id: id, receiving_user: target, sending_user: deposit_user)
+      ProxyDepositRequest.create!(work_id: id, receiving_user: target, sending_user: deposit_user)
     end
   end
 end

--- a/app/models/concerns/sufia/user.rb
+++ b/app/models/concerns/sufia/user.rb
@@ -115,9 +115,9 @@ module Sufia::User
   def trophy_works
     trophies.map do |t|
       begin
-        ::GenericWork.load_instance_from_solr(t.generic_work_id)
+        ::GenericWork.load_instance_from_solr(t.work_id)
       rescue ActiveFedora::ObjectNotFoundError
-        logger.error("Invalid trophy for user #{user_key} (generic work id #{t.generic_work_id})")
+        logger.error("Invalid trophy for user #{user_key} (work id #{t.work_id})")
         nil
       end
     end.compact

--- a/app/models/concerns/sufia/works/trophies.rb
+++ b/app/models/concerns/sufia/works/trophies.rb
@@ -6,7 +6,7 @@ module Sufia::Works
     end
 
     def cleanup_trophies
-      Trophy.destroy_all(generic_work_id: id)
+      Trophy.destroy_all(work_id: id)
     end
   end
 end

--- a/app/models/featured_work_list.rb
+++ b/app/models/featured_work_list.rb
@@ -32,7 +32,7 @@ class FeaturedWorkList
     end
 
     def ids
-      @works.pluck(:generic_work_id)
+      @works.pluck(:work_id)
     end
 
     def solr_docs
@@ -40,6 +40,6 @@ class FeaturedWorkList
     end
 
     def work_with_id(id)
-      @works.find { |w| w.generic_work_id == id }
+      @works.find { |w| w.work_id == id }
     end
 end

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -5,10 +5,10 @@ class ProxyDepositRequest < ActiveRecord::Base
   belongs_to :receiving_user, class_name: 'User'
   belongs_to :sending_user, class_name: 'User'
 
-  # attribute generic_work_id exists as result of renaming in db migrations.
+  # attribute work_id exists as result of renaming in db migrations.
   # See upgrade700_generator.rb
 
-  validates :sending_user, :generic_work_id, presence: true
+  validates :sending_user, :work_id, presence: true
   validate :transfer_to_should_be_a_valid_username
   validate :sending_user_should_not_be_receiving_user
   validate :should_not_be_already_part_of_a_transfer
@@ -31,7 +31,7 @@ class ProxyDepositRequest < ActiveRecord::Base
   end
 
   def should_not_be_already_part_of_a_transfer
-    transfers = ProxyDepositRequest.where(generic_work_id: generic_work_id, status: 'pending')
+    transfers = ProxyDepositRequest.where(work_id: work_id, status: 'pending')
     errors.add(:open_transfer, 'must close open transfer on the work before creating a new one') unless transfers.blank? || (transfers.count == 1 && transfers[0].id == id)
   end
 
@@ -80,11 +80,11 @@ class ProxyDepositRequest < ActiveRecord::Base
   end
 
   def deleted_work?
-    !GenericWork.exists?(generic_work_id)
+    !GenericWork.exists?(work_id)
   end
 
   def generic_work
-    @generic_work ||= GenericWork.find(generic_work_id)
+    @generic_work ||= GenericWork.find(work_id)
   end
 
   # Delegate to the SolrDocument of the work
@@ -102,6 +102,6 @@ class ProxyDepositRequest < ActiveRecord::Base
     end
 
     def query
-      ActiveFedora::SolrQueryBuilder.construct_query_for_ids([generic_work_id])
+      ActiveFedora::SolrQueryBuilder.construct_query_for_ids([work_id])
     end
 end

--- a/app/presenters/sufia/work_show_presenter.rb
+++ b/app/presenters/sufia/work_show_presenter.rb
@@ -41,7 +41,7 @@ module Sufia
 
       def featured?
         if @featured.nil?
-          @featured = FeaturedWork.where(generic_work_id: solr_document.id).exists?
+          @featured = FeaturedWork.where(work_id: solr_document.id).exists?
         end
         @featured
       end

--- a/app/search_builders/sufia/search_builder.rb
+++ b/app/search_builders/sufia/search_builder.rb
@@ -33,7 +33,7 @@ class Sufia::SearchBuilder < Blacklight::SearchBuilder
   end
 
   def show_only_highlighted_works(solr_parameters)
-    ids = scope.current_user.trophies.pluck(:generic_work_id)
+    ids = scope.current_user.trophies.pluck(:work_id)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += [
       ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)

--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -78,7 +78,7 @@ module Sufia
       end
     end
 
-    def inject_sufia_generic_work_behavior
+    def inject_sufia_work_behavior
       insert_into_file 'app/models/generic_work.rb', after: 'include ::CurationConcerns::BasicMetadata' do
         "\n  include Sufia::WorkBehavior" \
         "\n  self.human_readable_type = 'Work'"

--- a/lib/generators/sufia/templates/migrations/change_featured_work_generic_file_id_to_generic_work_id.rb
+++ b/lib/generators/sufia/templates/migrations/change_featured_work_generic_file_id_to_generic_work_id.rb
@@ -1,6 +1,0 @@
-class ChangeFeaturedWorkGenericFileIdToGenericWorkId < ActiveRecord::Migration
-  def change
-    return unless column_exists?(:featured_works, :generic_file_id)
-    rename_column :featured_works, :generic_file_id, :generic_work_id
-  end
-end

--- a/lib/generators/sufia/templates/migrations/change_featured_work_generic_file_id_to_work_id.rb
+++ b/lib/generators/sufia/templates/migrations/change_featured_work_generic_file_id_to_work_id.rb
@@ -1,0 +1,6 @@
+class ChangeFeaturedWorkGenericFileIdToWorkId < ActiveRecord::Migration
+  def change
+    return unless column_exists?(:featured_works, :generic_file_id)
+    rename_column :featured_works, :generic_file_id, :work_id
+  end
+end

--- a/lib/generators/sufia/templates/migrations/change_proxy_deposit_generic_file_id_to_generic_work_id.rb
+++ b/lib/generators/sufia/templates/migrations/change_proxy_deposit_generic_file_id_to_generic_work_id.rb
@@ -1,5 +1,0 @@
-class ChangeProxyDepositGenericFileIdToGenericWorkId < ActiveRecord::Migration
-  def change
-    rename_column :proxy_deposit_requests, :generic_file_id, :generic_work_id
-  end
-end

--- a/lib/generators/sufia/templates/migrations/change_proxy_deposit_generic_file_id_to_work_id.rb
+++ b/lib/generators/sufia/templates/migrations/change_proxy_deposit_generic_file_id_to_work_id.rb
@@ -1,0 +1,5 @@
+class ChangeProxyDepositGenericFileIdToWorkId < ActiveRecord::Migration
+  def change
+    rename_column :proxy_deposit_requests, :generic_file_id, :work_id
+  end
+end

--- a/lib/generators/sufia/templates/migrations/change_proxy_deposit_request_generic_file_id_to_generic_work_id.rb
+++ b/lib/generators/sufia/templates/migrations/change_proxy_deposit_request_generic_file_id_to_generic_work_id.rb
@@ -1,5 +1,0 @@
-class ChangeProxyDepositRequestGenericFileIdToGenericWorkId < ActiveRecord::Migration
-  def change
-    rename_column :proxy_deposit_requests, :generic_file_id, :generic_work_id if ProxyDepositRequest.column_names.include?('generic_file_id')
-  end
-end

--- a/lib/generators/sufia/templates/migrations/change_proxy_deposit_request_generic_file_id_to_work_id.rb
+++ b/lib/generators/sufia/templates/migrations/change_proxy_deposit_request_generic_file_id_to_work_id.rb
@@ -1,0 +1,5 @@
+class ChangeProxyDepositRequestGenericFileIdToWorkId < ActiveRecord::Migration
+  def change
+    rename_column :proxy_deposit_requests, :generic_file_id, :generic_id if ProxyDepositRequest.column_names.include?('generic_file_id')
+  end
+end

--- a/lib/generators/sufia/templates/migrations/change_trophy_generic_file_id_to_generic_work_id.rb
+++ b/lib/generators/sufia/templates/migrations/change_trophy_generic_file_id_to_generic_work_id.rb
@@ -1,5 +1,0 @@
-class ChangeTrophyGenericFileIdToGenericWorkId < ActiveRecord::Migration
-  def change
-    rename_column :trophies, :generic_file_id, :generic_work_id
-  end
-end

--- a/lib/generators/sufia/templates/migrations/change_trophy_generic_file_id_to_work_id.rb
+++ b/lib/generators/sufia/templates/migrations/change_trophy_generic_file_id_to_work_id.rb
@@ -1,0 +1,5 @@
+class ChangeTrophyGenericFileIdToWorkId < ActiveRecord::Migration
+  def change
+    rename_column :trophies, :generic_file_id, :work_id
+  end
+end

--- a/lib/generators/sufia/templates/migrations/create_featured_works.rb
+++ b/lib/generators/sufia/templates/migrations/create_featured_works.rb
@@ -2,11 +2,11 @@ class CreateFeaturedWorks < ActiveRecord::Migration
   def change
     create_table :featured_works do |t|
       t.integer :order, default: 5
-      t.string :generic_work_id
+      t.string :work_id
 
       t.timestamps null: false
     end
-    add_index :featured_works, :generic_work_id
+    add_index :featured_works, :work_id
     add_index :featured_works, :order
   end
 end

--- a/lib/generators/sufia/upgrade700_generator.rb
+++ b/lib/generators/sufia/upgrade700_generator.rb
@@ -24,11 +24,11 @@ This generator for upgrading sufia from 6.0.0 to 7.0 makes the following changes
   # Setup the database migrations
   def copy_migrations
     [
-      'change_trophy_generic_file_id_to_generic_work_id.rb',
-      'change_proxy_deposit_generic_file_id_to_generic_work_id.rb',
+      'change_trophy_generic_file_id_to_work_id.rb',
+      'change_proxy_deposit_generic_file_id_to_work_id.rb',
       'change_audit_log_generic_file_id_to_file_set_id.rb',
-      'change_proxy_deposit_request_generic_file_id_to_generic_work_id.rb',
-      'change_featured_work_generic_file_id_to_generic_work_id.rb'
+      'change_proxy_deposit_request_generic_file_id_to_work_id.rb',
+      'change_featured_work_generic_file_id_to_work_id.rb'
     ].each do |file|
       better_migration_template file
     end

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -47,7 +47,7 @@ describe DashboardController, type: :controller do
           get :index
           expect(response).to be_success
           expect(assigns[:incoming].first).to be_kind_of ProxyDepositRequest
-          expect(assigns[:incoming].first.generic_work_id).to eq(incoming_work.id)
+          expect(assigns[:incoming].first.work_id).to eq(incoming_work.id)
         end
       end
 
@@ -64,7 +64,7 @@ describe DashboardController, type: :controller do
           get :index
           expect(response).to be_success
           expect(assigns[:outgoing].first).to be_kind_of ProxyDepositRequest
-          expect(assigns[:outgoing].first.generic_work_id).to eq(outgoing_work.id)
+          expect(assigns[:outgoing].first.work_id).to eq(outgoing_work.id)
         end
       end
     end

--- a/spec/controllers/featured_works_controller_spec.rb
+++ b/spec/controllers/featured_works_controller_spec.rb
@@ -19,7 +19,7 @@ describe FeaturedWorksController, type: :controller do
     context "when there are 5 featured works" do
       before do
         5.times do |n|
-          FeaturedWork.create(generic_work_id: n.to_s)
+          FeaturedWork.create(work_id: n.to_s)
         end
       end
       it "does not create another" do
@@ -32,7 +32,7 @@ describe FeaturedWorksController, type: :controller do
   end
 
   describe "#destroy" do
-    let!(:featured_work) { FactoryGirl.create(:featured_work, generic_work_id: '1234abcd') }
+    let!(:featured_work) { FactoryGirl.create(:featured_work, work_id: '1234abcd') }
 
     before do
       sign_in FactoryGirl.create(:user)

--- a/spec/controllers/homepage_controller_spec.rb
+++ b/spec/controllers/homepage_controller_spec.rb
@@ -83,7 +83,7 @@ describe Sufia::HomepageController, type: :controller do
       let!(:my_work) { FactoryGirl.create(:work, user: user) }
 
       before do
-        FeaturedWork.create!(generic_work_id: my_work.id)
+        FeaturedWork.create!(work_id: my_work.id)
       end
 
       it "sets featured works" do

--- a/spec/controllers/my/highlights_controller_spec.rb
+++ b/spec/controllers/my/highlights_controller_spec.rb
@@ -10,7 +10,7 @@ describe My::HighlightsController, type: :controller do
         GenericWork.destroy_all
         Collection.destroy_all
         @highlighted_work = create(:generic_work, user: user)
-        user.trophies.create(generic_work_id: @highlighted_work.id)
+        user.trophies.create(work_id: @highlighted_work.id)
 
         @normal_work = create(:generic_work, user: user)
         other_user = create(:user)
@@ -18,14 +18,14 @@ describe My::HighlightsController, type: :controller do
           r.edit_users += [user.user_key]
           r.save!
         end
-        other_user.trophies.create(generic_work_id: @unrelated_highlighted_work.id)
+        other_user.trophies.create(work_id: @unrelated_highlighted_work.id)
       end
 
       it "paginates" do
         work1 = create(:work, user: user)
         work2 = create(:work, user: user)
-        user.trophies.create!(generic_work_id: work1.id)
-        user.trophies.create!(generic_work_id: work2.id)
+        user.trophies.create!(work_id: work1.id)
+        user.trophies.create!(work_id: work2.id)
         get :index, per_page: 2
         expect(assigns[:document_list].length).to eq 2
         get :index, per_page: 2, page: 2

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -29,9 +29,9 @@ describe TransfersController, type: :controller do
         get :index
         expect(response).to be_success
         expect(assigns[:incoming].first).to be_kind_of ProxyDepositRequest
-        expect(assigns[:incoming].first.generic_work_id).to eq(incoming_work.id)
+        expect(assigns[:incoming].first.work_id).to eq(incoming_work.id)
         expect(assigns[:outgoing].first).to be_kind_of ProxyDepositRequest
-        expect(assigns[:outgoing].first.generic_work_id).to eq(outgoing_work.id)
+        expect(assigns[:outgoing].first.work_id).to eq(outgoing_work.id)
       end
 
       describe "When the incoming request is for a deleted work" do
@@ -59,7 +59,7 @@ describe TransfersController, type: :controller do
           expect(response).to be_success
           expect(assigns[:generic_work]).to eq(work)
           expect(assigns[:proxy_deposit_request]).to be_kind_of ProxyDepositRequest
-          expect(assigns[:proxy_deposit_request].generic_work_id).to eq(work.id)
+          expect(assigns[:proxy_deposit_request].work_id).to eq(work.id)
         end
       end
     end
@@ -78,7 +78,7 @@ describe TransfersController, type: :controller do
         expect(response).to redirect_to @routes.url_helpers.transfers_path
         expect(flash[:notice]).to eq('Transfer request created')
         proxy_request = another_user.proxy_deposit_requests.first
-        expect(proxy_request.generic_work_id).to eq(work.id)
+        expect(proxy_request.work_id).to eq(work.id)
         expect(proxy_request.sending_user).to eq(user)
         # AND A NOTIFICATION SHOULD HAVE BEEN CREATED
         notification = another_user.reload.mailbox.inbox[0].messages[0]

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -25,10 +25,10 @@ describe UsersController, type: :controller do
       let(:work1) { GenericWork.create(title: ["w1"]) { |w| w.apply_depositor_metadata(user) } }
       let(:work2) { GenericWork.create(title: ["w2"]) { |w| w.apply_depositor_metadata(user) } }
       let(:work3) { GenericWork.create(title: ["w3"]) { |w| w.apply_depositor_metadata(user) } }
-      let!(:trophy1) { user.trophies.create!(generic_work_id: work1.id) }
-      let!(:trophy2) { user.trophies.create!(generic_work_id: work2.id) }
-      let!(:trophy3) { user.trophies.create!(generic_work_id: work3.id) }
-      let!(:badtrophy) { user.trophies.create!(generic_work_id: 'not_a_generic_work') }
+      let!(:trophy1) { user.trophies.create!(work_id: work1.id) }
+      let!(:trophy2) { user.trophies.create!(work_id: work2.id) }
+      let!(:trophy3) { user.trophies.create!(work_id: work3.id) }
+      let!(:badtrophy) { user.trophies.create!(work_id: 'not_a_generic_work') }
 
       it "show the user profile if user exists" do
         get :show, id: user.user_key
@@ -128,9 +128,9 @@ describe UsersController, type: :controller do
       let(:work1) { GenericWork.create(title: ["w1"]) { |w| w.apply_depositor_metadata(user) } }
       let(:work2) { GenericWork.create(title: ["w2"]) { |w| w.apply_depositor_metadata(user) } }
       let(:work3) { GenericWork.create(title: ["w3"]) { |w| w.apply_depositor_metadata(user) } }
-      let!(:trophy1) { user.trophies.create!(generic_work_id: work1.id) }
-      let!(:trophy2) { user.trophies.create!(generic_work_id: work2.id) }
-      let!(:trophy3) { user.trophies.create!(generic_work_id: work3.id) }
+      let!(:trophy1) { user.trophies.create!(work_id: work1.id) }
+      let!(:trophy2) { user.trophies.create!(work_id: work2.id) }
+      let!(:trophy3) { user.trophies.create!(work_id: work3.id) }
 
       it "show the user profile if user exists" do
         get :edit, id: user.user_key
@@ -224,7 +224,7 @@ describe UsersController, type: :controller do
     context "when removing a trophy" do
       let(:work) { GenericWork.create(title: ["w1"]) { |w| w.apply_depositor_metadata(user) } }
       before do
-        user.trophies.create!(generic_work_id: work.id)
+        user.trophies.create!(work_id: work.id)
       end
       it "removes a trophy" do
         expect {
@@ -293,7 +293,7 @@ describe UsersController, type: :controller do
       post :toggle_trophy, id: user.user_key, work_id: work_id
       json = JSON.parse(response.body)
       expect(json['user_id']).to eq user.id
-      expect(json['generic_work_id']).to eq work_id
+      expect(json['work_id']).to eq work_id
     end
     it "does not trophy a work for a different user" do
       post :toggle_trophy, id: another_user.user_key, work_id: work_id

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -11,7 +11,7 @@ describe SufiaHelper, type: :helper do
     end
 
     context "when work is canceled" do
-      let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: user, sending_user: sender, status: 'canceled') }
+      let(:request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: sender, status: 'canceled') }
       subject { helper.show_transfer_request_title request }
       it { expect(subject).to eq 'Test work' }
     end

--- a/spec/helpers/trophy_helper_spec.rb
+++ b/spec/helpers/trophy_helper_spec.rb
@@ -19,7 +19,7 @@ describe TrophyHelper, type: :helper do
 
     context "when there is a trophy" do
       before do
-        user.trophies.create(generic_work_id: id)
+        user.trophies.create(work_id: id)
       end
 
       it "has a link for highlighting" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -62,13 +62,13 @@ describe Sufia::Ability, type: :model do
     end
 
     context "with a ProxyDepositRequest that they receive" do
-      let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: user, sending_user: sender) }
+      let(:request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: sender) }
       it { should be_able_to(:accept, request) }
       it { should be_able_to(:reject, request) }
       it { should_not be_able_to(:destroy, request) }
 
       context "and the request has already been accepted" do
-        let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: user, sending_user: sender, status: 'accepted') }
+        let(:request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: sender, status: 'accepted') }
         it { should_not be_able_to(:accept, request) }
         it { should_not be_able_to(:reject, request) }
         it { should_not be_able_to(:destroy, request) }
@@ -76,13 +76,13 @@ describe Sufia::Ability, type: :model do
     end
 
     context "with a ProxyDepositRequest they are the sender of" do
-      let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: sender, sending_user: user) }
+      let(:request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: sender, sending_user: user) }
       it { should_not be_able_to(:accept, request) }
       it { should_not be_able_to(:reject, request) }
       it { should be_able_to(:destroy, request) }
 
       context "and the request has already been accepted" do
-        let(:request) { ProxyDepositRequest.create!(generic_work_id: work.id, receiving_user: sender, sending_user: user, status: 'accepted') }
+        let(:request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: sender, sending_user: user, status: 'accepted') }
         it { should_not be_able_to(:accept, request) }
         it { should_not be_able_to(:reject, request) }
         it { should_not be_able_to(:destroy, request) }

--- a/spec/models/featured_work_list_spec.rb
+++ b/spec/models/featured_work_list_spec.rb
@@ -6,8 +6,8 @@ describe FeaturedWorkList, type: :model do
 
   describe 'featured_works' do
     before do
-      create(:featured_work, generic_work_id: work1.id)
-      create(:featured_work, generic_work_id: work2.id)
+      create(:featured_work, work_id: work1.id)
+      create(:featured_work, work_id: work2.id)
     end
 
     it 'is a list of the featured work objects, each with the generic_work\'s solr_doc' do
@@ -20,8 +20,8 @@ describe FeaturedWorkList, type: :model do
 
   describe 'file deleted' do
     before do
-      create(:featured_work, generic_work_id: work1.id)
-      create(:featured_work, generic_work_id: work2.id)
+      create(:featured_work, work_id: work1.id)
+      create(:featured_work, work_id: work2.id)
       work1.destroy
     end
 
@@ -36,7 +36,7 @@ describe FeaturedWorkList, type: :model do
   describe '#empty?' do
     context "when there are featured works" do
       before do
-        create(:featured_work, generic_work_id: work1.id)
+        create(:featured_work, work_id: work1.id)
       end
       it { is_expected.not_to be_empty }
     end

--- a/spec/models/featured_work_spec.rb
+++ b/spec/models/featured_work_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
 describe FeaturedWork, type: :model do
-  let(:feature) { described_class.create(generic_work_id: "99") }
+  let(:feature) { described_class.create(work_id: "99") }
 
   it "has a file" do
-    expect(feature.generic_work_id).to eq "99"
+    expect(feature.work_id).to eq "99"
   end
 
   it "does not allow six features" do
     5.times do |n|
-      expect(described_class.create(generic_work_id: n.to_s)).to_not be_new_record
+      expect(described_class.create(work_id: n.to_s)).to_not be_new_record
     end
-    described_class.create(generic_work_id: "6").tap do |sixth|
+    described_class.create(work_id: "6").tap do |sixth|
       expect(sixth).to be_new_record
       expect(sixth.errors.full_messages).to eq ["Limited to 5 featured works."]
     end
@@ -29,7 +29,7 @@ describe FeaturedWork, type: :model do
     context "when five exist" do
       before do
         5.times do |n|
-          described_class.create(generic_work_id: n.to_s)
+          described_class.create(work_id: n.to_s)
         end
       end
 

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -43,14 +43,14 @@ describe GenericWork do
       @w = described_class.create!(title: ['demoname']) do |gw|
         gw.apply_depositor_metadata(u)
       end
-      @t = Trophy.create(user_id: u.id, generic_work_id: @w.id)
+      @t = Trophy.create(user_id: u.id, work_id: @w.id)
     end
     it "has a trophy" do
-      expect(Trophy.where(generic_work_id: @w.id).count).to eq 1
+      expect(Trophy.where(work_id: @w.id).count).to eq 1
     end
     it "removes all trophies when work is deleted" do
       @w.destroy
-      expect(Trophy.where(generic_work_id: @w.id).count).to eq 0
+      expect(Trophy.where(work_id: @w.id).count).to eq 0
     end
   end
 

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -5,7 +5,7 @@ describe ProxyDepositRequest, type: :model do
   let(:receiver) { create(:user) }
   let(:receiver2) { create(:user) }
   let(:work) do
-    GenericWork.new.tap do |w|
+    GenericWork.new do |w|
       w.title = ["Test work"]
       w.apply_depositor_metadata(sender.user_key)
       w.save!
@@ -13,7 +13,7 @@ describe ProxyDepositRequest, type: :model do
   end
 
   subject do
-    described_class.new(generic_work_id: work.id, sending_user: sender,
+    described_class.new(work_id: work.id, sending_user: sender,
                         receiving_user: receiver, sender_comment: "please take this")
   end
 
@@ -88,7 +88,7 @@ describe ProxyDepositRequest, type: :model do
         subject.transfer_to = receiver.user_key
         subject.save!
         proxy_request = receiver.proxy_deposit_requests.first
-        expect(proxy_request.generic_work_id).to eq(work.id)
+        expect(proxy_request.work_id).to eq(work.id)
         expect(proxy_request.sending_user).to eq(sender)
       end
     end
@@ -102,7 +102,7 @@ describe ProxyDepositRequest, type: :model do
     end
 
     context 'when the work is already being transferred' do
-      let(:subject2) { described_class.new(generic_work_id: work.id, sending_user: sender, receiving_user: receiver2, sender_comment: 'please take this') }
+      let(:subject2) { described_class.new(work_id: work.id, sending_user: sender, receiving_user: receiver2, sender_comment: 'please take this') }
 
       it 'raises an error' do
         subject.save!

--- a/spec/models/trophy_spec.rb
+++ b/spec/models/trophy_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Trophy, type: :model do
   before(:all) do
-    @trophy = described_class.create(user_id: 99, generic_work_id: "99")
+    @trophy = described_class.create(user_id: 99, work_id: "99")
   end
 
   it "has a user" do
@@ -11,12 +11,12 @@ describe Trophy, type: :model do
   end
 
   it "has a work" do
-    expect(@trophy).to respond_to(:generic_work_id)
-    expect(@trophy.generic_work_id).to eq("99")
+    expect(@trophy).to respond_to(:work_id)
+    expect(@trophy.work_id).to eq("99")
   end
 
   it "does not allow six trophies" do
-    (1..6).each { |n| described_class.create(user_id: 120, generic_work_id: n.to_s) }
+    (1..6).each { |n| described_class.create(user_id: 120, work_id: n.to_s) }
     expect(described_class.where(user_id: 120).count).to eq(5)
     described_class.where(user_id: 120).map(&:delete)
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -122,9 +122,9 @@ describe User, type: :model do
     let(:work1) { GenericWork.create(title: ["work A"]) { |w| w.apply_depositor_metadata(user) } }
     let(:work2) { GenericWork.create(title: ["work B"]) { |w| w.apply_depositor_metadata(user) } }
     let(:work3) { GenericWork.create(title: ["work C"]) { |w| w.apply_depositor_metadata(user) } }
-    let!(:trophy1) { user.trophies.create!(generic_work_id: work1.id) }
-    let!(:trophy2) { user.trophies.create!(generic_work_id: work2.id) }
-    let!(:trophy3) { user.trophies.create!(generic_work_id: work3.id) }
+    let!(:trophy1) { user.trophies.create!(work_id: work1.id) }
+    let!(:trophy2) { user.trophies.create!(work_id: work2.id) }
+    let!(:trophy3) { user.trophies.create!(work_id: work3.id) }
 
     it "returns a list of generic works" do
       expect(user.trophy_works).to eq [work1, work2, work3]

--- a/spec/presenters/sufia/work_show_presenter_spec.rb
+++ b/spec/presenters/sufia/work_show_presenter_spec.rb
@@ -48,7 +48,7 @@ describe Sufia::WorkShowPresenter do
     end
 
     context 'with a featured work' do
-      before { FeaturedWork.create(generic_work_id: work.id) }
+      before { FeaturedWork.create(work_id: work.id) }
       it 'can unfeature the work' do
         expect(presenter.display_feature_link?).to be false
         expect(presenter.display_unfeature_link?).to be true

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -9,14 +9,14 @@ describe "Rake tasks" do
       load_rake_environment [File.expand_path("../../../tasks/migrate.rake", __FILE__)]
     end
 
-    describe "deleting the namespace from ProxyDepositRequest#generic_work_id" do
+    describe "deleting the namespace from ProxyDepositRequest#work_id" do
       let(:sender) { create(:user) }
       let(:receiver) { create(:user) }
       before do
-        ProxyDepositRequest.create(generic_work_id: namespaced_id, sending_user: sender, receiving_user: receiver, sender_comment: "please take this")
+        ProxyDepositRequest.create(work_id: namespaced_id, sending_user: sender, receiving_user: receiver, sender_comment: "please take this")
         run_task "sufia:migrate:proxy_deposits"
       end
-      subject { ProxyDepositRequest.first.generic_work_id }
+      subject { ProxyDepositRequest.first.work_id }
       it { is_expected.to eql corrected_id }
     end
 

--- a/tasks/migrate.rake
+++ b/tasks/migrate.rake
@@ -4,7 +4,7 @@
     desc "Migrate proxy deposits"
     task proxy_deposits: :environment do
       ProxyDepositRequest.all.each do |pd|
-        pd.generic_work_id = pd.generic_work_id.delete "#{Sufia.config.redis_namespace}:"
+        pd.work_id = pd.work_id.delete "#{Sufia.config.redis_namespace}:"
         pd.save
       end
     end
@@ -16,6 +16,5 @@
         cs.save
       end
     end
-
   end
 end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

This will position us to be able to use more work types (besides
`GenericWork`) in the future