### PR TITLE
Remove blacklight_gallery.scss

### DIFF
--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -23,8 +23,10 @@ module Sufia
    4. Adds controller behavior to the application controller
    5. Copies the catalog controller into the local app
    6. Adds Sufia::SolrDocumentBehavior to app/models/solr_document.rb
-   7. Updates simple_form to use browser validations
-   8. Installs Blacklight gallery
+   7. Installs sufia assets
+   8. Installs hydra:batch_edit
+   9. Updates simple_form to use browser validations
+   10. Installs Blacklight gallery (and removes it's scss)
          """
 
     def banner
@@ -205,6 +207,14 @@ module Sufia
       generate "sufia:upgrade700"
     end
 
+    def install_assets
+      generate "sufia:assets"
+    end
+
+    def install_batch_edit
+      generate "hydra_batch_edit:install"
+    end
+
     def use_browser_validations
       gsub_file 'config/initializers/simple_form.rb',
                 /browser_validations = false/,
@@ -213,6 +223,9 @@ module Sufia
 
     def install_blacklight_gallery
       generate "blacklight_gallery:install"
+      # This was pulling in an extra copy of bootstrap, so we added the needed
+      # includes to sufia.scss
+      remove_file 'app/assets/stylesheets/blacklight_gallery.css.scss'
     end
   end
 end

--- a/lib/generators/sufia/templates/sufia.scss
+++ b/lib/generators/sufia/templates/sufia.scss
@@ -8,4 +8,8 @@
 @import 'bootstrap';
 @import 'blacklight/blacklight';
 @import "font-awesome";
+@import "blacklight_gallery/gallery";
+@import "blacklight_gallery/masonry";
+@import "blacklight_gallery/slideshow";
+@import "blacklight_gallery/osd_viewer";
 @import 'sufia/sufia';

--- a/lib/generators/sufia/upgrade700_generator.rb
+++ b/lib/generators/sufia/upgrade700_generator.rb
@@ -45,12 +45,4 @@ This generator for upgrading sufia from 6.0.0 to 7.0 makes the following changes
       puts "     \e[31mFailure\e[0m  Sufia requires a CurationConcerns::GenericWorksController object. This generator assumes that the model is defined in the file #{file_path}, which does not exist."
     end
   end
-
-  def install_assets
-    generate "sufia:assets"
-  end
-
-  def install_batch_edit
-    generate "hydra_batch_edit:install"
-  end
 end


### PR DESCRIPTION

This keeps the application from pulling in an extra copy of Bootstrap's
css. Put the required includes into sufia.scss.

Fixes #2185