### PR TITLE
Properly namespace UploadedFile to avoid uploading error

### DIFF
--- a/app/controllers/concerns/sufia/uploads_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/uploads_controller_behavior.rb
@@ -2,7 +2,7 @@ module Sufia::UploadsControllerBehavior
   extend ActiveSupport::Concern
 
   included do
-    load_and_authorize_resource class: UploadedFile
+    load_and_authorize_resource class: Sufia::UploadedFile
   end
 
   def create


### PR DESCRIPTION
This was introduced in 0f035cce6555721318bb27f5ed39496f96e76e0b and presently blocks any uploads from occurring. Oddly, the error does not present when tests are run and only happens when you use the internal test application.

@projecthydra/sufia-code-reviewers

