### PR TITLE
Require new enough version of fcrepo_wrapper

### DIFF
--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mida', '~> 0.3'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
   spec.add_development_dependency 'solr_wrapper', '~> 0.5'
-  spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'
+  spec.add_development_dependency 'fcrepo_wrapper', '~> 0.5', '>= 0.5.1'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'rspec-its', '~> 1.1'
   spec.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0'


### PR DESCRIPTION
On `0.5.0` and earlier, an older version of fcrepo jar is downloaded,
leading to `java.util.NoSuchElementException` errors in CI, as pasted
here:
    https://gist.github.com/atz/830defcd146ceb801c3f0bfb6f1c47a3

Note: for reason not fully understood, I need to do `bundle update fcrepo_wrapper` and not just `bundle` after this bump.  It seems that `bundle` failed to enforce the `'>= 0.5.1'` constraint.