### PR TITLE
Update contact form and tests, fixes #2225

### DIFF
--- a/app/controllers/concerns/sufia/contact_form_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/contact_form_controller_behavior.rb
@@ -17,13 +17,15 @@ module Sufia
         flash.now[:error] << @contact_form.errors.full_messages.map(&:to_s).join(",")
       end
       render :new
-    rescue
+    rescue RuntimeError
       flash.now[:error] = 'Sorry, this message was not delivered.'
       render :new
     end
 
+    # Override this method if you want to perform additional operations
+    # when a email is successfully sent, such as sending a confirmation
+    # response to the user.
     def after_deliver
-      return unless Sufia.config.enable_contact_form_delivery
     end
   end
 end

--- a/app/models/contact_form.rb
+++ b/app/models/contact_form.rb
@@ -20,8 +20,8 @@ class ContactForm < MailForm::Base
   # in ActionMailer accepts.
   def headers
     {
-      subject: "Contact Form:#{subject}",
-      to: Sufia.config.contact_email,
+      subject: "#{Sufia.config.subject_prefix} #{subject}",
+      to: email,
       from: Sufia.config.from_email
     }
   end

--- a/lib/generators/sufia/templates/config/sufia.rb
+++ b/lib/generators/sufia/templates/config/sufia.rb
@@ -1,6 +1,12 @@
 Sufia.config do |config|
   config.register_curation_concern :generic_work
 
+  # Account appearing in the "From" field of emails sent from the contact form
+  # config.from_email = "no-reply@example.org"
+
+  # Text prefacing the subject entered in the contact form
+  # config.subject_prefix = "Contact form:"
+
   # How many notifications should be displayed on the dashboard
   # config.max_notifications_for_dashboard = 5
 

--- a/lib/sufia/configuration.rb
+++ b/lib/sufia/configuration.rb
@@ -23,11 +23,6 @@ module Sufia
       @libreoffice_path ||= "soffice"
     end
 
-    attr_writer :enable_contact_form_delivery
-    def enable_contact_form_delivery
-      @enable_contact_form_delivery ||= false
-    end
-
     attr_writer :browse_everything
     def browse_everything
       @browse_everything ||= nil
@@ -122,6 +117,16 @@ module Sufia
     attr_writer :translate_id_to_uri
     def translate_id_to_uri
       @translate_id_to_uri ||= ActiveFedora::Noid.config.translate_id_to_uri
+    end
+
+    attr_writer :from_email
+    def from_email
+      @from_email ||= "no-reply@example.org"
+    end
+
+    attr_writer :subject_prefix
+    def subject_prefix
+      @subject_prefix ||= "Contact form:"
     end
   end
 end

--- a/spec/controllers/contact_form_controller_spec.rb
+++ b/spec/controllers/contact_form_controller_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe ContactFormController do
+  let(:user) { create(:user) }
+  let(:required_params) do
+    {
+      category: "Depositing content",
+      name: "Rose Tyler",
+      email: "rose@timetraveler.org",
+      subject: "The Doctor",
+      message: "Run."
+    }
+  end
+
+  before { sign_in(user) }
+
+  describe "#new" do
+    subject { response }
+    before { get :new }
+    it { is_expected.to be_success }
+  end
+
+  describe "#create" do
+    subject { flash }
+    before { post :create, contact_form: params }
+    context "with the required parameters" do
+      let(:params) { required_params }
+      its(:notice) { is_expected.to eq("Thank you for your message!") }
+    end
+
+    context "without a category" do
+      let(:params)  { required_params.except(:category) }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Category can't be blank") }
+    end
+
+    context "without a name" do
+      let(:params)  { required_params.except(:name) }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Name can't be blank") }
+    end
+
+    context "without an email" do
+      let(:params)  { required_params.except(:email) }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email can't be blank") }
+    end
+
+    context "without a subject" do
+      let(:params)  { required_params.except(:subject) }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Subject can't be blank") }
+    end
+
+    context "without a message" do
+      let(:params)  { required_params.except(:message) }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Message can't be blank") }
+    end
+
+    context "with an invalid email" do
+      let(:params)  { required_params.merge(email: "bad-wolf") }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email is invalid") }
+    end
+  end
+
+  describe "#after_deliver" do
+    context "with a successful email" do
+      it "calls #after_deliver" do
+        expect(controller).to receive(:after_deliver)
+        post :create, contact_form: required_params
+      end
+    end
+    context "with an unsuccessful email" do
+      it "does not call #after_deliver" do
+        expect(controller).not_to receive(:after_deliver)
+        post :create, contact_form: required_params.except(:email)
+      end
+    end
+  end
+end

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -1,10 +1,7 @@
 describe "Sending an email via the contact form", type: :feature do
-  before do
-    sign_in :user_with_fixtures
-  end
+  before { sign_in(:user) }
 
   it "sends mail" do
-    allow_any_instance_of(ContactForm).to receive(:deliver).and_return(true)
     visit '/'
     click_link "Contact"
     expect(page).to have_content "Contact Form"
@@ -14,90 +11,6 @@ describe "Sending an email via the contact form", type: :feature do
     fill_in "contact_form_subject", with: "My Subject is Cool"
     select "Depositing content", from: "contact_form_category"
     click_button "Send"
-    expect(page).to have_content "Thank you"
-    expect(page).not_to have_content "I am contacting you regarding ScholarSphere."
-    # this step allows the delivery to go back to normal
-    allow_any_instance_of(ContactForm).to receive(:deliver).and_call_original
-  end
-
-  it "gives an error when I don't provide a contact type" do
-    visit '/'
-    click_link "Contact"
-    expect(page).to have_content "Contact Form"
-    fill_in "contact_form_name", with: "Test McPherson"
-    fill_in "contact_form_email", with: "archivist1@example.com"
-    fill_in "contact_form_message", with: "I am contacting you regarding ScholarSphere."
-    fill_in "contact_form_subject", with: "My Subject is Cool"
-    click_button "Send"
-    expect(page).to have_content "Sorry, this message was not sent successfully"
-  end
-
-  it "gives an error when I don't provide a valid email" do
-    visit '/'
-    click_link "Contact"
-    expect(page).to have_content "Contact Form"
-    fill_in "contact_form_name", with: "Test McPherson"
-    fill_in "contact_form_email", with: "archivist1"
-    fill_in "contact_form_message", with: "I am contacting you regarding ScholarSphere."
-    fill_in "contact_form_subject", with: "My Subject is Cool"
-    select "Depositing content", from: "contact_form_category"
-    click_button "Send"
-    expect(page).to have_content "Sorry, this message was not sent successfully"
-  end
-
-  it "gives an error when I don't provide a name" do
-    visit '/'
-    click_link "Contact"
-    expect(page).to have_content "Contact Form"
-    fill_in "contact_form_email", with: "archivist1@example.com"
-    fill_in "contact_form_message", with: "I am contacting you regarding ScholarSphere."
-    fill_in "contact_form_subject", with: "My Subject is Cool"
-    select "Depositing content", from: "contact_form_category"
-    click_button "Send"
-    expect(page).to have_content "Sorry, this message was not delivered"
-  end
-
-  context "when I don't provide a subject", :js do
-    it "gives an error" do
-      # TODO: this should be a controller test, because that any_instance will be in a different thread
-      visit '/'
-      click_link "Contact"
-      expect(page).to have_content "Contact Form"
-      fill_in "contact_form_name", with: "Test McPherson"
-      fill_in "contact_form_email", with: "archivist1@example.com"
-      fill_in "contact_form_message", with: "I am contacting you regarding ScholarSphere."
-      select "Depositing content", from: "contact_form_category"
-      expect_any_instance_of(ContactForm).not_to receive(:deliver)
-      click_button "Send"
-    end
-  end
-
-  context "when I don't provide a message", :js do
-    it "gives an error" do
-      # TODO: this should be a controller test, because that any_instance will be in a different thread
-      visit '/'
-      click_link "Contact"
-      expect(page).to have_content "Contact Form"
-      fill_in "contact_form_name", with: "Test McPherson"
-      fill_in "contact_form_email", with: "archivist1@example.com"
-      fill_in "contact_form_subject", with: "My Subject is Cool"
-      select "Depositing content", from: "contact_form_category"
-      expect_any_instance_of(ContactForm).not_to receive(:deliver)
-      click_button "Send"
-    end
-  end
-
-  it "gives an error when I provide an invalid captcha" do
-    visit '/'
-    click_link "Contact"
-    expect(page).to have_content "Contact Form"
-    fill_in 'contact_form_contact_method', with: 'My name is', visible: false
-    fill_in "contact_form_name", with: "Test McPherson"
-    fill_in "contact_form_email", with: "archivist1@example.com"
-    fill_in "contact_form_subject", with: "My Subject is Cool"
-    fill_in "contact_form_message", with: "I am contacting you regarding ScholarSphere."
-    select "Depositing content", from: "contact_form_category"
-    click_button "Send"
-    expect(page).to have_content "Sorry, this message was not sent successfully"
+    expect(page).to have_content "Thank you for your message!"
   end
 end


### PR DESCRIPTION
Fixes #2225 

* Remove enable_contact_form_delivery in config
* fail better in ContactFormControllerBehavior
* use more accurate controller tests instead of features

@projecthydra/sufia-code-reviewers