### PR TITLE
Adds method iconify_auto_link to descriptions Works/Collections

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -98,7 +98,7 @@ module Sufia
       # this block is only executed when a link is inserted;
       # if we pass text containing no links, it just returns text.
       auto_link(html_escape(text)) do |value|
-        "<i class='glyphicon glyphicon-new-window'></i>#{('&nbsp;' + value) if showLink}<br />"
+        "<span class='glyphicon glyphicon-new-window'></span>#{('&nbsp;' + value) if showLink}"
       end
     end
 

--- a/app/views/collections/_collection_description.erb
+++ b/app/views/collections/_collection_description.erb
@@ -1,3 +1,3 @@
 <% presenter.description.each do |description| %>
-    <p class="collection_description"><%= description %></p>
+    <p class="collection_description"><%= iconify_auto_link(description) %></p>
 <% end %>

--- a/app/views/curation_concerns/base/_work_description.erb
+++ b/app/views/curation_concerns/base/_work_description.erb
@@ -1,3 +1,3 @@
 <% presenter.description.each do |description| %>
-    <p class="work_description"><%= description %></p>
+    <p class="work_description"><%= iconify_auto_link(description) %></p>
 <% end %>

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -27,7 +27,7 @@ describe 'catalog/_index_list_default' do
     expect(rendered).to include '<span class="attribute-label h4">Creator:</span>'
     expect(rendered).to include '<span itemprop="creator">Justin</span> and <span itemprop="creator">Joe</span>'
     expect(rendered).to include '<span class="attribute-label h4">Description:</span>'
-    expect(rendered).to include '<span itemprop="description">This links to <a href="http://example.com/"><i class="glyphicon glyphicon-new-window"></i> http://example.com/<br></a> What about that?</span>'
+    expect(rendered).to include '<span itemprop="description">This links to <a href="http://example.com/"><span class="glyphicon glyphicon-new-window"></span> http://example.com/</a> What about that?</span>'
     expect(rendered).to include '<span class="attribute-label h4">Date Uploaded:</span>'
     expect(rendered).to include '<span itemprop="datePublished">03/14/2013</span>'
     expect(rendered).to include '<span class="attribute-label h4">Depositor:</span>'


### PR DESCRIPTION
Fixes #2042 

Adds iconify_auto_link method back to Works and Collections descriptions, so that links become clickable when added. Also removes `<br />` from method since metadata is styled semantically.

Changes proposed in this pull request:
* Add iconify_auto_link method
* removes `<br />` from method

@projecthydra/sufia-code-reviewers
