### PR TITLE
Add #rights_statement_links helper to rights field

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -122,6 +122,12 @@ module Sufia
       link_to text, Sufia::Engine.routes.url_helpers.profile_path(user)
     end
 
+    # @param [Hash] options hash from blacklight passes from helper_method
+    #                       invocation. Maps rights URIs to links with labels.
+    def rights_statement_links(options = {})
+      options[:value].map { |right| link_to RightsService.label(right), right }.to_sentence.html_safe
+    end
+
     def link_to_telephone(user = nil)
       @user ||= user
       link_to @user.telephone, "wtai://wp/mc;#{@user.telephone}" if @user.telephone

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -75,7 +75,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: "Date Uploaded", itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), label: "Date Modified", itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field solr_name("date_created", :stored_searchable), label: "Date Created", itemprop: 'dateCreated'
-    config.add_index_field solr_name("rights", :stored_searchable), label: "Rights"
+    config.add_index_field solr_name("rights", :stored_searchable), label: "Rights", helper_method: :rights_statement_links
     config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type"
     config.add_index_field solr_name("format", :stored_searchable), label: "File Format"
     config.add_index_field solr_name("identifier", :stored_searchable), label: "Identifier"

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -217,4 +217,20 @@ describe SufiaHelper, type: :helper do
       expect(subject).to include('class="glyphicon glyphicon-new-window"')
     end
   end
+
+  describe "#rights_statement_links" do
+    it "maps the url to a link with a label" do
+      expect(helper.rights_statement_links(
+               value: ["http://creativecommons.org/publicdomain/zero/1.0/"]
+      )).to eq("<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">CC0 1.0 Universal</a>")
+    end
+
+    it "converts multiple rights statements to a sentence" do
+      expect(helper.rights_statement_links(
+               value: ["http://creativecommons.org/publicdomain/zero/1.0/",
+                       "http://creativecommons.org/publicdomain/mark/1.0/",
+                       "http://www.europeana.eu/portal/rights/rr-r.html"]
+      )).to eq("<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">CC0 1.0 Universal</a>, <a href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Public Domain Mark 1.0</a>, and <a href=\"http://www.europeana.eu/portal/rights/rr-r.html\">All rights reserved</a>")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2078 

Implements a #rights_statement_links helper to display labels as links instead of URIs for the rights field in Blacklight search results.

The labels should appear in sentence form.

Changes proposed in this pull request:
* #rights_statement_links added to app/helpers/sufia/sufia_helper_behavior.rb

@projecthydra/sufia-code-reviewers
