### PR TITLE
Fixes vertical padding of the file upload button bar.

### DIFF
--- a/app/assets/stylesheets/fileupload/jquery.fileupload-ui.scss
+++ b/app/assets/stylesheets/fileupload/jquery.fileupload-ui.scss
@@ -10,11 +10,14 @@
  * http://www.opensource.org/licenses/MIT
  */
 
+.fileupload-buttonbar {
+  padding: 1.5em 0;
+}
 .fileinput-button {
   position: relative;
   overflow: hidden;
   float: left;
-  margin-right: 4px;
+  margin-right: 0.50em;
 }
 .fileinput-button input {
   position: absolute;
@@ -28,10 +31,6 @@
   -moz-transform: translate(-300px, 0) scale(4);
   direction: ltr;
   cursor: pointer;
-}
-.fileupload-buttonbar .btn,
-.fileupload-buttonbar .toggle {
-  margin-bottom: 5px;
 }
 .files .progress {
   width: 200px;


### PR DESCRIPTION
Fixes #2107 

The add files and add folder buttons were vertically aligned with the top of their container. Quick fix to pad the file upload button bar and switch a value from pixels to ems.

Changes proposed in this pull request:
*  Removed unused CSS
*  Add padding to file upload bar class
*  Update pixel value to em

@projecthydra/sufia-code-reviewers

Moves button bar CSS to top of file and replaces pixel margin with em.

![screen shot 2016-05-31 at 2 45 03 pm](https://cloud.githubusercontent.com/assets/4163828/15712976/7f4dfeec-27e2-11e6-8a9c-3c7a55007bc2.png)
