### PR TITLE
Work relationships view should label link with presenter#to_s vs. presenter#title

### DIFF
--- a/app/views/curation_concerns/base/_relationships.html.erb
+++ b/app/views/curation_concerns/base/_relationships.html.erb
@@ -11,7 +11,7 @@
             <% collection_presenters.each do |collection| %>
               <ul class="tabular">
                 <li class='attribute title'>
-                  <%= link_to collection.title, main_app.collection_path(collection) %>
+                  <%= link_to collection.to_s, main_app.collection_path(collection) %>
                 </li>
               </ul>
             <% end %>

--- a/spec/views/curation_concerns/base/_relationships.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_relationships.html.erb_spec.rb
@@ -15,7 +15,7 @@ describe 'curation_concerns/base/relationships' do
   end
 
   context "when collections are present" do
-    let(:collection_presenters) { [double(id: '456', title: 'Containing collection')] }
+    let(:collection_presenters) { [double(id: '456', title: ['Containing collection', 'foobar'], to_s: 'Containing collection')] }
     let(:page) { Capybara::Node::Simple.new(rendered) }
     before do
       allow(presenter).to receive(:collection_presenters).and_return(collection_presenters)
@@ -23,6 +23,9 @@ describe 'curation_concerns/base/relationships' do
     end
     it "links to collections" do
       expect(page).to have_link 'Containing collection'
+    end
+    it "labels the link using the presenter's #to_s method" do
+      expect(page).not_to have_content 'foobar'
     end
   end
 end


### PR DESCRIPTION
Because `#title` returns an array, and humans do not like looking at arrays.

Fixes #2148