### PR TITLE
Remove generic_work route

### DIFF
--- a/app/controllers/concerns/sufia/file_sets_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/file_sets_controller_behavior.rb
@@ -39,7 +39,7 @@ module Sufia
       when 'edit'.freeze
         add_breadcrumb I18n.t("sufia.file_set.browse_view"), main_app.curation_concerns_file_set_path(params["id"])
       when 'show'.freeze
-        add_breadcrumb presenter.parent.to_s, sufia.polymorphic_path(presenter.parent)
+        add_breadcrumb presenter.parent.to_s, main_app.polymorphic_path(presenter.parent)
         add_breadcrumb presenter.to_s, main_app.polymorphic_path(presenter)
       end
     end

--- a/app/views/sufia/homepage/_home_header.html.erb
+++ b/app/views/sufia/homepage/_home_header.html.erb
@@ -1,7 +1,7 @@
 <div class="home_call_action col-xs-12 col-sm-4 pull-right">
   <% if @presenter.display_share_button? %>
     <div class="home_share_work">
-      <%= link_to sufia.new_curation_concerns_generic_work_path, class: "btn btn-primary btn-lg btn-block", id: "contribute_link" do %>
+      <%= link_to new_curation_concerns_generic_work_path, class: "btn btn-primary btn-lg btn-block", id: "contribute_link" do %>
         <i class="glyphicon glyphicon-upload"></i> <%= t('sufia.share_button') %>
       <% end %>
       <p class="text-center"><a href="/terms/">Terms of Use</a></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,6 @@ Sufia::Engine.routes.draw do
         get 'stats'
       end
     end
-    resources :generic_works
   end
 
   resources :files, only: [] do

--- a/spec/controllers/file_sets_controller_spec.rb
+++ b/spec/controllers/file_sets_controller_spec.rb
@@ -250,7 +250,7 @@ describe CurationConcerns::FileSetsController do
       it "shows me the breadcrumbs" do
         expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Sufia::Engine.routes.url_helpers.dashboard_index_path)
         expect(controller).to receive(:add_breadcrumb).with('My Works', Sufia::Engine.routes.url_helpers.dashboard_works_path)
-        expect(controller).to receive(:add_breadcrumb).with('test title', Sufia::Engine.routes.url_helpers.curation_concerns_generic_work_path(work.id))
+        expect(controller).to receive(:add_breadcrumb).with('test title', main_app.curation_concerns_generic_work_path(work.id))
         expect(controller).to receive(:add_breadcrumb).with('test file', main_app.curation_concerns_file_set_path(file_set))
         get :show, id: file_set
         expect(response).to be_successful

--- a/spec/controllers/generic_works_controller_spec.rb
+++ b/spec/controllers/generic_works_controller_spec.rb
@@ -83,7 +83,7 @@ describe CurationConcerns::GenericWorksController do
       it "sets breadcrumbs" do
         expect(controller).to receive(:add_breadcrumb).with('My Dashboard', Sufia::Engine.routes.url_helpers.dashboard_index_path)
         expect(controller).to receive(:add_breadcrumb).with('My Works', Sufia::Engine.routes.url_helpers.dashboard_works_path)
-        expect(controller).to receive(:add_breadcrumb).with('test title', Sufia::Engine.routes.url_helpers.curation_concerns_generic_work_path(work.id))
+        expect(controller).to receive(:add_breadcrumb).with('test title', main_app.curation_concerns_generic_work_path(work.id))
         get :show, id: work
         expect(response).to be_successful
       end

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -59,7 +59,7 @@ describe StatsController do
       expect(WorkUsage).to receive(:new).with(work.id).and_return(usage)
       expect(controller).to receive(:add_breadcrumb).with(I18n.t('sufia.dashboard.my.works'), Sufia::Engine.routes.url_helpers.dashboard_works_path)
       expect(controller).to receive(:add_breadcrumb).with(I18n.t('sufia.dashboard.title'), Sufia::Engine.routes.url_helpers.dashboard_index_path)
-      expect(controller).to receive(:add_breadcrumb).with(I18n.t('sufia.work.browse_view'), curation_concerns_generic_work_path(work))
+      expect(controller).to receive(:add_breadcrumb).with(I18n.t('sufia.work.browse_view'), main_app.curation_concerns_generic_work_path(work))
       get :work, id: work
       expect(response).to be_success
       expect(response).to render_template('stats/work')

--- a/spec/views/_toolbar.html.erb_spec.rb
+++ b/spec/views/_toolbar.html.erb_spec.rb
@@ -43,7 +43,7 @@ describe '/_toolbar.html.erb', type: :view do
       it "has a link to upload" do
         allow(view).to receive(:can?).with(:create, GenericWork).and_return(true)
         render
-        expect(rendered).to have_link('New Work', href: sufia.new_curation_concerns_generic_work_path)
+        expect(rendered).to have_link('New Work', href: new_curation_concerns_generic_work_path)
       end
     end
 


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

It's already created by curation_concerns.