### PR TITLE
Analytics.config returns nil when not configured

### DIFF
--- a/app/services/sufia/analytics.rb
+++ b/app/services/sufia/analytics.rb
@@ -13,30 +13,47 @@ module Sufia
     # `  client_email: GOOGLE_OAUTH_CLIENT_EMAIL`
     # @return [Hash] A hash containing five keys: 'app_name', 'app_version', 'client_email', 'privkey_path', 'privkey_secret'
     def self.config
-      @config ||= YAML.load(File.read(File.join(Rails.root, 'config', 'analytics.yml')))['analytics']
+      @config ||= load_config
     end
+    private_class_method :config
+
+    def self.load_config
+      filename = File.join(Rails.root, 'config', 'analytics.yml')
+      yaml = YAML.load(File.read(filename))
+      unless yaml
+        Rails.logger.error("Unable to fetch any keys from #{filename}.")
+        return
+      end
+      yaml.fetch('analytics')
+    end
+    private_class_method :load_config
 
     # Generate an OAuth2 token for Google Analytics
     # @return [OAuth2::AccessToken] An OAuth2 access token for GA
     def self.token
       scope = 'https://www.googleapis.com/auth/analytics.readonly'
-      client = Google::APIClient.new(application_name: config['app_name'],
-                                     application_version: config['app_version'])
-      key = Google::APIClient::PKCS12.load_key(config['privkey_path'],
-                                               config['privkey_secret'])
-      service_account = Google::APIClient::JWTAsserter.new(config['client_email'], scope,
+      client = Google::APIClient.new(application_name: config.fetch('app_name'),
+                                     application_version: config.fetch('app_version'))
+      key = Google::APIClient::PKCS12.load_key(config.fetch('privkey_path'),
+                                               config.fetch('privkey_secret'))
+      service_account = Google::APIClient::JWTAsserter.new(config.fetch('client_email'),
+                                                           scope,
                                                            key)
       client.authorization = service_account.authorize
-      oauth_client = OAuth2::Client.new('', '',           authorize_url: 'https://accounts.google.com/o/oauth2/auth',
-                                                          token_url: 'https://accounts.google.com/o/oauth2/token')
+      oauth_client = OAuth2::Client.new('',
+                                        '',
+                                        authorize_url: 'https://accounts.google.com/o/oauth2/auth',
+                                        token_url: 'https://accounts.google.com/o/oauth2/token')
       OAuth2::AccessToken.new(oauth_client, client.authorization.access_token)
     end
+    private_class_method :token
 
     # Return a user object linked to a Google Analytics account
     # @return [Legato::User] A user account wit GA access
     def self.user
       Legato::User.new(token)
     end
+    private_class_method :user
 
     # Return a Google Analytics profile matching specified ID
     # @ return [Legato::Management::Profile] A user profile associated with GA

--- a/spec/lib/sufia/analytics_spec.rb
+++ b/spec/lib/sufia/analytics_spec.rb
@@ -4,20 +4,28 @@ describe Sufia::Analytics do
     allow(subject).to receive(:token).and_return(token)
   end
 
-  it 'responds to :config' do
-    expect(subject).to respond_to(:config)
-  end
+  describe "configuration" do
+    context "When the yaml file has values" do
+      it 'reads its config from a yaml file' do
+        expect(subject.send(:config).keys.sort).to eql ['app_name', 'app_version', 'client_email', 'privkey_path', 'privkey_secret']
+      end
+    end
 
-  it 'reads its config from a yaml file' do
-    expect(subject.config.keys.sort).to eql ['app_name', 'app_version', 'client_email', 'privkey_path', 'privkey_secret']
-  end
-
-  it 'responds to :user' do
-    expect(subject).to respond_to(:user)
+    context "When the yaml file has no values" do
+      before do
+        described_class.send(:remove_instance_variable, :@config)
+        allow(File).to receive(:read).and_return("# Just comments\n# and comments\n")
+      end
+      it 'returns nil' do
+        expect(Rails.logger).to receive(:error)
+          .with(starting_with("Unable to fetch any keys from"))
+        expect(subject.send(:config)).to be nil
+      end
+    end
   end
 
   it 'instantiates a user' do
-    expect(subject.user).to be_a(Legato::User)
+    expect(subject.send(:user)).to be_a(Legato::User)
   end
 
   it 'responds to :profile' do


### PR DESCRIPTION
Fix error when analytics.yml is not configured.
Instead log an error and return nil

Fixes #2156