### PR TITLE
2060 add shoulda matcher to rspec

### DIFF
--- a/spec/forms/curation_concerns/work_form_spec.rb
+++ b/spec/forms/curation_concerns/work_form_spec.rb
@@ -88,10 +88,11 @@ describe CurationConcerns::GenericWorkForm do
     it { is_expected.to eq 'restricted' }
   end
 
-  describe "on_behalf_of" do
-    subject { form.on_behalf_of }
-    it { is_expected.to be nil }
-  end
+  subject { form }
+
+  it { is_expected.to delegate_method(:on_behalf_of).to(:model) }
+  it { is_expected.to delegate_method(:depositor).to(:model) }
+  it { is_expected.to delegate_method(:permissions).to(:model) }
 
   describe "#agreement_accepted" do
     subject { form.agreement_accepted }

--- a/spec/models/featured_work_list_spec.rb
+++ b/spec/models/featured_work_list_spec.rb
@@ -33,14 +33,5 @@ describe FeaturedWorkList, type: :model do
     end
   end
 
-  describe '#empty?' do
-    context "when there are featured works" do
-      before do
-        create(:featured_work, work_id: work1.id)
-      end
-      it { is_expected.not_to be_empty }
-    end
-
-    it { is_expected.to be_empty }
-  end
+  it { is_expected.to delegate_method(:empty?).to(:featured_works) }
 end

--- a/spec/models/proxy_deposit_request_spec.rb
+++ b/spec/models/proxy_deposit_request_spec.rb
@@ -22,9 +22,7 @@ describe ProxyDepositRequest, type: :model do
   its(:fulfillment_date) { is_expected.to be_nil }
   its(:sender_comment) { is_expected.to eq 'please take this' }
 
-  it "has a title for the file" do
-    expect(subject.to_s).to eq('Test work')
-  end
+  it { is_expected.to delegate_method(:to_s).to(:work) }
 
   context "After approval" do
     before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -90,9 +90,10 @@ describe User, type: :model do
     end
   end
 
-  it "has a cancan ability defined" do
-    expect(user).to respond_to(:can?)
-  end
+  subject { user }
+  it { is_expected.to delegate_method(:can?).to(:ability) }
+  it { is_expected.to delegate_method(:cannot?).to(:ability) }
+
   it "does not have any followers" do
     expect(user.followers_count).to eq(0)
     expect(another_user.follow_count).to eq(0)

--- a/spec/presenters/sufia/collection_presenter_spec.rb
+++ b/spec/presenters/sufia/collection_presenter_spec.rb
@@ -59,8 +59,9 @@ describe Sufia::CollectionPresenter do
     it { is_expected.to eq 0 }
   end
 
-  describe "#identifier" do
-    subject { presenter.identifier }
-    it { is_expected.to be_nil }
-  end
+  subject { presenter }
+  it { is_expected.to delegate_method(:resource_type).to(:solr_document) }
+  it { is_expected.to delegate_method(:based_near).to(:solr_document) }
+  it { is_expected.to delegate_method(:related_url).to(:solr_document) }
+  it { is_expected.to delegate_method(:identifier).to(:solr_document) }
 end

--- a/spec/presenters/sufia/file_set_presenter_spec.rb
+++ b/spec/presenters/sufia/file_set_presenter_spec.rb
@@ -6,11 +6,18 @@ describe Sufia::FileSetPresenter do
   let(:presenter) { described_class.new(solr_document, ability) }
   let(:attributes) { file.to_solr }
   let(:file) { build(:file_set, id: '123abc', user: user) }
+  let(:user) { double(user_key: 'sarah') }
 
   describe 'stats_path' do
-    let(:user) { double(user_key: 'sarah') }
     it { expect(presenter.stats_path).to eq Sufia::Engine.routes.url_helpers.stats_file_path(id: file) }
   end
+
+  subject { presenter }
+  it { is_expected.to delegate_method(:depositor).to(:solr_document) }
+  it { is_expected.to delegate_method(:keyword).to(:solr_document) }
+  it { is_expected.to delegate_method(:date_created).to(:solr_document) }
+  it { is_expected.to delegate_method(:date_modified).to(:solr_document) }
+  it { is_expected.to delegate_method(:itemtype).to(:solr_document) }
 
   describe '#tweeter' do
     subject { presenter.tweeter }

--- a/spec/presenters/sufia/homepage_presenter_spec.rb
+++ b/spec/presenters/sufia/homepage_presenter_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Sufia::HomepagePresenter do
   let(:presenter) { described_class.new(ability) }
   let(:ability) { instance_double("Ability") }
+  subject { presenter }
+  it { is_expected.to delegate_method(:can?).to(:current_ability) }
 
   describe "#display_share_button?" do
     subject { presenter.display_share_button? }

--- a/spec/presenters/sufia/work_show_presenter_spec.rb
+++ b/spec/presenters/sufia/work_show_presenter_spec.rb
@@ -4,6 +4,15 @@ describe Sufia::WorkShowPresenter do
   let(:solr_document) { SolrDocument.new(work.to_solr) }
   let(:presenter) { described_class.new(solr_document, ability) }
 
+  subject { described_class.new(double, double) }
+  it { is_expected.to delegate_method(:based_near).to(:solr_document) }
+  it { is_expected.to delegate_method(:related_url).to(:solr_document) }
+  it { is_expected.to delegate_method(:depositor).to(:solr_document) }
+  it { is_expected.to delegate_method(:identifier).to(:solr_document) }
+  it { is_expected.to delegate_method(:resource_type).to(:solr_document) }
+  it { is_expected.to delegate_method(:keyword).to(:solr_document) }
+  it { is_expected.to delegate_method(:itemtype).to(:solr_document) }
+
   describe 'stats_path' do
     let(:user) { 'sarah' }
     let(:ability) { double "Ability" }

--- a/spec/services/sufia/admin/depositor_stats_spec.rb
+++ b/spec/services/sufia/admin/depositor_stats_spec.rb
@@ -18,6 +18,7 @@ describe Sufia::Admin::DepositorStats do
   end
 
   let(:service) { described_class.new(start_date, end_date) }
+
   describe "#depositors" do
     subject { service.depositors }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,6 +105,13 @@ module EngineRoutes
   end
 end
 
+require 'shoulda/matchers'
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+  end
+end
+
 require 'active_fedora/cleaner'
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
@@ -143,6 +150,8 @@ RSpec.configure do |config|
   # automatically. This will be the default behavior in future versions of
   # rspec-rails.
   config.infer_base_class_for_anonymous_controllers = false
+
+  config.include Shoulda::Matchers::Independent
 
   config.include Devise::TestHelpers, type: :controller
   config.include EngineRoutes, type: :controller

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -59,4 +59,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "equivalent-xml", '~> 0.5'
   spec.add_development_dependency "jasmine", '~> 2.3'
   spec.add_development_dependency 'rubocop', '~> 0.40'
+  spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
 end


### PR DESCRIPTION
## Adding should-matchers for delegate_method specs

RSpec is a specification tool. By leveraging existing macros we can
better convey our expected behavior via the documentation. In this
particular instance, the original expected to be nil is confusing as
it is asserting the side-effect of the implementation detail.

Closes to #2060
