### PR TITLE
Draw fields appropriate for GenericWorks

### DIFF
--- a/app/views/sufia/homepage/_featured_fields.html.erb
+++ b/app/views/sufia/homepage/_featured_fields.html.erb
@@ -1,14 +1,10 @@
 <h3>
   <span class="sr-only">Title</span>
-  <%= link_to truncate(featured.title_or_label, length: 28, separator: ' '), featured  %>
+  <%= link_to truncate(featured.title.first, length: 28, separator: ' '), featured %>
 </h3>
 <div>
   <span class="sr-only">Depositor</span>
   <%= link_to_profile featured.depositor("no depositor value") %>
-</div>
-<div>
-  <span class="sr-only">Filename</span>
-  <%= link_to truncate(featured.label, length: 25), featured, title: featured.label %>
 </div>
 <div>
   <span class="sr-only">File type</span>

--- a/spec/views/homepage/_featured_works.html.erb_spec.rb
+++ b/spec/views/homepage/_featured_works.html.erb_spec.rb
@@ -13,9 +13,17 @@ describe "sufia/homepage/_featured_works.html.erb" do
   end
 
   context "with featured works" do
+    let(:doc) { SolrDocument.new(id: '12345678',
+                                 title_tesim: ['Doc title'],
+                                 has_model_ssim: ['GenericWork']) }
+    let(:presenter) { Sufia::WorkShowPresenter.new(doc, nil) }
+    let(:featured_work) { FeaturedWork.new }
     before do
       allow(view).to receive(:can?).with(:update, FeaturedWork).and_return(false)
+      allow(view).to receive(:render_thumbnail_tag).with(presenter, width: 90)
       allow(list).to receive(:empty?).and_return(false)
+      allow(list).to receive(:featured_works).and_return([featured_work])
+      allow(featured_work).to receive(:presenter).and_return(presenter)
       render
     end
 


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

In Sufia 6, we featured files. In Sufia 7, we feature works, so adjust
the fields that show up.