### PR TITLE
Don't import bootstrap twice into the css bundle

### DIFF
--- a/lib/generators/sufia/assets_generator.rb
+++ b/lib/generators/sufia/assets_generator.rb
@@ -8,6 +8,10 @@ class Sufia::AssetsGenerator < Rails::Generators::Base
 
   source_root File.expand_path('../templates', __FILE__)
 
+  def remove_blacklight_css
+    remove_file "app/assets/stylesheets/blacklight.scss"
+  end
+
   def inject_css
     copy_file "sufia.scss", "app/assets/stylesheets/sufia.scss"
   end

--- a/lib/generators/sufia/templates/sufia.scss
+++ b/lib/generators/sufia/templates/sufia.scss
@@ -6,5 +6,6 @@
 
 @import "bootstrap-sprockets";
 @import 'bootstrap';
+@import 'blacklight/blacklight';
 @import "font-awesome";
 @import 'sufia/sufia';

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -13,7 +13,7 @@ class TestAppGenerator < Rails::Generators::Base
   end
 
   def browse_everything_install
-    generate "browse_everything:install"
+    generate "browse_everything:install --skip-assets"
   end
 
   def banner


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

This gives us the custom blacklight styles without importing a second
copy of bootstrap.