### PR TITLE
Align collection form with work form, display required tag, fixes #2190

### DIFF
--- a/app/forms/sufia/forms/collection_form.rb
+++ b/app/forms/sufia/forms/collection_form.rb
@@ -2,9 +2,12 @@ module Sufia::Forms
   class CollectionForm < CurationConcerns::Forms::CollectionEditForm
     delegate :id, to: :model
 
-    def rendered_terms
-      [:title,
-       :creator,
+    def primary_terms
+      [:title]
+    end
+
+    def secondary_terms
+      [:creator,
        :contributor,
        :description,
        :keyword,

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -1,9 +1,23 @@
 <%= simple_form_for @form, html: { class: 'editor' } do |f| %>
   <div id="descriptions_display">
-    <h2 class="non lower">Descriptions</h2>
-    <% f.object.rendered_terms.each do |term| %>
-      <%= render_edit_field_partial term, f: f %>
-    <% end %>
+    <h2 class="non lower"><%= t('sufia.collection.edit.description') %></h2>
+    <div id="base-terms">
+      <% f.object.primary_terms.each do |term| %>
+        <%= render_edit_field_partial(term, f: f) %>
+      <% end %>
+    </div>
+    <%= link_to t('sufia.collection.edit.additional_fields'),
+            '#extended-terms',
+            class: 'btn btn-default',
+            data: { toggle: 'collapse' },
+            role: "button",
+            'aria-expanded'=> "false",
+            'aria-controls'=> "extended-terms" %>
+    <div id="extended-terms" class='collapse'>
+      <% f.object.secondary_terms.each do |term| %>
+        <%= render_edit_field_partial(term, f: f) %>
+      <% end %>
+    </div>
   </div>
   <%= hidden_field_tag :type, params[:type] %>
   <% if params[:batch_document_ids].present? %>

--- a/app/views/curation_concerns/base/_form_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_metadata.html.erb
@@ -7,7 +7,7 @@
             <%= render_edit_field_partial(term, f: f) %>
           <% end %>
         </div>
-        <%= link_to 'Additional fields',
+        <%= link_to t('sufia.generic_works.edit.additional_fields'),
                     '#extended-terms',
                     class: 'btn btn-default',
                     data: { toggle: 'collapse' },

--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -11,7 +11,9 @@
         <% else %>
           <li role="presentation">
         <% end %>
-            <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab"><%= tab.capitalize %></a>
+            <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
+              <%= t("sufia.generic_works.edit.tab.#{tab}") %>
+            </a>
           </li>
       <% end %>
     </ul>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -212,6 +212,12 @@ en:
       edit:
         header: Edit Work
         in_collections: This Work in Collections
+        additional_fields: "Additional fields"
+        tab:
+          metadata:      "Description"
+          files:         "Files"
+          relationships: "Relationships"
+          share:         "Share"
       progress:
         header: Save Work
       show:
@@ -241,6 +247,8 @@ en:
           confirmation: "Delete this collection?"
       edit:
         manage_items: "Manage Items in this Collection"
+        description: "Description"
+        additional_fields: "Additional fields"
       document_list:
         edit: "Edit"
         no_visible_works: "The collection is either empty or does not contain items to which you have access."
@@ -341,7 +349,7 @@ en:
         empty:       "This %{type} is not currently in any collections."
         collections: "In collections:"
       metadata:
-        header: Metadata
+        header: Description
         attribute_name_label: Attribute Name
         attribute_values_label: Values
       items:

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -18,7 +18,7 @@ describe 'collection', type: :feature do
       visit '/dashboard'
       first('#hydra-collection-add').click
       expect(page).to have_content 'Create New Collection'
-
+      click_link('Additional fields')
       # Creator is a multi-value field, so it should have button to add more fields
       expect(page).to have_selector "div.collection_creator .input-append button.add"
 

--- a/spec/forms/sufia/collection_form_spec.rb
+++ b/spec/forms/sufia/collection_form_spec.rb
@@ -24,11 +24,15 @@ describe Sufia::Forms::CollectionForm do
   let(:collection) { build(:collection) }
   let(:form) { described_class.new(collection) }
 
-  describe "#rendered_terms" do
-    subject { form.rendered_terms }
+  describe "#primary_terms" do
+    subject { form.primary_terms }
+    it { is_expected.to eq([:title]) }
+  end
+
+  describe "#secondary_terms" do
+    subject { form.secondary_terms }
 
     it { is_expected.to eq [
-      :title,
       :creator,
       :contributor,
       :description,

--- a/spec/views/collections/_form.html.erb_spec.rb
+++ b/spec/views/collections/_form.html.erb_spec.rb
@@ -11,6 +11,7 @@ describe 'collections/_form.html.erb' do
   it "draws the metadata fields for collection" do
     render
     expect(rendered).to have_selector("input#collection_title")
+    expect(rendered).to have_selector("span", text: "required")
     expect(rendered).to_not have_selector("div#additional_title.multi_value")
     expect(rendered).to have_selector("input#collection_creator.multi_value")
     expect(rendered).to have_selector("textarea#collection_description")

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.version       = Sufia::VERSION
   spec.license       = 'Apache2'
 
-  spec.add_dependency 'curation_concerns', '>= 1.0.0.beta8', '< 2'
+  spec.add_dependency 'curation_concerns', '>= 1.0.0.beta9', '< 2'
   spec.add_dependency 'hydra-batch-edit', '~> 2.0'
   spec.add_dependency 'browse-everything', '~> 0.10'
   spec.add_dependency 'blacklight-gallery', '~> 0.1'


### PR DESCRIPTION
Fixes #2190 

Makes the collection form a little bit more like the work form

@projecthydra/sufia-code-reviewers

