### PR TITLE
Change the key which help text is put under to match what simple_form…

### DIFF
--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -302,7 +302,7 @@ en:
         size:             "Size"
         <<: *work_labels
 
-    metadata_help:
+    hints:
       generic_work:
         resource_type_html: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
         title: "A name to aid in identifying a work."


### PR DESCRIPTION
Fixes #2007 

Help text was not appearing because recent commits used the old key (`metadata_help`) for help text in the locales config files. Now that we are using `simple_form` to render our help text it needs to be listed under `hints`.