### PR TITLE
importing form style from cc, using it and deleting duplicate styles

### DIFF
--- a/app/assets/stylesheets/sufia/_collections.scss
+++ b/app/assets/stylesheets/sufia/_collections.scss
@@ -79,7 +79,6 @@ form.per_page {
     padding-left: 0;
   }
 }
-
-.collection_form_visibility .form-group {
-  padding-left: 25px;
+.presenter-title {
+    padding-left: 20px;
 }

--- a/app/assets/stylesheets/sufia/_file_sets.scss
+++ b/app/assets/stylesheets/sufia/_file_sets.scss
@@ -45,28 +45,6 @@ table.files td.preview img {
     height: 50px;
 }
 
-/* From curation_concerns */
-#set-access-controls {
-  label { font-weight: normal; }
-  & > .form-group { padding: 0 1.75em; }
-
-  .form-inline {
-    .control-label, label {
-      padding-left: 0;
-      display: inline;
-      &:after {
-        content: ' ';
-      }
-    }
-    .help-block {
-      display: inline;
-      &:before {
-        content: ' ';
-      }
-    }
-  }
-}
-
 .edit_file_set_previous_version {
   margin-top: 3em;
 }

--- a/app/assets/stylesheets/sufia/_form-progress.scss
+++ b/app/assets/stylesheets/sufia/_form-progress.scss
@@ -29,32 +29,10 @@ aside.form-progress {
     padding-right: 5px;
   }
 
-  .visibility {
-    padding-left: 20px;
-  }
-
   h3 {
     margin: 0;
     padding: 5px;
     font-size: 12pt;
   }
 
-  label { font-weight: normal; }
-  & > .form-group { padding: 0 1.75em; }
-
-  .form-inline {
-    .control-label, label {
-      padding-left: 0;
-      display: inline;
-      &:after {
-        content: ' ';
-      }
-    }
-    .help-block {
-      display: inline;
-      &:before {
-        content: ' ';
-      }
-    }
-  }
 }

--- a/app/assets/stylesheets/sufia/_sufia.scss
+++ b/app/assets/stylesheets/sufia/_sufia.scss
@@ -1,5 +1,5 @@
 @import 'hydra-editor/multi_value_fields';
-
+@import 'curation_concerns/modules/forms';
 @import 'sufia/file_sets';
 @import 'sufia/settings', 'sufia/header', 'sufia/styles', 'sufia/file-listing',
         'sufia/browse_everything_overrides', 'sufia/nestable',

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -11,7 +11,7 @@
       </ul>
     </div>
 
-    <div class="list-group-item">
+    <div class="set-access-controls list-group-item">
       <%= render 'form_visibility_component', f: f %>
     </div>
     <% unless current_user.can_make_deposits_for.empty? %>

--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -7,7 +7,7 @@
       <%= render 'show_actions', presenter: @presenter, parent: parent %>
     </div>
     <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
-      <h1 class="visibility"><%= @presenter.title %> <%= render_visibility_badge @presenter %></h1>
+      <h1 class="presenter-title"><%= @presenter.title %> <%= render_visibility_badge @presenter %></h1>
       <p class="genericfile_description"><%= display_multiple @presenter.description %></p>
       <%# TODO: render 'show_descriptions' See https://github.com/projecthydra/sufia/issues/1481 %>
       <%= render 'show_details' %>


### PR DESCRIPTION
Fixes #1987 ; refs #1987

Cleaning up tech debt of duplicating styles.

This PR removes a style copied directly from Curation Concerns and a few others that are used to achieve the position of radio buttons in the visibility forms. It replaces these things by @importing the forms.scss module from CC and applying it in the html. This PR depends on a CC PR which changes the style that gets imported slightly to be more inclusive (from an id to a class on set-access-controls, and from the application to the first direct child to any child with a class of .form-group). 


Changes proposed in this pull request:
-use .set-access-controls & .form-group by importing from CC
- delete styles in Sufia that duplicate the one in CC and tagged as tech-debt 
- use @imported classes in html  


@projecthydra/sufia-code-reviewers