### PR TITLE
Disable turbolink for admin users to side-step TinyMCE issue

### DIFF
--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,8 +1,8 @@
 <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container-fluid">
     <ul class="nav navbar-nav col-sm-5 col-md-6">
-      <li <%= 'class=active' if current_page?(sufia.root_path) %>><a href="<%= sufia.root_path %>">Home</a></li>
-      <li <%= 'class=active' if current_page?(sufia.about_path) %>><a href="<%= sufia.about_path %>">About</a></li>
+      <li <%= 'class=active' if current_page?(sufia.root_path) %>><%= link_to 'Home', sufia.root_path, :'data-no-turbolink'=>"true" %></li>
+      <li <%= 'class=active' if current_page?(sufia.about_path) %>><%= link_to 'About', sufia.about_path, :'data-no-turbolink'=>"true" %></li>
       <li <%= 'class=active' if action_name == "help" %>><a href="<%= sufia.static_path('help') %>">Help</a></li>
       <li <%= 'class=active' if current_page?(sufia.contact_path) %>><a href="<%= sufia.contact_path %>">Contact</a></li>
     </ul><!-- /.nav -->

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,4 +1,4 @@
-<a id="logo" class="navbar-brand" href="<%= sufia.root_path %>">
+<a id="logo" class="navbar-brand" href="<%= sufia.root_path %>" data-no-turbolink="true">
   <span class="glyphicon glyphicon-globe"></span>
   <span class="institution_name"><%=application_name %></span>
 </a>


### PR DESCRIPTION
Fixes #379

Disables turbolinks when user is an admin. This is to workaround a bug in TinyMCE editor.

@projecthydra/sufia-code-reviewers

