### PR TITLE
Expose an API for reading data

### DIFF
--- a/app/connections/clean_connection.rb
+++ b/app/connections/clean_connection.rb
@@ -1,0 +1,23 @@
+# This stands in for ActiveFedora::CleanConnection. It behaves the same way,
+# but it doesn't clear the has_model assertion
+class CleanConnection < SimpleDelegator
+  def get(*args)
+    result = __getobj__.get(*args) do |req|
+      prefer_headers = Ldp::PreferHeaders.new(req.headers["Prefer"])
+      prefer_headers.omit = prefer_headers.omit | omit_uris
+      req.headers["Prefer"] = prefer_headers.to_s
+    end
+    result
+  end
+
+  private
+
+    def omit_uris
+      [
+        ::RDF::Vocab::Fcrepo4.ServerManaged,
+        ::RDF::Vocab::LDP.PreferContainment,
+        ::RDF::Vocab::LDP.PreferEmptyContainer,
+        ::RDF::Vocab::LDP.PreferMembership
+      ]
+    end
+end

--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -57,6 +57,7 @@ module Sufia
       # Called by CurationConcerns::CurationConcernController#show
       def additional_response_formats(format)
         format.endnote { render text: presenter.solr_document.export_as_endnote }
+        document_export_formats(format)
       end
 
       def add_breadcrumb_for_controller
@@ -70,6 +71,24 @@ module Sufia
         when 'show'.freeze
           add_breadcrumb presenter.to_s, main_app.polymorphic_path(presenter)
         end
+      end
+
+      def document_export_formats(format)
+        format.any do
+          format_name = params.fetch(:format, '').to_sym
+          raise ActionController::UnknownFormat unless presenter.export_formats.include? format_name
+          render_document_export_format format_name
+        end
+      end
+
+      ##
+      # Render the document export formats for a response
+      # First, try to render an appropriate template (e.g. index.endnote.erb)
+      # If that fails, just concatenate the document export responses with a newline.
+      def render_document_export_format(format_name)
+        render
+      rescue ActionView::MissingTemplate
+        render text: presenter.export_as(format_name), layout: false
       end
   end
 end

--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -66,5 +66,14 @@ module Sufia
         ::SolrDocument.new(hash)
       end
     end
+
+    # This overrides the connection provided by Hydra::ContentNegotiation so we
+    # can get the model too.
+    module ConnectionWithModel
+      def connection
+        # TODO: clean the fedora added triples out.
+        @connection ||= CleanConnection.new(ActiveFedora.fedora.connection)
+      end
+    end
   end
 end

--- a/app/presenters/sufia/work_show_presenter.rb
+++ b/app/presenters/sufia/work_show_presenter.rb
@@ -2,7 +2,7 @@ module Sufia
   class WorkShowPresenter < ::CurationConcerns::WorkShowPresenter
     # delegate fields from Sufia::Works::Metadata to solr_document
     delegate :based_near, :related_url, :depositor, :identifier, :resource_type,
-             :keyword, :itemtype, to: :solr_document
+             :keyword, :itemtype, :export_formats, :export_as, to: :solr_document
 
     def editor?
       current_ability.can?(:edit, solr_document)

--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -186,6 +186,12 @@ module Sufia
           "\n  # Adds Sufia behaviors to the SolrDocument.\n" \
             "  include Sufia::SolrDocumentBehavior\n"
         end
+
+        insert_into_file file_path, after: /use_extension\(\s*Hydra::ContentNegotiation\s*\)/ do
+          "\n\n  # Overrides the connection provided by Hydra::ContentNegotiation so we" \
+          "\n  # can get the model too." \
+          "\n  use_extension(ConnectionWithModel)"
+        end
       else
         puts "     \e[31mFailure\e[0m  Sufia requires a SolrDocument object. This generator assumes that the model is defined in the file #{file_path}, which does not exist."
       end

--- a/lib/generators/sufia/templates/config/sufia.rb
+++ b/lib/generators/sufia/templates/config/sufia.rb
@@ -82,7 +82,10 @@ Sufia.config do |config|
 
   # Temporary path to hold uploads before they are ingested into FCrepo.
   # This must be a lambda that returns a Pathname
-  #  config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
+  # config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
+
+  # Hostname is used for the externally visible URI when RDF is requested
+  # config.hostname = 'localhost'
 
   # If browse-everything has been configured, load the configs.  Otherwise, set to nil.
   begin

--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -46,4 +46,19 @@ module Sufia
 
     @config
   end
+
+  # This method is called once for each statement in the graph.
+  def self.id_to_resource_uri
+    lambda do |id, graph|
+      result = graph.query([nil, ActiveFedora::RDF::Fcrepo::Model.hasModel, nil]).first
+      route_key = result.object.to_s.constantize.model_name.singular_route_key
+      routes = Rails.application.routes.url_helpers
+      builder = ActionDispatch::Routing::PolymorphicRoutes::HelperMethodBuilder
+      builder.polymorphic_method routes, route_key, nil, :url, id: id, host: hostname
+    end
+  end
+
+  def self.hostname
+    config.hostname
+  end
 end

--- a/lib/sufia/configuration.rb
+++ b/lib/sufia/configuration.rb
@@ -123,5 +123,11 @@ module Sufia
     def translate_id_to_uri
       @translate_id_to_uri ||= ActiveFedora::Noid.config.translate_id_to_uri
     end
+
+    # Hostname is used for the externally visible URI when RDF is requested
+    attr_writer :hostname
+    def hostname
+      @hostname ||= 'localhost'
+    end
   end
 end

--- a/lib/sufia/engine.rb
+++ b/lib/sufia/engine.rb
@@ -47,6 +47,7 @@ module Sufia
       end
 
       CurationConcerns::CurationConcern.actor_factory = Sufia::ActorFactory
+      Hydra.config.id_to_resource_uri = Sufia.id_to_resource_uri
     end
 
     initializer 'sufia.assets.precompile' do |app|

--- a/spec/controllers/generic_works_controller_spec.rb
+++ b/spec/controllers/generic_works_controller_spec.rb
@@ -56,15 +56,28 @@ describe CurationConcerns::GenericWorksController do
       create(:work, title: ['test title'], user: user)
     end
 
-    it "is successful" do
-      get :show, id: work
-      expect(response).to be_successful
-      expect(assigns(:presenter)).to be_kind_of Sufia::WorkShowPresenter
+    context "html" do
+      it "is successful" do
+        get :show, id: work
+        expect(response).to be_successful
+        expect(assigns(:presenter)).to be_kind_of Sufia::WorkShowPresenter
+      end
     end
 
-    it 'renders an endnote file' do
-      get :show, id: work, format: 'endnote'
-      expect(response).to be_successful
+    context "endnote" do
+      it 'renders an endnote file' do
+        get :show, id: work, format: 'endnote'
+        expect(response).to be_successful
+      end
+    end
+
+    context "ttl" do
+      it 'renders an turtle file' do
+        get :show, id: work, format: :ttl
+        expect(response).to be_successful
+        expect(response.body).to start_with "\n<http://localhost/concern/generic_works/#{work.id}>"
+        expect(response.body).to match %r{<http://purl\.org/dc/terms/title> "test title";}
+      end
     end
 
     context "without a referer" do


### PR DESCRIPTION
This allows you to fetch RDF by setting the `Accept` request headers to an RDF type on an object show page.


@projecthydra/sufia-code-reviewers

@tpendragon should we push this down to curation_concerns?

