### PR TITLE
Give media_display a presenter

### DIFF
--- a/app/models/concerns/sufia/file_set_behavior.rb
+++ b/app/models/concerns/sufia/file_set_behavior.rb
@@ -2,5 +2,10 @@ module Sufia
   module FileSetBehavior
     extend ActiveSupport::Concern
     include Sufia::WithEvents
+
+    # Cast to a SolrDocument by querying from Solr
+    def to_presenter
+      CatalogController.new.fetch(id).last
+    end
   end
 end

--- a/app/views/curation_concerns/file_sets/edit.html.erb
+++ b/app/views/curation_concerns/file_sets/edit.html.erb
@@ -5,7 +5,7 @@
 
 <div class="row">
   <div class="col-xs-12 col-sm-4">
-    <%= media_display curation_concern %>
+    <%= media_display curation_concern.to_presenter %>
   </div>
   <div class="col-xs-12 col-sm-8">
     <ul class="nav nav-tabs" role="tablist">

--- a/spec/features/edit_file_spec.rb
+++ b/spec/features/edit_file_spec.rb
@@ -2,17 +2,19 @@ describe "Editing a file:", type: :feature do
   let(:user) { create(:user) }
   let(:file_title) { 'Some kind of title' }
   let(:work) { build(:work, user: user) }
-  let(:file) { work.members.first }
+  let(:file_set) { create(:file_set, user: user, title: [file_title]) }
+  let(:file) { File.open(fixture_path + '/world.png') }
 
   before do
     sign_in user
-    work.ordered_members << create(:file_set, user: user, title: [file_title])
+    Hydra::Works::AddFileToFileSet.call(file_set, file, :original_file)
+    work.ordered_members << file_set
     work.save!
   end
 
   context 'when the user tries to update file content, but forgets to select a file:' do
     it 'shows the edit page again' do
-      visit edit_curation_concerns_file_set_path(file)
+      visit edit_curation_concerns_file_set_path(file_set)
       click_link 'Versions'
       click_button 'Upload New Version'
       expect(page).to have_content "Edit #{file_title}"


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Media display only takes a presenter in the latest version of
curation_concerns. Previously we were sending a FileSet.