### PR TITLE
Breadcrumbs work for Collections and Works

### DIFF
--- a/app/controllers/concerns/sufia/collections_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/collections_controller_behavior.rb
@@ -1,10 +1,9 @@
 module Sufia
   module CollectionsControllerBehavior
     extend ActiveSupport::Concern
+    include Sufia::Breadcrumbs
 
     included do
-      include Sufia::Breadcrumbs
-
       before_action :has_access?, except: :show
       before_action :build_breadcrumbs, only: [:edit, :show]
       layout "sufia-one-column"
@@ -13,5 +12,20 @@ module Sufia
       self.presenter_class = Sufia::CollectionPresenter
       self.form_class = Sufia::Forms::CollectionForm
     end
+
+    protected
+
+      def add_breadcrumb_for_controller
+        add_breadcrumb I18n.t('sufia.dashboard.my.collections'), sufia.dashboard_collections_path
+      end
+
+      def add_breadcrumb_for_action
+        case action_name
+        when 'edit'.freeze
+          add_breadcrumb I18n.t("sufia.collection.browse_view"), main_app.collection_path(params["id"])
+        when 'show'.freeze
+          add_breadcrumb presenter.to_s, main_app.polymorphic_path(presenter)
+        end
+      end
   end
 end

--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -1,11 +1,11 @@
 module Sufia
   module WorksControllerBehavior
     extend ActiveSupport::Concern
+    include Sufia::Breadcrumbs
     include Sufia::Controller
     include CurationConcerns::CurationConcernController
 
     included do
-      include Sufia::Breadcrumbs
       before_action :has_access?, except: :show
       before_action :build_breadcrumbs, only: [:edit, :show]
       self.curation_concern_type = GenericWork
@@ -61,6 +61,19 @@ module Sufia
       # Called by CurationConcerns::FileSetsControllerBehavior#show
       def additional_response_formats(format)
         format.endnote { render text: presenter.solr_document.export_as_endnote }
+      end
+
+      def add_breadcrumb_for_controller
+        add_breadcrumb I18n.t('sufia.dashboard.my.works'), sufia.dashboard_works_path
+      end
+
+      def add_breadcrumb_for_action
+        case action_name
+        when 'edit'.freeze
+          add_breadcrumb I18n.t("sufia.work.browse_view"), main_app.curation_concerns_generic_work_path(params["id"])
+        when 'show'.freeze
+          add_breadcrumb presenter.to_s, main_app.polymorphic_path(presenter)
+        end
       end
   end
 end

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -190,6 +190,7 @@ en:
         add_another_rights: "add another Rights"
       generic_work:
         edit: "Edit"
+      browse_view: "Browse View"
     mailbox:
       date:     'Date'
       subject:  'Subject'

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -160,6 +160,28 @@ describe CollectionsController do
           expect(assigns[:member_docs].map(&:id)).to match_array [asset3].map(&:id)
         end
       end
+
+      context "without a referer" do
+        it "sets breadcrumbs" do
+          expect(controller).to receive(:add_breadcrumb).with(I18n.t('sufia.dashboard.title'), Sufia::Engine.routes.url_helpers.dashboard_index_path)
+          get :show, id: collection
+          expect(response).to be_successful
+        end
+      end
+
+      context "with a referer" do
+        before do
+          allow(controller.request).to receive(:referer).and_return('foo')
+        end
+
+        it "sets breadcrumbs" do
+          expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Sufia::Engine.routes.url_helpers.dashboard_index_path)
+          expect(controller).to receive(:add_breadcrumb).with('My Collections', Sufia::Engine.routes.url_helpers.dashboard_collections_path)
+          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id))
+          get :show, id: collection
+          expect(response).to be_successful
+        end
+      end
     end
 
     context "not signed in" do
@@ -178,6 +200,28 @@ describe CollectionsController do
       expect(response).to be_success
       expect(assigns[:form]).to be_instance_of Sufia::Forms::CollectionForm
       expect(flash[:notice]).to be_nil
+    end
+
+    context "without a referer" do
+      it "sets breadcrumbs" do
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('sufia.dashboard.title'), Sufia::Engine.routes.url_helpers.dashboard_index_path)
+        get :edit, id: collection
+        expect(response).to be_successful
+      end
+    end
+
+    context "with a referer" do
+      before do
+        allow(controller.request).to receive(:referer).and_return('foo')
+      end
+
+      it "sets breadcrumbs" do
+        expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Sufia::Engine.routes.url_helpers.dashboard_index_path)
+        expect(controller).to receive(:add_breadcrumb).with('My Collections', Sufia::Engine.routes.url_helpers.dashboard_collections_path)
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t("sufia.collection.browse_view"), collection_path(collection.id))
+        get :edit, id: collection
+        expect(response).to be_successful
+      end
     end
   end
 end

--- a/spec/controllers/generic_works_controller_spec.rb
+++ b/spec/controllers/generic_works_controller_spec.rb
@@ -21,7 +21,7 @@ describe CurationConcerns::GenericWorksController do
   end
 
   describe "#edit" do
-    let(:work) { create(:work, user: user) }
+    let(:work) { create(:work, title: ['test title'], user: user) }
 
     it "is successful" do
       get :edit, id: work
@@ -29,19 +29,66 @@ describe CurationConcerns::GenericWorksController do
       expect(response).to render_template("layouts/sufia-one-column")
       expect(assigns[:form]).to be_kind_of CurationConcerns::GenericWorkForm
     end
+
+    context "without a referer" do
+      it "sets breadcrumbs" do
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('sufia.dashboard.title'), Sufia::Engine.routes.url_helpers.dashboard_index_path)
+        get :edit, id: work
+        expect(response).to be_successful
+      end
+    end
+
+    context "with a referer" do
+      before do
+        allow(controller.request).to receive(:referer).and_return('foo')
+      end
+
+      it "sets breadcrumbs" do
+        expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Sufia::Engine.routes.url_helpers.dashboard_index_path)
+        expect(controller).to receive(:add_breadcrumb).with('My Works', Sufia::Engine.routes.url_helpers.dashboard_works_path)
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t("sufia.work.browse_view"), Rails.application.routes.url_helpers.curation_concerns_generic_work_path(work))
+        get :edit, id: work
+        expect(response).to be_successful
+      end
+    end
   end
 
   describe "#show" do
-    let(:work) { create(:work, user: user) }
+    let(:work) do
+      create(:work, title: ['test title'], user: user)
+    end
 
     it "is successful" do
       get :show, id: work
       expect(response).to be_successful
       expect(assigns(:presenter)).to be_kind_of Sufia::WorkShowPresenter
     end
+
     it 'renders an endnote file' do
       get :show, id: work, format: 'endnote'
       expect(response).to be_successful
+    end
+
+    context "without a referer" do
+      it "sets breadcrumbs" do
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('sufia.dashboard.title'), Sufia::Engine.routes.url_helpers.dashboard_index_path)
+        get :show, id: work
+        expect(response).to be_successful
+      end
+    end
+
+    context "with a referer" do
+      before do
+        allow(controller.request).to receive(:referer).and_return('foo')
+      end
+
+      it "sets breadcrumbs" do
+        expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Sufia::Engine.routes.url_helpers.dashboard_index_path)
+        expect(controller).to receive(:add_breadcrumb).with('My Works', Sufia::Engine.routes.url_helpers.dashboard_works_path)
+        expect(controller).to receive(:add_breadcrumb).with('test title', Sufia::Engine.routes.url_helpers.curation_concerns_generic_work_path(work.id))
+        get :show, id: work
+        expect(response).to be_successful
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #2041 

Breadcrumbs work for Collections and Works.

Functionality duplicates what currently is happening for FileSets breadcrumbs, where there is slightly different behavior depending on the status of request.referer. The original issue does not mention Collections, but I went ahead and made those changes for this PR as well.

Changes proposed in this pull request:
* Breadcrumbs work for Works and Collections including different behavior for show and edit actions 

@projecthydra/sufia-code-reviewers

