### PR TITLE
Fix 2175 - Use plural labels for relationships

### DIFF
--- a/app/views/curation_concerns/base/_form_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_relationships.html.erb
@@ -1,4 +1,4 @@
-<h3>This Work in Collections</h3>
+<h3><%= t("sufia.#{controller_name}.#{action_name}.in_collections") %></h3>
 <div id="collection-widget">
   <%= f.input :collection_ids, as: :select,
       collection: available_collections(nil),

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -160,8 +160,10 @@ en:
     generic_works:
       new:
         header: Add New Work
+        in_collections: This Work in Collections
       edit:
         header: Edit Work
+        in_collections: This Work in Collections
       progress:
         header: Save Work
       show:
@@ -169,6 +171,7 @@ en:
     batch_uploads:
       new:
         header: Batch Create New Works
+        in_collections: These Works in Collections
       progress:
         header: Save Works
       files:

--- a/spec/views/curation_concerns/base/_form.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form.html.erb_spec.rb
@@ -16,6 +16,8 @@ describe 'curation_concerns/base/_form.html.erb' do
     allow(view).to receive(:curation_concern).and_return(work)
     allow(controller).to receive(:current_user).and_return(stub_model(User))
     assign(:form, form)
+    controller.stub(:controller_name).and_return('batch_uploads')
+    controller.stub(:action_name).and_return('new')
   end
 
   let(:page) do

--- a/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
@@ -13,6 +13,8 @@ describe 'sufia/batch_uploads/_form.html.erb' do
     allow(view).to receive(:curation_concern).and_return(work)
     allow(controller).to receive(:current_user).and_return(user)
     assign(:form, form)
+    controller.stub(:controller_name).and_return('batch_uploads')
+    controller.stub(:action_name).and_return('new')
   end
 
   let(:page) do


### PR DESCRIPTION
Fixes #2175 ; refs #issuenumber

Adds a check to determine if the current page is batch create works and sets the label for 'in Collections' accordingly.

@projecthydra/sufia-code-reviewers

