### PR TITLE
Delegate collection identifier to solr document

### DIFF
--- a/app/presenters/sufia/collection_presenter.rb
+++ b/app/presenters/sufia/collection_presenter.rb
@@ -1,6 +1,6 @@
 module Sufia
   class CollectionPresenter < CurationConcerns::CollectionPresenter
-    delegate :resource_type, :based_near, :related_url, to: :solr_document
+    delegate :resource_type, :based_near, :related_url, :identifier, to: :solr_document
 
     # Terms is the list of fields displayed by app/views/collections/_show_descriptions.html.erb
     def self.terms

--- a/spec/presenters/sufia/collection_presenter_spec.rb
+++ b/spec/presenters/sufia/collection_presenter_spec.rb
@@ -58,4 +58,9 @@ describe Sufia::CollectionPresenter do
     subject { presenter.total_items }
     it { is_expected.to eq 0 }
   end
+
+  describe "#identifier" do
+    subject { presenter.identifier }
+    it { is_expected.to be_nil }
+  end
 end


### PR DESCRIPTION
Collections cannot be viewed if they have an identifier because that property isn't delegated to the solr document.

@projecthydra/sufia-code-reviewers

