### PR TITLE
Shares controller should show works

### DIFF
--- a/app/search_builders/sufia/catalog_search_builder.rb
+++ b/app/search_builders/sufia/catalog_search_builder.rb
@@ -4,4 +4,33 @@ class Sufia::CatalogSearchBuilder < Sufia::SearchBuilder
     :add_advanced_parse_q_to_solr,
     :show_works_or_works_that_contain_files
   ]
+
+  # show both works that match the query and works that contain files that match the query
+  def show_works_or_works_that_contain_files(solr_parameters)
+    return if solr_parameters[:q].blank?
+    solr_parameters[:user_query] = solr_parameters[:q]
+    solr_parameters[:q] = new_query
+  end
+
+  private
+
+    # the {!lucene} gives us the OR syntax
+    def new_query
+      "{!lucene}#{interal_query(dismax_query)} #{interal_query(join_for_works_from_files)}"
+    end
+
+    # the _query_ allows for another parser (aka dismax)
+    def interal_query(query_value)
+      "_query_:\"#{query_value}\""
+    end
+
+    # the {!dismax} causes the query to go against the query fields
+    def dismax_query
+      "{!dismax v=$user_query}"
+    end
+
+    # join from file id to work relationship solrized file_set_ids_ssim
+    def join_for_works_from_files
+      "{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}#{dismax_query}"
+    end
 end

--- a/app/search_builders/sufia/my_collections_search_builder.rb
+++ b/app/search_builders/sufia/my_collections_search_builder.rb
@@ -6,4 +6,11 @@ class Sufia::MyCollectionsSearchBuilder < Sufia::SearchBuilder
     :show_only_resources_deposited_by_current_user,
     :show_only_collections
   ]
+
+  def show_only_collections(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Collection.to_class_uri)
+    ]
+  end
 end

--- a/app/search_builders/sufia/my_highlights_search_builder.rb
+++ b/app/search_builders/sufia/my_highlights_search_builder.rb
@@ -2,7 +2,13 @@
 class Sufia::MyHighlightsSearchBuilder < Sufia::SearchBuilder
   include Sufia::MySearchBuilderBehavior
 
-  self.default_processor_chain += [
-    :show_only_highlighted_works
-  ]
+  self.default_processor_chain += [:show_only_highlighted_works]
+
+  def show_only_highlighted_works(solr_parameters)
+    ids = scope.current_user.trophies.pluck(:work_id)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)
+    ]
+  end
 end

--- a/app/search_builders/sufia/my_shares_search_builder.rb
+++ b/app/search_builders/sufia/my_shares_search_builder.rb
@@ -2,5 +2,12 @@
 class Sufia::MySharesSearchBuilder < Sufia::SearchBuilder
   include Sufia::MySearchBuilderBehavior
 
-  self.default_processor_chain = default_processor_chain - [:filter_models] + [:show_only_shared_files]
+  self.default_processor_chain += [:show_only_shared_files]
+
+  def show_only_shared_files(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: scope.current_user.user_key)
+    ]
+  end
 end

--- a/app/search_builders/sufia/search_builder.rb
+++ b/app/search_builders/sufia/search_builder.rb
@@ -4,13 +4,6 @@ class Sufia::SearchBuilder < Blacklight::SearchBuilder
   include Hydra::AccessControlsEnforcement
   include CurationConcerns::SearchFilters
 
-  def show_only_collections(solr_parameters)
-    solr_parameters[:fq] ||= []
-    solr_parameters[:fq] += [
-      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Collection.to_class_uri)
-    ]
-  end
-
   def show_only_resources_deposited_by_current_user(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += [
@@ -24,56 +17,4 @@ class Sufia::SearchBuilder < Blacklight::SearchBuilder
       ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::GenericWork.to_class_uri)
     ]
   end
-
-  def show_only_shared_files(solr_parameters)
-    solr_parameters[:fq] ||= []
-    solr_parameters[:fq] += [
-      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: scope.current_user.user_key)
-    ]
-  end
-
-  def show_only_highlighted_works(solr_parameters)
-    ids = scope.current_user.trophies.pluck(:work_id)
-    solr_parameters[:fq] ||= []
-    solr_parameters[:fq] += [
-      ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)
-    ]
-  end
-
-  # Limits search results just to GenericWorks and collections
-  # @param solr_parameters the current solr parameters
-  # @param user_parameters the current user-submitted parameters
-  def only_works_and_collections(solr_parameters)
-    solr_parameters[:fq] ||= []
-    solr_parameters[:fq] << "#{Solrizer.solr_name('has_model', :symbol)}:(\"GenericWork\" \"Collection\")"
-  end
-
-  # show both works that match the query and works that contain files that match the query
-  def show_works_or_works_that_contain_files(solr_parameters)
-    return if solr_parameters[:q].blank?
-    solr_parameters[:user_query] = solr_parameters[:q]
-    solr_parameters[:q] = new_query
-  end
-
-  protected
-
-    # the {!lucene} gives us the OR syntax
-    def new_query
-      "{!lucene}#{interal_query(dismax_query)} #{interal_query(join_for_works_from_files)}"
-    end
-
-    # the _query_ allows for another parser (aka dismax)
-    def interal_query(query_value)
-      "_query_:\"#{query_value}\""
-    end
-
-    # the {!dismax} causes the query to go against the query fields
-    def dismax_query
-      "{!dismax v=$user_query}"
-    end
-
-    # join from file id to work relationship solrized file_set_ids_ssim
-    def join_for_works_from_files
-      "{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}#{dismax_query}"
-    end
 end

--- a/spec/controllers/my/shares_controller_spec.rb
+++ b/spec/controllers/my/shares_controller_spec.rb
@@ -1,4 +1,3 @@
-
 describe My::SharesController, type: :controller do
   describe "logged in user" do
     let(:user) { create(:user) }
@@ -11,11 +10,11 @@ describe My::SharesController, type: :controller do
       let(:other_user)   { create(:user) }
       let(:someone_else) { create(:user) }
 
-      let!(:my_file)                  { create(:file_set, user: user) }
-      let!(:unshared_file)            { create(:file_set, user: other_user) }
-      let!(:shared_with_me)           { create(:file_set, user: other_user, edit_users: [user, other_user]) }
-      let!(:read_shared_with_me)      { create(:file_set, user: other_user, read_users: [user, other_user]) }
-      let!(:shared_with_someone_else) { create(:file_set, user: other_user, edit_users: [someone_else, other_user]) }
+      let!(:my_work)                  { create(:work, user: user) }
+      let!(:unshared_work)            { create(:work, user: other_user) }
+      let!(:shared_with_me)           { create(:work, user: other_user, edit_users: [user, other_user]) }
+      let!(:read_shared_with_me)      { create(:work, user: other_user, read_users: [user, other_user]) }
+      let!(:shared_with_someone_else) { create(:work, user: other_user, edit_users: [someone_else, other_user]) }
       let!(:my_collection)            { create(:public_collection, user: user) }
 
       it "responds with success" do
@@ -24,7 +23,7 @@ describe My::SharesController, type: :controller do
       end
 
       context "with multiple pages of results" do
-        before { 2.times { create(:file_set, user: other_user, edit_users: [user, other_user]) } }
+        before { 2.times { create(:work, user: other_user, edit_users: [user, other_user]) } }
         it "paginates" do
           get :index, per_page: 2
           expect(assigns[:document_list].length).to eq 2

--- a/spec/search_builder/sufia/catalog_search_builder_spec.rb
+++ b/spec/search_builder/sufia/catalog_search_builder_spec.rb
@@ -1,4 +1,4 @@
-describe Sufia::SearchBuilder do
+describe Sufia::CatalogSearchBuilder do
   let(:builder) { described_class.new([], self) }
   let(:solr_params) { { q: user_query } }
 

--- a/spec/search_builder/sufia/my_shares_search_builder_spec.rb
+++ b/spec/search_builder/sufia/my_shares_search_builder_spec.rb
@@ -1,0 +1,21 @@
+describe Sufia::MySharesSearchBuilder do
+  let(:me) { create(:user) }
+  let(:config) { CatalogController.blacklight_config }
+  let(:scope) { double('The scope',
+                       blacklight_config: config,
+                       params: {},
+                       current_user: me) }
+  let(:builder) { described_class.new(scope) }
+
+  before do
+    builder.current_ability = Ability.new(me)
+  end
+
+  subject { builder.to_hash['fq'] }
+
+  it "filters things we have access to in which we are not the depositor" do
+    expect(subject).to eq ["edit_access_group_ssim:public OR edit_access_group_ssim:registered OR edit_access_person_ssim:#{me.user_key}",
+                           "(_query_:\"{!field f=has_model_ssim}GenericWork\" OR _query_:\"{!field f=has_model_ssim}Collection\")",
+                           "-_query_:\"{!field f=depositor_ssim}#{me.user_key}\""]
+  end
+end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Previously it was attempting to show
`ActiveFedora::Aggregation::ListSource`s.

Fixes #2162

Also refactors search builders to move methods to the most useful
concrete class.