### PR TITLE
Remove outdated required field notes from forms

### DIFF
--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for @form, html: { class: 'editor' } do |f| %>
   <div id="descriptions_display">
-    <h2 class="non lower">Descriptions <small class="pull-right"><span class="error">*</span> indicates required fields</small> </h2>
+    <h2 class="non lower">Descriptions</h2>
     <% f.object.rendered_terms.each do |term| %>
       <%= render_edit_field_partial term, f: f %>
     <% end %>

--- a/app/views/curation_concerns/file_sets/_descriptions.html.erb
+++ b/app/views/curation_concerns/file_sets/_descriptions.html.erb
@@ -1,7 +1,7 @@
 <div id="descriptions_display" class="tab-pane active">
   <%= simple_form_for [sufia, @form], html: { multipart: true } do |f| %>
     <%= hidden_field_tag('redirect_tab', 'descriptions') %>
-    <h1>Descriptions <span class="pull-right required"><abbr title="required">*</abbr> indicates required fields</span></h1>
+    <h1>Description</h1>
       <% f.object.terms.each do |term| %>
         <%= render_edit_field_partial(term, f: f) %>
       <% end %>


### PR DESCRIPTION
refs #2106

Removes hard coded notes that `*` indicates a required field. Since `*` no longer indicates a required field this PR just removes the HTML instead of moving them into `locales`.

@projecthydra/sufia-code-reviewers
