### PR TITLE
Update flash message after work is created, fixes #2104

### DIFF
--- a/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
@@ -13,13 +13,7 @@ module Sufia
     def create
       authenticate_user!
       create_update_job
-      flash[:notice] = <<-EOS.strip_heredoc.tr("\n", ' ')
-        Your files are being processed by #{view_context.application_name} in
-        the background. The metadata and access controls you specified are being applied.
-        Files will be marked <span class="label label-danger" title="Private">Private</span>
-        until this process is complete (shouldn't take too long, hang in there!). You may need
-        to refresh your dashboard to see these updates.
-      EOS
+      flash[:notice] = t('sufia.generic_works.new.after_create_html', application_name: view_context.application_name)
       redirect_after_update
     end
 

--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -45,11 +45,7 @@ module Sufia
     def after_create_response
       respond_to do |wants|
         wants.html do
-          flash[:notice] = "Your files are being processed by #{view_context.application_name} in " \
-            "the background. The metadata and access controls you specified are being applied. " \
-            "Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> " \
-            "until this process is complete (shouldn't take too long, hang in there!). You may need " \
-            "to refresh your dashboard to see these updates."
+          flash[:notice] = t('sufia.generic_works.new.after_create_html', application_name: view_context.application_name)
           redirect_to [main_app, curation_concern]
         end
         wants.json { render :show, status: :created, location: polymorphic_path([main_app, curation_concern]) }

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -208,6 +208,7 @@ en:
       new:
         header: Add New Work
         in_collections: This Work in Collections
+        after_create_html: "Your files are being processed by %{application_name} in the background. The metadata and access controls you specified are being applied. Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh this page to see these updates."
       edit:
         header: Edit Work
         in_collections: This Work in Collections

--- a/spec/controllers/generic_works_controller_spec.rb
+++ b/spec/controllers/generic_works_controller_spec.rb
@@ -106,7 +106,7 @@ describe CurationConcerns::GenericWorksController do
       post :create, generic_work: { title: ["First title"],
                                     visibility: 'open' },
                     uploaded_files: ['777', '888']
-      expect(flash[:notice]).to eq "Your files are being processed by Sufia in the background. The metadata and access controls you specified are being applied. Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh your dashboard to see these updates."
+      expect(flash[:notice]).to eq "Your files are being processed by Sufia in the background. The metadata and access controls you specified are being applied. Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh this page to see these updates."
       expect(response).to redirect_to main_app.curation_concerns_generic_work_path(work)
     end
 
@@ -156,7 +156,7 @@ describe CurationConcerns::GenericWorksController do
                         uploaded_files: uploaded_files,
                         parent_id: work.id,
                         generic_work: { title: ['First title'] }
-          expect(flash[:notice]).to eq "Your files are being processed by Sufia in the background. The metadata and access controls you specified are being applied. Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh your dashboard to see these updates."
+          expect(flash[:notice]).to eq "Your files are being processed by Sufia in the background. The metadata and access controls you specified are being applied. Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh this page to see these updates."
           expect(response).to redirect_to main_app.curation_concerns_generic_work_path(work)
         end
       end


### PR DESCRIPTION
Fixes #2104 

Updates the flash message and puts the content under i18n for better management.

@projecthydra/sufia-code-reviewers