### PR TITLE
Removing nil or empty string identifiers from CreateWithFilesActor

### DIFF
--- a/app/actors/sufia/create_with_files_actor.rb
+++ b/app/actors/sufia/create_with_files_actor.rb
@@ -2,16 +2,21 @@ module Sufia
   # Creates a work and attaches files to the work
   class CreateWithFilesActor < CurationConcerns::Actors::AbstractActor
     def create(attributes)
-      @uploaded_file_ids = attributes.delete(:uploaded_files)
+      self.uploaded_file_ids = attributes.delete(:uploaded_files)
       validate_files && next_actor.create(attributes) && attach_files
     end
 
     def update(attributes)
-      @uploaded_file_ids = attributes.delete(:uploaded_files)
+      self.uploaded_file_ids = attributes.delete(:uploaded_files)
       validate_files && next_actor.update(attributes) && attach_files
     end
 
     protected
+
+      attr_reader :uploaded_file_ids
+      def uploaded_file_ids=(input)
+        @uploaded_file_ids = Array.wrap(input).select(&:present?)
+      end
 
       # ensure that the files we are given are owned by the depositor of the work
       def validate_files
@@ -34,8 +39,8 @@ module Sufia
 
       # Fetch uploaded_files from the database
       def uploaded_files
-        return [] unless @uploaded_file_ids
-        @uploaded_files ||= UploadedFile.find(@uploaded_file_ids)
+        return [] if uploaded_file_ids.empty?
+        @uploaded_files ||= UploadedFile.find(uploaded_file_ids)
       end
   end
 end

--- a/spec/actors/create_with_files_actor_spec.rb
+++ b/spec/actors/create_with_files_actor_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Sufia::CreateWithFilesActor do
   let(:create_actor) { double('create actor', create: true,
                                               curation_concern: work,
+                                              update: true,
                                               user: user) }
   let(:actor) do
     CurationConcerns::Actors::ActorStack.new(work, user, [described_class])
@@ -14,17 +15,24 @@ describe Sufia::CreateWithFilesActor do
   let(:uploaded_file_ids) { [uploaded_file1.id, uploaded_file2.id] }
   let(:attributes) { { uploaded_files: uploaded_file_ids } }
 
-  before do
-    allow(CurationConcerns::Actors::RootActor).to receive(:new).and_return(create_actor)
-    allow(create_actor).to receive(:create).and_return(true)
-  end
-
   [:create, :update].each do |mode|
     context "on #{mode}" do
+      before do
+        allow(CurationConcerns::Actors::RootActor).to receive(:new).and_return(create_actor)
+        allow(create_actor).to receive(mode).and_return(true)
+      end
+      context "when uploaded_file_ids include nil" do
+        let(:uploaded_file_ids) { [nil, uploaded_file1.id, nil] }
+        it "will discard those nil values when attempting to find the associated UploadedFile" do
+          allow(AttachFilesToWorkJob).to receive(:perform_later)
+          expect(Sufia::UploadedFile).to receive(:find).with([uploaded_file1.id]).and_return([uploaded_file1])
+          actor.public_send(mode, attributes)
+        end
+      end
+
       context "when uploaded_file_ids belong to me" do
         it "attaches files" do
           expect(AttachFilesToWorkJob).to receive(:perform_later).with(GenericWork, [uploaded_file1, uploaded_file2])
-          expect(actor.next_actor).to receive(mode).with(attributes.except(:uploaded_file_ids)).and_return(true)
           expect(actor.public_send(mode, attributes)).to be true
         end
       end
@@ -33,7 +41,6 @@ describe Sufia::CreateWithFilesActor do
         let(:uploaded_file2) { Sufia::UploadedFile.create }
         it "doesn't attach files" do
           expect(AttachFilesToWorkJob).not_to receive(:perform_later)
-          expect(actor.next_actor).to_not receive(mode)
           expect(actor.public_send(mode, attributes)).to be false
         end
       end


### PR DESCRIPTION
Removing nil or empty string identifiers

Following @jcoyne's suggestion of removing any nil file upload ids
as it relates to #2051 (e.g. "If file upload errors, then
work creation fails.")

Closes #2051
