### PR TITLE
Updated collection title and description to handle multiple

### DIFF
--- a/app/views/collections/_collection_description.erb
+++ b/app/views/collections/_collection_description.erb
@@ -1,0 +1,3 @@
+<% presenter.description.each do |description| %>
+    <p class="collection_description"><%= description %></p>
+<% end %>

--- a/app/views/collections/_collection_title.erb
+++ b/app/views/collections/_collection_title.erb
@@ -1,0 +1,7 @@
+<% presenter.title.each_with_index do |title, index| %>
+    <% if index == 0 %>
+        <h1><%= title %> <%= presenter.permission_badge %></h1>
+    <% else %>
+        <h1><%= title %></h1>
+    <% end %>
+<% end %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,11 +1,11 @@
 <% provide :page_title, construct_page_title(@presenter.title) %>
-
   <div itemscope itemtype="http://schema.org/CollectionPage" class="row">
     <div class="col-sm-10 pull-right">
       <header>
-        <h1><%= @presenter.title %> <%= @presenter.permission_badge %></h1>
-        <p class="collection_description"><%= @presenter.description %></p>
+        <%= render 'collection_title', presenter: @presenter %>
       </header>
+      <%= render 'collection_description', presenter: @presenter %>
+
       <% unless has_collection_search_parameters? %>
       <%= render 'collections/show_descriptions' %>
       <% end %>

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -228,7 +228,7 @@ describe 'collection', type: :feature do
       expect(header).not_to have_content(collection.title.first)
       expect(header).not_to have_content(collection.description.first)
       expect(header).to have_content(new_title)
-      expect(header).to have_content(new_description)
+      expect(page).to have_content(new_description)
       expect(page).to have_content(creators.first)
     end
   end


### PR DESCRIPTION
Fixes #2020

Updates Collection show page to display multiple titles and descriptions.

Changes proposed in this pull request:
* Added `render` to show page
* New title partial
* New description partial

@projecthydra/sufia-code-reviewers

…ike works.