### PR TITLE
Removing group and login from profile update

### DIFF
--- a/app/controllers/concerns/sufia/users_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/users_controller_behavior.rb
@@ -106,9 +106,9 @@ module Sufia::UsersControllerBehavior
   protected
 
     def user_params
-      params.require(:user).permit(:email, :login, :display_name, :address, :admin_area,
+      params.require(:user).permit(:display_name, :address, :admin_area,
                                    :department, :title, :office, :chat_id, :website, :affiliation,
-                                   :telephone, :avatar, :group_list, :groups_last_update, :facebook_handle,
+                                   :telephone, :avatar, :facebook_handle,
                                    :twitter_handle, :googleplus_handle, :linkedin_handle, :remove_avatar, :orcid)
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -220,6 +220,19 @@ describe UsersController, type: :controller do
       expect(u.orcid).to eq 'http://orcid.org/0000-0000-1111-2222'
     end
 
+    it "does not allow groups to be set" do
+      user.group_list = 'private group'
+      user.save
+      post :update, id: user.user_key, user: { group_list: ['my group'] }
+      expect(user.reload.group_list).to eq 'private group'
+    end
+
+    it "does not allow email to be set" do
+      original_email = user.email
+      post :update, id: user.user_key, user: { email: ['myemail.email.com'] }
+      expect(user.reload.email).to eq original_email
+    end
+
     it 'displays a flash when invalid ORCID is entered' do
       expect(user.orcid).to be_blank
       post :update, id: user.user_key, user: { orcid: 'foobar' }


### PR DESCRIPTION
Only permit bulk update of attributes on the user form