### PR TITLE
Removes the "* required" in the Creation of New Works

### DIFF
--- a/app/assets/stylesheets/sufia/_batch-edit.scss
+++ b/app/assets/stylesheets/sufia/_batch-edit.scss
@@ -21,3 +21,7 @@
   @extend .glyphicon-chevron-down;
 }
 
+.switch-upload-type {
+  padding-top: 1.5em;
+}
+

--- a/app/views/curation_concerns/base/_form_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_metadata.html.erb
@@ -1,9 +1,6 @@
 
         <div class="form-instructions">
           <p>The more descriptive information you provide the better we can serve your needs.</p>
-          <div class="clearfix">
-            <small class="pull-left"><span class="error">*</span> required</small>
-          </div>
         </div>
         <div class="base-terms">
           <% f.object.primary_terms.each do |term| %>

--- a/app/views/sufia/batch_uploads/_form.html.erb
+++ b/app/views/sufia/batch_uploads/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for [sufia, @form], html: { multipart: true } do |f| %>
   <% content_for :files_tab do %>
-    <p class="instructions"><strong><%= t("sufia.batch_uploads.files.instructions") %></strong></p>
     <p class="switch-upload-type">To create a single work for all the files, go to <%= link_to "New Work", new_curation_concerns_generic_work_path %></p>
+        <p class="instructions"><%= t("sufia.batch_uploads.files.instructions") %></p>
   <% end %>
   <%= render 'curation_concerns/base/guts4form', f: f, tabs: %w[files metadata relationships share] do %>
   <% end %>


### PR DESCRIPTION
Fixes #2112 

Removes the "* required" from the instructional and supportive text when creating a new work. Also fixes vertically padding and aligns the display of content under tabs for the creation of works and batch create.

Changes proposed in this pull request:
* Adds padding to class for the switching of upload type
* Removes "* required"
* Swapped position of instructional support text and upload type text

@projecthydra/sufia-code-reviewers

Aligns the instructions and file-upload switch with one another for consistent padding and presentation.

