### PR TITLE
Uses solr_name :facetable for the link_to_search: and Fixes spec test…

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -91,6 +91,18 @@ module Sufia
       link_to(label, main_app.search_catalog_path(state))
     end
 
+    def index_field_link(options = {})
+      field_name = options[:config][:field_name]
+      values = options[:value]
+      safe_join(values.map { |item| link_to_index_field(item, field_name) }, ", ")
+    end
+
+    def link_to_index_field(name, value)
+      params = { search_field: 'advanced', name => "\"#{value}\"" }
+      state = search_state.params_for_search(params)
+      link_to(name, main_app.search_catalog_path(state))
+    end
+
     # @param [String,Hash] text either the string to escape or a hash containing the
     #                           string to escape under the :value key.
     def iconify_auto_link(text, showLink = true)

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -63,22 +63,22 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name', if: false
     config.add_index_field solr_name("description", :stored_searchable), label: "Description", itemprop: 'description', helper_method: :iconify_auto_link
-    config.add_index_field solr_name("keyword", :stored_searchable), label: "Keyword", itemprop: 'keywords'
-    config.add_index_field solr_name("subject", :stored_searchable), label: "Subject", itemprop: 'about'
-    config.add_index_field solr_name("creator", :stored_searchable), label: "Creator", itemprop: 'creator'
-    config.add_index_field solr_name("contributor", :stored_searchable), label: "Contributor", itemprop: 'contributor'
+    config.add_index_field solr_name("keyword", :stored_searchable), label: "Keyword", itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
+    config.add_index_field solr_name("subject", :stored_searchable), label: "Subject", itemprop: 'about', link_to_search: solr_name("subject", :facetable)
+    config.add_index_field solr_name("creator", :stored_searchable), label: "Creator", itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
+    config.add_index_field solr_name("contributor", :stored_searchable), label: "Contributor", itemprop: 'contributor', helper_method: :index_field_link, field_name: 'contributor'
     config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
     config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
-    config.add_index_field solr_name("publisher", :stored_searchable), label: "Publisher", itemprop: 'publisher'
-    config.add_index_field solr_name("based_near", :stored_searchable), label: "Location", itemprop: 'contentLocation'
-    config.add_index_field solr_name("language", :stored_searchable), label: "Language", itemprop: 'inLanguage'
+    config.add_index_field solr_name("publisher", :stored_searchable), label: "Publisher", itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
+    config.add_index_field solr_name("based_near", :stored_searchable), label: "Location", itemprop: 'contentLocation', link_to_search: solr_name("based_near", :facetable)
+    config.add_index_field solr_name("language", :stored_searchable), label: "Language", itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
     config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: "Date Uploaded", itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), label: "Date Modified", itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field solr_name("date_created", :stored_searchable), label: "Date Created", itemprop: 'dateCreated'
     config.add_index_field solr_name("rights", :stored_searchable), label: "Rights", helper_method: :rights_statement_links
-    config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type"
-    config.add_index_field solr_name("format", :stored_searchable), label: "File Format"
-    config.add_index_field solr_name("identifier", :stored_searchable), label: "Identifier"
+    config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)
+    config.add_index_field solr_name("file_format", :stored_searchable), label: "File Format", link_to_search: solr_name("file_format", :facetable)
+    config.add_index_field solr_name("identifier", :stored_searchable), label: "Identifier", helper_method: :index_field_link, field_name: 'identifier'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe BlacklightHelper, type: :helper do
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:attributes) do
+    { 'creator_tesim' => ['Justin', 'Joe'],
+      'depositor_tesim' => ['jcoyne@justincoyne.com'],
+      'proxy_depositor_ssim' => ['atz@stanford.edu'],
+      'description_tesim' => ['This links to http://example.com/ What about that?'],
+      'date_uploaded_dtsi' => '2013-03-14T00:00:00Z',
+      'rights_tesim' => ["http://creativecommons.org/publicdomain/zero/1.0/",
+                         "http://creativecommons.org/publicdomain/mark/1.0/",
+                         "http://www.europeana.eu/portal/rights/rr-r.html"],
+      'identifier_tesim' => ['65434567654345654'],
+      'keyword_tesim' => ['taco', 'mustache'],
+      'subject_tesim' => ['Awesome'],
+      'contributor_tesim' => ['Bird, Big'],
+      'publisher_tesim' => ['Penguin Random House'],
+      'based_near_tesim' => ['Pennsylvania'],
+      'language_tesim' => ['English'],
+      'resource_type_tesim' => ['Capstone Project'] }
+  end
+
+  let(:document) { SolrDocument.new(attributes) }
+  before do
+    allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
+  end
+
+  describe "render_index_field_value" do
+    include SufiaHelper
+    subject { render_index_field_value document, field: field_name }
+
+    context "rights_tesim" do
+      let(:field_name) { 'rights_tesim' }
+      it { is_expected.to eq "<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">CC0 1.0 Universal</a>, <a href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Public Domain Mark 1.0</a>, and <a href=\"http://www.europeana.eu/portal/rights/rr-r.html\">All rights reserved</a>" }
+    end
+
+    context "metadata index links" do
+      let(:search_state) { Blacklight::SearchState.new(params, CatalogController.blacklight_config) }
+      before do
+        allow(controller).to receive(:search_state).and_return(search_state)
+        def search_action_path(stuff)
+          search_catalog_path(stuff)
+        end
+      end
+
+      context "keyword_tesim" do
+        let(:field_name) { 'keyword_tesim' }
+        it { is_expected.to eq "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco\"><span itemprop=\"keywords\">taco</span></a></span> and <span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache\"><span itemprop=\"keywords\">mustache</span></a></span>" }
+      end
+
+      context "subject_tesim" do
+        let(:field_name) { 'subject_tesim' }
+        it { is_expected.to eq "<span itemprop=\"about\"><a href=\"/catalog?f%5Bsubject_sim%5D%5B%5D=Awesome\"><span itemprop=\"about\">Awesome</span></a></span>" }
+      end
+
+      context "creator_tesim" do
+        let(:field_name) { 'creator_tesim' }
+        it { is_expected.to eq "<span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Justin\"><span itemprop=\"creator\">Justin</span></a></span> and <span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Joe\"><span itemprop=\"creator\">Joe</span></a></span>" }
+      end
+
+      context "contributor_tesim" do
+        let(:field_name) { 'contributor_tesim' }
+        it { is_expected.to eq "<span itemprop=\"contributor\"><a href=\"/catalog?Bird%2C+Big=%22contributor%22&amp;search_field=advanced\">Bird, Big</a></span>" }
+      end
+
+      context "publisher_tesim" do
+        let(:field_name) { 'publisher_tesim' }
+        it { is_expected.to eq "<span itemprop=\"publisher\"><a href=\"/catalog?f%5Bpublisher_sim%5D%5B%5D=Penguin+Random+House\"><span itemprop=\"publisher\">Penguin Random House</span></a></span>" }
+      end
+
+      context "location_tesim" do
+        let(:field_name) { 'based_near_tesim' }
+        it { is_expected.to eq "<span itemprop=\"contentLocation\"><a href=\"/catalog?f%5Bbased_near_sim%5D%5B%5D=Pennsylvania\"><span itemprop=\"contentLocation\">Pennsylvania</span></a></span>" }
+      end
+
+      context "language_tesim" do
+        let(:field_name) { 'language_tesim' }
+        it { is_expected.to eq "<span itemprop=\"inLanguage\"><a href=\"/catalog?f%5Blanguage_sim%5D%5B%5D=English\"><span itemprop=\"inLanguage\">English</span></a></span>" }
+      end
+
+      context "resource_type_tesim" do
+        let(:field_name) { 'resource_type_tesim' }
+        it { is_expected.to eq "<a href=\"/catalog?f%5Bresource_type_sim%5D%5B%5D=Capstone+Project\">Capstone Project</a>" }
+      end
+
+      context "identifier_tesim" do
+        let(:field_name) { 'identifier_tesim' }
+        it { is_expected.to eq "<a href=\"/catalog?65434567654345654=%22identifier%22&amp;search_field=advanced\">65434567654345654</a>" }
+      end
+    end
+  end
+end

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -1,42 +1,37 @@
 
 describe 'catalog/_index_list_default', type: :view do
   let(:attributes) do
-    { 'creator_tesim' => ['Justin', 'Joe'],
-      'depositor_tesim' => ['jcoyne@justincoyne.com'],
-      'proxy_depositor_ssim' => ['atz@stanford.edu'],
-      'description_tesim' => ['This links to http://example.com/ What about that?'],
-      'date_uploaded_dtsi' => '2013-03-14T00:00:00Z',
-      'rights_tesim' => ["http://creativecommons.org/publicdomain/zero/1.0/",
-                         "http://creativecommons.org/publicdomain/mark/1.0/",
-                         "http://www.europeana.eu/portal/rights/rr-r.html"] }
+    { 'creator_tesim' => [''],
+      'depositor_tesim' => [''],
+      'proxy_depositor_ssim' => [''],
+      'description_tesim' => [''],
+      'date_uploaded_dtsi' => 'a date',
+      'rights_tesim' => [''] }
   end
   let(:document) { SolrDocument.new(attributes) }
   let(:blacklight_configuration_context) do
     Blacklight::Configuration::Context.new(controller)
   end
-  let(:joe) { stub_model(User, email: 'atz@stanford.edu') }
-  let(:justin) { stub_model(User, email: 'jcoyne@justincoyne.com') }
-
   before do
-    allow(User).to receive(:find_by_user_key).and_return(joe, justin)
     allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
     allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+    allow(view).to receive(:render_index_field_value) { |_, conf| "Test #{conf[:field]}" }
     render 'catalog/index_list_default', document: document
   end
 
   it "displays metadata" do
     expect(rendered).not_to include 'Title:'
     expect(rendered).to include '<span class="attribute-label h4">Creator:</span>'
-    expect(rendered).to include '<span itemprop="creator">Justin</span> and <span itemprop="creator">Joe</span>'
+    expect(rendered).to include 'Test creator_tesim'
     expect(rendered).to include '<span class="attribute-label h4">Description:</span>'
-    expect(rendered).to include '<span itemprop="description">This links to <a href="http://example.com/"><span class="glyphicon glyphicon-new-window"></span> http://example.com/</a> What about that?</span>'
+    expect(rendered).to include 'Test description_tesim'
     expect(rendered).to include '<span class="attribute-label h4">Date Uploaded:</span>'
-    expect(rendered).to include '<span itemprop="datePublished">03/14/2013</span>'
+    expect(rendered).to include 'Test date_uploaded_dtsi'
     expect(rendered).to include '<span class="attribute-label h4">Depositor:</span>'
-    expect(rendered).to include '<a href="/users/atz@stanford-dot-edu">atz@stanford.edu</a>'
+    expect(rendered).to include 'Test proxy_depositor_ssim'
     expect(rendered).to include '<span class="attribute-label h4">Owner:</span>'
-    expect(rendered).to include '<a href="/users/jcoyne@justincoyne-dot-com">jcoyne@justincoyne.com</a>'
+    expect(rendered).to include 'Test depositor_tesim'
     expect(rendered).to include '<span class="attribute-label h4">Rights:</span>'
-    expect(rendered).to include '<a href="http://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal</a>, <a href="http://creativecommons.org/publicdomain/mark/1.0/">Public Domain Mark 1.0</a>, and <a href="http://www.europeana.eu/portal/rights/rr-r.html">All rights reserved</a>'
+    expect(rendered).to include 'Test rights_tesim'
   end
 end


### PR DESCRIPTION
Fixes #2165 
In Sufia 7.0.0 the metadata in the search results is not linked and we'd like the metadata to be consistently linked throughout the application. Uses Blacklight `link_to_search` in the catalog controller and updates spec test to allow the view to use `:search_state` and `:search_action_path`.

Changes proposed in this pull request:
* Adds link_to_search: solr_name("term", :facetable) to catalog controller
* Updates spec test to use :search_state and :search_action_path

@projecthydra/sufia-code-reviewers

… to allow the view to receive :search_state and :search_action_path.