### PR TITLE
Enables Works within Works and related UI and functionality

### DIFF
--- a/app/assets/javascripts/sufia.js
+++ b/app/assets/javascripts/sufia.js
@@ -57,7 +57,7 @@
 //= require sufia/autocomplete/location
 //= require sufia/autocomplete/subject
 //= require sufia/autocomplete/language
-
+//= require sufia/relationships
 //= require curation_concerns/collections
 //= require hydra-editor/hydra-editor
 //= require nestable

--- a/app/assets/javascripts/sufia/app.js
+++ b/app/assets/javascripts/sufia/app.js
@@ -9,6 +9,7 @@ Sufia = {
         this.permissions();
         this.notifications();
         this.transfers();
+        this.relationships_table();
     },
 
     autocomplete: function () {
@@ -58,6 +59,13 @@ Sufia = {
 
     transfers: function () {
         $("#proxy_deposit_request_transfer_to").userSearch();
+    },
+
+    relationships_table: function () {
+        var rel = require('sufia/relationships/table');
+        $('table.relationships-ajax-enabled').each(function () {
+            new rel.RelationshipsTable($(this));
+        });
     }
 };
 

--- a/app/assets/javascripts/sufia/relationships.js
+++ b/app/assets/javascripts/sufia/relationships.js
@@ -1,0 +1,2 @@
+//= require sufia/relationships/table
+//= require sufia/relationships/table_row

--- a/app/assets/javascripts/sufia/relationships/table.es6
+++ b/app/assets/javascripts/sufia/relationships/table.es6
@@ -1,0 +1,206 @@
+import { RelationshipsTableRow } from './table_row'
+
+export class RelationshipsTable {
+
+  /**
+   * Initializes the class in the context of an individual table element
+   * @param {jQuery} element the table element that this class represents
+   */
+  constructor(element) {
+    this.$element = element;
+    this.form_action = this.$element.parents("form").attr("action");
+    this.query_url = this.$element.data('query-url');
+    this.existing_related_works_values = this.$element.find("input.related_works_ids:not(.new-form-control)").map(function(i, e){ return e.value; });
+
+    // TODO: Fall back to just cloning rows and removing rows for form posting
+    if (!this.query_url)
+      return;
+
+    this.bindAddButton();
+    this.bindRemoveButton();
+    this.bindKeyEvents();
+  }
+
+  /**
+   * Handle click events by the "Add" button in the table, setting a warning
+   * message if the input is empty or calling the server to handle the request
+   */
+  bindAddButton() {
+    let $this = this;
+
+    $this.$element.on("click", ".btn-add-row", function(event) {
+      let $row = $(this).parents("tr:first");
+      let $input = $row.find("input.new-form-control");
+
+      // Display an error when the input field is empty, or if the work ID is already related,
+      // otherwise clone the row and set appropriate styles
+      if ($input.val() == "") {
+        $this.setWarningMessage($row, "ID cannot be empty.");
+      } else if ($.inArray($input.val(), $this.existing_related_works_values) > -1) {
+        $this.setWarningMessage($row, "Work is already related.");
+      } else {
+
+        let query_url = $this.query_url.replace('$id', $input.val());
+        $this.hideWarningMessage($row);
+        $this.callAjax({
+          row: $row,
+          table: $this.$element,
+          input: $input,
+          url: $this.form_action,
+          query_url: query_url,
+          on_error: $this.handleError,
+          on_success: $this.handleAddRowSuccess
+        });
+      }
+    });
+  }
+
+  /**
+   * Find and fire off the click event for the "Add" button
+   * @param {jQuery} $row the row containing the add button to click
+   */
+  clickAddbutton($row) {
+    $row.find(".btn-add-row").click();
+  }
+
+  /**
+   * Handle click events by the "Remove" buttons in the table, and calling the
+   * server to handle the request
+   */
+  bindRemoveButton() {
+    let $this = this;
+
+    $this.$element.on("click", ".btn-remove-row", function(event) {
+      let $row = $(this).parents("tr:first");
+      let $input = $row.find("input.related_works_ids:first");
+
+      // Track which input is attemping to be removed, to provide an easy way
+      // for the ajax call to exclude it when making the call to the server
+      $input.addClass("removing");
+      $this.callAjax({
+        row: $row,
+        table: $this.$element,
+        input: $input,
+        url: $this.form_action,
+        on_error: $this.handleError,
+        on_success: $this.handleRemoveRowSuccess
+      });
+    });
+  }
+
+  /**
+   * Handle keyup and keypress events at the form level to prevent the ENTER key
+   * from submitting the form. ENTER key within a relationships table should
+   * click the "Add" button instead. ESC key should clear the input and hide the
+   * error message.
+   */
+  bindKeyEvents() {
+    let $this = this;
+    let $form = this.$element.parents("form");
+
+    $form.on("keyup keypress", "input.related_works_ids", function(event) {
+      let $row = $(this).parents("tr:first");
+      let key_code = event.keyCode || event.which;
+
+      // ENTER key was pressed, wait for keyup to click the Add button
+      if (key_code === 13) {
+        if (event.type == "keyup") {
+          $this.clickAddbutton($row);
+        }
+        event.preventDefault();
+        return false;
+      }
+
+      // ESC key was pressed, clear the input field and hide the error
+      if (key_code === 27 && event.type == "keyup") {
+        $(this).val("");
+        $this.hideWarningMessage($row);
+      }
+    });
+  }
+
+  /**
+   * Set the warning message related to the appropriate row in the table
+   * @param {jQuery} $row the row containing the warning message to display
+   * @param {String} message the warning message text to set
+   */
+  setWarningMessage($row, message) {
+    $row.find(".message.has-warning").text(message).removeClass("hidden");
+  }
+
+  /**
+   * Hide the warning message on the appropriate row
+   * @param {jQuery} $row the row containing the warning message to hide
+   */
+  hideWarningMessage($row){
+    $row.find(".message").addClass("hidden");
+  }
+
+  /**
+   * Call the server, then call the appropriate callbacks to handle success and errors
+   * @param {Object} args the table, row, input, url, and callbacks
+   */
+  callAjax(args) {
+    let $this = this;
+    // Send only the IDs in this table that aren't in the midst of being "removed"
+    let data = args.table.find("input.related_works_ids:not('.removing')").serialize();
+    $.ajax({
+        type: 'patch',
+        url: args.url,
+        dataType: 'json',
+        data: data
+      })
+      .done(function(json) {
+        args.on_success($this, args, json);
+      })
+      .fail(function(jqxhr, status, err) {
+        args.on_error($this, args, jqxhr, status, err);
+      });
+  }
+
+  /**
+   * Set a warning message to alert the user on an error
+   * @param {jQuery} $this the RelationshipsTable class instance
+   * @param {Object} args the table, row, input, url, and callbacks
+   * @param {Object} jqxhr the jQuery XHR response object
+   * @param {String} status the HTTP error status
+   * @param {String} err the HTTP error
+   */
+  handleError($this, args, jqxhr, status, err) {
+    args.row.find('input.removing').removeClass('removing');
+    let message = jqxhr.statusText;
+    if(jqxhr.responseJSON){
+      message = jqxhr.responseJSON.description;
+    }
+    $this.setWarningMessage(args.row, message);
+  }
+
+  /**
+   * Remove the row when the API returns this type of success
+   * @param {jQuery} $this the RelationshipsTable class instance
+   * @param {Object} args the table, row, input, url, and callbacks
+   * @param {String} json the returned JSON string
+   */
+  handleRemoveRowSuccess($this, args, json) {
+    args.row.remove();
+  }
+
+  /**
+   * Add a new row to the table, query the server for details about the work to
+   * set the title and link for the new work that was added. Hide the input
+   * field and display the title and edit button
+   * @param {jQuery} $this the RelationshipsTable class instance
+   * @param {Object} args the table, row, input, url, and callbacks
+   * @param {String} json the returned JSON string
+   */
+  handleAddRowSuccess($this, args, json) {
+    let new_row = new RelationshipsTableRow(args.table);
+    new_row.clone(args.row);
+    new_row.callAjaxQuery(args.query_url);
+
+    // finally, empty the "add" row input value
+    args.row.find("input.new-form-control").val("");
+    // synch the related_works_values to include the new work relationship
+    $this.existing_related_works_values = $this.$element.find("input.related_works_ids:not(.new-form-control)").map(function(i, e){ return e.value; });
+  }
+}

--- a/app/assets/javascripts/sufia/relationships/table_row.es6
+++ b/app/assets/javascripts/sufia/relationships/table_row.es6
@@ -1,0 +1,79 @@
+export class RelationshipsTableRow {
+  /**
+   * Inititializes a new table row class
+   * @param {jQuery} $table the table which this row is related to
+   */
+  constructor($table){
+    this.table = $table;
+    this.element = null;
+  }
+
+  /**
+   * The title element
+   * @returns {jQuery} the title element
+   */
+  get title() { return this.element.find("a.title:first"); }
+
+  /**
+   * The input field
+   * @returns {jQuery} the input field
+   */
+  get input() { return this.element.find("input.related_works_ids:first"); }
+
+  /**
+   * The "Add" button
+   * @returns {jQuery} the add button element
+   */
+  get addButton() { return this.element.find(".btn-add-row"); }
+
+  /**
+   * The "Remove" button
+   * @returns {jQuery} the remove button element
+   */
+  get removeButton() { return this.element.find(".btn-remove-row"); }
+
+  /**
+   * The "Edit" button
+   * @returns {jQuery} the edit button element
+   */
+  get editButton() { return this.element.find("a.edit:first"); }
+
+  /**
+   * Clone the row, set the element in this instance of the class, and reset the proper styles for this row. Insert
+   * this new row before the row passed in.. leaving the passed in row styled as-is, the caller of this method is responsible
+   * for properly handling adjustment to the passed in row
+   * @param {jQuery} $row the row to be cloned
+   */
+  clone($row){
+    this.element = $row.clone();
+    this.addButton.addClass("hidden");
+    this.removeButton.removeClass("hidden");
+    this.element.insertBefore($row);
+  }
+
+  /**
+   * Make an ajax call to the supplied url.
+   * After a row is cloned, this method could be called to refresh the row with more details (title, appropriate links, etc)
+   * based on the details returned from the server.
+   * @param {String} query_url the url to be called for querying details from the server
+   */
+  callAjaxQuery(query_url) {
+    let $this = this;
+    $.getJSON(query_url, function (data) {
+      // Set the cloned input to have the proper name and value for posting the
+      // form to the server, and hide it.
+      $this.input.removeClass("new-form-control")
+        .addClass("hidden")
+        .val(data.id);
+
+      // Set the linkified title and show.
+      $this.title.text(data.title[0])
+        .attr("href", query_url)
+        .removeClass("hidden");
+
+      // Set the edit button link and show.
+      $this.editButton.attr("href", query_url + "/edit")
+        .removeClass("hidden");
+    });
+  }
+}

--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -34,7 +34,19 @@ module Sufia::Forms
          :visibility_after_embargo, :visibility_during_lease,
          :lease_expiration_date, :visibility_after_lease, :visibility,
          :thumbnail_id, :representative_id, :ordered_member_ids,
-         :collection_ids]
+         :collection_ids, :in_works_ids]
+    end
+
+    # The ordered_members which are FileSet types
+    # @return [Array] All of the file sets in the ordered_members
+    def ordered_fileset_members
+      model.ordered_members.to_a.select { |m| m.model_name.singular.to_sym == :file_set }
+    end
+
+    # The ordered_members which are not FileSet types
+    # @return [Array] All of the non file sets in the ordered_members
+    def ordered_work_members
+      model.ordered_members.to_a.select { |m| m.model_name.singular.to_sym != :file_set }
     end
 
     def self.multiple?(term)

--- a/app/presenters/sufia/work_show_presenter.rb
+++ b/app/presenters/sufia/work_show_presenter.rb
@@ -17,6 +17,17 @@ module Sufia
       end
     end
 
+    def presenter_types
+      CurationConcerns.config.registered_curation_concern_types.map(&:underscore) + ["collection"]
+    end
+
+    def grouped_presenters(filtered_by: nil, except: nil)
+      grouped = collection_presenters.group_by(&:model_name).transform_keys { |key| key.to_s.underscore }
+      grouped.select! { |obj| obj.downcase == filtered_by } unless filtered_by.nil?
+      grouped.except!(*except) unless except.nil?
+      grouped
+    end
+
     def display_feature_link?
       user_can_feature_works? && solr_document.public? && FeaturedWork.can_create_another? && !featured?
     end

--- a/app/views/curation_concerns/base/_form_child_work_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_child_work_relationships.html.erb
@@ -1,0 +1,65 @@
+<%# Form UI behavior code and details;
+Code:
+  app/assets/javascripts/sufia/relationships
+CSS:
+  table.relationships-ajax-enabled : Used by sufia JS app as selector to wire up the UI functionality
+  tr.new-row : The basic template row for cloning when user clicks "Add"
+  .btn-remove-row : Button to remove its parent TR from the table
+  .btn-add-row : Button to clone its parent TR and inject a new row into the table
+  input.new-form-control : Input field for client client side validation and additional features
+  .message.has-warning : Used to display UI errors related to input values and server errors
+HTML Properties:
+  table:
+    data-query-url : URL base to append newly added work ID to for querying details (title, href)
+%>
+<div class="form-group multi_value optional managed">
+  <%= link_to "Attach New Work", polymorphic_path([main_app, :new, :curation_concerns, :parent, curation_concern.model_name.singular], parent_id: params[:id]), target: "_blank", class: 'btn btn-primary' %>
+
+  <table class="table table-striped related-files relationships-ajax-enabled"
+         data-query-url="<%= polymorphic_path([main_app, :curation_concerns, curation_concern.model_name.singular], id: '$id') %>">
+    <thead>
+    <tr>
+      <th>Child Work</th>
+      <th>Actions</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr class="hidden">
+      <td>
+        <% f.object.ordered_fileset_members.each do |fileset| %>
+          <input class="related_works_ids work_filesets_ids" name="<%= f.object.model_name.param_key %>[ordered_member_ids][]" type="hidden" value="<%= fileset.id %>">
+        <% end %>
+      </td>
+      <td></td>
+    </tr>
+    <% f.object.ordered_work_members.each do |member| %>
+        <tr>
+          <td>
+            <%= link_to member.title.first, [main_app, member] %>
+            <input class="string multi_value optional form-control related_works_ids work_child_members_ids form-control multi-text-field hidden" value="<%= member.id %>" id="work_child_members_ids" aria-labelledby="work_child_members_ids_label" name="<%= f.object.model_name.param_key %>[ordered_member_ids][]" type="text">
+          </td>
+          <td>
+            <div class="child-actions">
+              <%= link_to "Edit", [main_app, :edit, member], target: "_blank", class: 'btn btn-default' %>
+              <a class="btn btn-danger btn-remove-row">Remove</a>
+            </div>
+          </td>
+        </tr>
+    <% end %>
+    <tr class="new-row">
+      <td>
+        <a href="" class="title hidden"></a>
+        <input class="new-form-control string multi_value optional related_works_ids work_child_members_ids form-control multi-text-field" value="" id="work_child_members_ids" aria-labelledby="work_child_members_ids_label" name="<%= f.object.model_name.param_key %>[ordered_member_ids][]" type="text">
+        <div class="message has-warning hidden"></div>
+      </td>
+      <td>
+        <div class="child-actions">
+          <a href="" class="edit hidden btn btn-default" target="_blank">Edit</a>
+          <a class="btn btn-danger btn-remove-row hidden">Remove</a>
+          <a class="btn btn-primary btn-add-row">Add</a>
+        </div>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/curation_concerns/base/_form_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_relationships.html.erb
@@ -1,6 +1,15 @@
+<%= render 'form_in_works', f: f %>
 <h2><%= t("sufia.works.#{action_name}.in_collections") %></h2>
 <div id="collection-widget">
   <%= f.input :collection_ids, as: :select,
-      collection: available_collections(nil),
-      input_html: { class: 'form-control', multiple: true } %>
+              collection: available_collections(nil),
+              input_html: { class: 'form-control', multiple: true } %>
 </div>
+
+<% if params[:id] %>
+  <h3><%= t("sufia.works.#{action_name}.in_this_work") %></h3>
+  <%= render 'form_child_work_relationships', f: f %>
+
+  <h3><%= t("sufia.works.#{action_name}.in_other_works") %></h3>
+  <%= render_edit_field_partial(:in_works_ids, f: f) %>
+<% end %>

--- a/app/views/curation_concerns/base/_relationships.html.erb
+++ b/app/views/curation_concerns/base/_relationships.html.erb
@@ -1,22 +1,7 @@
-    <h2><%= t('.header') %></h2>
-    <% collection_presenters = presenter.collection_presenters %>
-    <% if collection_presenters.blank? %>
-        <p><%= t('.empty', type: presenter.human_readable_type) %></p>
-    <% else %>
-      <table class="table table-striped relationships">
-        <tbody>
-        <tr>
-          <th><%= t('.collections', type: presenter.human_readable_type) %></th>
-          <td>
-            <% collection_presenters.each do |collection| %>
-              <ul class="tabular">
-                <li class='attribute title'>
-                  <%= link_to collection.to_s, main_app.collection_path(collection) %>
-                </li>
-              </ul>
-            <% end %>
-          </td>
-        </tr>
-        </tbody>
-      </table>
-    <% end %>
+<h2><%= t('.header') %></h2>
+<table class="table table-striped relationships">
+  <tbody>
+    <%= render 'relationships_parent_rows', presenter: presenter %>
+    <%= render 'relationships_member_rows', presenter: presenter %>
+  </tbody>
+</table>

--- a/app/views/curation_concerns/base/_relationships_member_rows.html.erb
+++ b/app/views/curation_concerns/base/_relationships_member_rows.html.erb
@@ -1,0 +1,24 @@
+<% member_presenters = presenter.member_presenters.group_by(&:model_name).transform_keys{|key| key.to_s.singularize.underscore}.select{ |k,v| k.to_sym != :file_set } %>
+<% if member_presenters.blank? %>
+  <tr>
+    <th><%= t(".label", type: presenter.human_readable_type) %></th>
+    <td>
+      <p><%= t('.empty', type: presenter.human_readable_type) %></p>
+    </td>
+  </tr>
+<% else %>
+  <% member_presenters.each_pair do |model_name, members| %>
+    <tr>
+      <th><%= t(".label", type: presenter.human_readable_type) %></th>
+      <td>
+        <ul class="tabular">
+          <% members.each do |member| %>
+            <li class='attribute title'>
+              <%= link_to member.title.first, [main_app, member] %>
+            </li>
+          <% end %>
+        </ul>
+      </td>
+    </tr>
+  <% end %>
+<% end %>

--- a/app/views/curation_concerns/base/_relationships_parent_row.html.erb
+++ b/app/views/curation_concerns/base/_relationships_parent_row.html.erb
@@ -1,0 +1,16 @@
+<tr>
+  <th><%= t(".label", type: type.humanize) %></th>
+  <td>
+    <% if items.blank? %>
+      <p><%= t('.empty', type: type.humanize) %></p>
+    <% else %>
+      <ul class="tabular">
+        <% items.each do |item| %>
+          <li class='attribute title'>
+            <%= link_to item.title.first, [main_app, item] %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/curation_concerns/base/_relationships_parent_row_empty.html.erb
+++ b/app/views/curation_concerns/base/_relationships_parent_row_empty.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <th><%= t(".label", type: type.humanize) %></th>
+  <td>
+    <p><%= t(".empty", type: type.humanize) %></p>
+  </td>
+</tr>

--- a/app/views/curation_concerns/base/_relationships_parent_rows.html.erb
+++ b/app/views/curation_concerns/base/_relationships_parent_rows.html.erb
@@ -1,0 +1,23 @@
+<% presenters = presenter.collection_presenters %>
+<% if presenters.blank? %>
+  <% presenter.presenter_types.each do |type| %>
+    <%= render 'relationships_parent_row_empty', type: type, presenter: presenter %>
+  <% end %>
+<% else %>
+
+  <%# Render presenters which aren't specified in the 'presenter_types' %>
+  <% presenter.grouped_presenters(except: presenter.presenter_types).each_pair do |model_name, items| %>
+    <%= render 'relationships_parent_row', type: model_name, items: items, presenter: presenter %>
+  <% end %>
+
+  <%# Render grouped presenters showing rows or an 'empty' row if there are none for that type %>
+  <% presenter.presenter_types.each do |type| %>
+    <% if presenter.grouped_presenters(filtered_by: type).blank? %>
+      <%= render 'relationships_parent_row_empty', type: type, presenter: presenter %>
+    <% else %>
+      <% presenter.grouped_presenters(filtered_by: type).each_pair do |model_name, items| %>
+        <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/records/edit_fields/_in_works_ids.html.erb
+++ b/app/views/records/edit_fields/_in_works_ids.html.erb
@@ -1,0 +1,59 @@
+<%# Form UI behavior code and details;
+Code:
+  app/assets/javascripts/sufia/relationships
+CSS:
+  table.relationships-ajax-enabled : Used by sufia JS app as selector to wire up the UI functionality
+  tr.new-row : The basic template row for cloning when user clicks "Add"
+  .btn-remove-row : Button to remove its parent TR from the table
+  .btn-add-row : Button to clone its parent TR and inject a new row into the table
+  input.new-form-control : Input field for client client side validation and additional features
+  .message.has-warning : Used to display UI errors related to input values and server errors
+HTML Properties:
+  table:
+    data-query-url : URL base to append newly added work ID to for querying details (title, href)
+%>
+<% if f.object.class.multiple? key %>
+  <div class="form-group multi_value optional work_in_works_ids managed">
+    <table class="table table-striped related-files relationships-ajax-enabled"
+           data-query-url="<%=polymorphic_path([main_app, :curation_concerns, curation_concern.model_name.singular], id: '$id') %>">
+      <thead>
+        <tr>
+          <th>Parent Work</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% curation_concern.in_works.each do |parent| %>
+          <tr>
+            <td>
+              <%= link_to "#{parent.title.first}", polymorphic_path([main_app, :curation_concerns, curation_concern.model_name.singular], id: parent.id) %>
+              <input class="string multi_value optional form-control related_works_ids form-control multi-text-field hidden" name="<%= curation_concern.model_name.param_key %>[in_works_ids][]" value="<%= parent.id %>" id="work_in_works_ids" aria-labelledby="work_in_works_ids_label" type="text">
+            </td>
+            <td>
+              <div class="child-actions">
+                <%= link_to "Edit", edit_polymorphic_path([main_app, :curation_concerns, curation_concern.model_name.singular], id: parent.id), target: "_blank", class: 'btn btn-default' %>
+                <a class="btn btn-danger btn-remove-row">Remove</a>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+        <tr class="new-row">
+          <td>
+            <a href="" class="title hidden"></a>
+            <input class="new-form-control string multi_value optional related_works_ids form-control multi-text-field" name="<%= curation_concern.model_name.param_key %>[in_works_ids][]" value="" aria-labelledby="work_in_works_ids_label" type="text">
+            <div class="message has-warning hidden"></div>
+          </td>
+          <td>
+            <div class="child-actions">
+              <a href="" class="edit hidden btn btn-default" target="_blank">Edit</a>
+              <a class="btn btn-danger btn-remove-row hidden">Remove</a>
+              <a class="btn btn-primary btn-add-row">Add</a>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+<% else %>
+  <%= f.input key, required: f.object.required?(key) %>
+<% end %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -212,10 +212,14 @@ en:
       new:
         header: Add New Work
         in_collections: This Work in Collections
+        in_this_work: Other Works in this Work
+        in_other_works: This Work in Other Works
         after_create_html: "Your files are being processed by %{application_name} in the background. The metadata and access controls you specified are being applied. Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh this page to see these updates."
       edit:
         header: Edit Work
         in_collections: This Work in Collections
+        in_this_work: Other Works in this Work
+        in_other_works: This Work in Other Works
         additional_fields: "Additional fields"
         tab:
           metadata:      "Descriptions"
@@ -230,6 +234,8 @@ en:
       new:
         header: Batch Create New Works
         in_collections: These Works in Collections
+        in_this_work: Other Works in this Work
+        in_other_works: This Work in Other Works
       progress:
         header: Save Works
       files:
@@ -342,8 +348,15 @@ en:
     base:
       relationships:
         header: Relationships
-        empty:       "This %{type} is not currently in any collections."
-        collections: "In collections:"
+        empty: "This %{type} is not currently in any collections."
+      relationships_parent_row:
+        label: "In %{type}:"
+      relationships_parent_row_empty:
+        label: "In %{type}:"
+        empty: "There are no %{type} relationships."
+      relationships_member_rows:
+        label: "Has related %{type}:"
+        empty: "This %{type} does not have any related works."
       metadata:
         header: Descriptions
         attribute_name_label: Attribute Name
@@ -372,6 +385,7 @@ en:
       fields:
         show:
           keyword: Keyword
+
 
   helpers:
     action:

--- a/spec/forms/sufia/forms/work_form_spec.rb
+++ b/spec/forms/sufia/forms/work_form_spec.rb
@@ -1,0 +1,20 @@
+describe Sufia::Forms::WorkForm do
+  let(:work) { GenericWork.new }
+  let(:form) { described_class.new(work, nil) }
+  let(:works) { [GenericWork.new, FileSet.new, GenericWork.new] }
+  let(:files) { [FileSet.new, GenericWork.new, FileSet.new] }
+
+  describe "#ordered_fileset_members" do
+    it "expects ordered fileset members" do
+      allow(work).to receive(:ordered_members).and_return(files)
+      expect(form.ordered_fileset_members.size).to eq(2)
+    end
+  end
+
+  describe "#ordered_work_members" do
+    it "expects ordered work members" do
+      allow(work).to receive(:ordered_members).and_return(works)
+      expect(form.ordered_work_members.size).to eq(2)
+    end
+  end
+end

--- a/spec/javascripts/helpers/test_fixtures.js.coffee
+++ b/spec/javascripts/helpers/test_fixtures.js.coffee
@@ -1,0 +1,9 @@
+window.TestFixtures = {
+  relationships_table: {
+    child_id: 'child1234',
+    parent_id: 'parent5678'
+  }
+}
+
+window.TestFixtures.relationships_table["html"] = "<form action='/concern/generic_works/#{TestFixtures.relationships_table.child_id}'><table class='table table-striped related-files relationships-ajax-enabled' data-query-url='/concern/generic_works/$id'> <thead> <tr> <th>Parent Work</th> <th>Actions</th> </tr> </thead> <tbody> <tr class='new-row'> <td> <a href='' class='title hidden'></a> <input class='new-form-control string multi_value optional related_works_ids form-control multi-text-field' name='generic_work[in_works_ids][]' value='' aria-labelledby='generic_work_in_works_ids_label' type='text'> <div class='message has-warning hidden'></div> </td> <td> <div class='child-actions'> <a href='' class='edit hidden btn btn-default' target='_blank'>Edit</a> <a class='btn btn-danger btn-remove-row hidden'>Remove</a> <a class='btn btn-primary btn-add-row'>Add</a></div></td></tr></tbody></table></form>"
+

--- a/spec/javascripts/helpers/test_responses.js
+++ b/spec/javascripts/helpers/test_responses.js
@@ -1,0 +1,13 @@
+var TestResponses = {
+  relationships_table: {
+    query_url_success: {
+        id: "parent5678",
+        title: ["Parent"]
+    },
+    ajax_add_success:{},
+    ajax_remove_success:{},
+    ajax_error: {
+      responseText: "Error"
+    },
+  }
+}

--- a/spec/javascripts/relationships_table_spec.js.coffee
+++ b/spec/javascripts/relationships_table_spec.js.coffee
@@ -1,0 +1,83 @@
+describe 'RelationshipsTable', ->
+  control = require('sufia/relationships/table')
+  form = null
+  element = null
+  btn_remove = null
+  btn_add = null
+  btn_edit = null
+  input = null
+  message = null
+  test_fixtures = TestFixtures
+  test_responses = TestResponses
+  deferred_ajax = null
+
+  beforeEach ->
+    form = $(test_fixtures.relationships_table.html)
+    element = form.find("table")
+    btn_remove = element.find('.btn-remove-row')
+    btn_add = element.find('.btn-add-row')
+    btn_edit = element.find('.edit')
+    input = element.find('.new-form-control')
+    message = element.find('.message')
+    target = new control.RelationshipsTable(element)
+    jasmine.Ajax.install()
+    deferred_ajax = new jQuery.Deferred()
+    spyOn($,'ajax').and.returnValue(deferred_ajax)
+    spyOn($,'getJSON').and.callFake((url, success) ->
+      success(test_responses.relationships_table.query_url_success))
+
+  afterEach ->
+    jasmine.Ajax.uninstall()
+
+  describe 'when adding/removing a row', ->
+    # the new-row is properly rendered
+    it 'only displays one new row with an add button visible', ->
+      expect(btn_remove.hasClass("hidden")).toBeTruthy()
+      expect(btn_edit.hasClass("hidden")).toBeTruthy()
+      expect(btn_add.hasClass("hidden")).toBeFalsy()
+
+    it 'clicks add with a valid id', ->
+      input.val(test_fixtures.relationships_table.parent_id)
+      btn_add.click()
+      deferred_ajax.resolve(test_responses.relationships_table.ajax_add_success)
+      expect(message.hasClass("hidden")).toBeTruthy()
+      expect(element.find("tbody tr").length).toEqual(2)
+
+    it 'clicks add with an invalid id', ->
+      input.val('invalid')
+      btn_add.click()
+      deferred_ajax.reject(test_responses.relationships_table.ajax_error)
+      expect(message.hasClass("hidden")).toBeFalsy()
+      expect(element.find("tbody tr").length).toEqual(1)
+
+    it 'clicks add without an id', ->
+      expect(message.hasClass("hidden")).toBeTruthy()
+      btn_add.click()
+      expect(message.hasClass("hidden")).toBeFalsy()
+      expect(message.text()).toContain("ID cannot be empty")
+      expect(element.find("tbody tr").length).toEqual(1)
+
+    it 'clicks remove to remove a work', ->
+      input.val(test_fixtures.relationships_table.parent_id)
+      btn_add.click()
+      deferred_ajax.resolve(test_responses.relationships_table.ajax_add_success)
+      expect(element.find("tbody tr").length).toEqual(2)
+      parent_row = element.find("tbody tr:first")
+      parent_delete = parent_row.find(".btn-remove-row")
+      parent_delete.click()
+      deferred_ajax.resolve(test_responses.relationships_table.ajax_remove_success)
+      expect(element.find("tbody tr").length).toEqual(1)
+
+    it 'clicks add with a duplicate id', ->
+      input.val(test_fixtures.relationships_table.parent_id)
+      btn_add.click()
+      deferred_ajax.resolve(test_responses.relationships_table.ajax_add_success)
+      expect(element.find("tbody tr").length).toEqual(2)
+      input = element.find("tbody tr:nth-child(2) .new-form-control")
+      input.val(test_fixtures.relationships_table.parent_id)
+      btn_add = element.find("tbody tr:nth-child(2) .btn-add-row")
+      btn_add.click()
+      message = element.find("tbody tr:nth-child(2) .message")
+      expect(element.find("tbody tr").length).toEqual(2)
+      expect(message.hasClass("hidden")).toBeFalsy()
+      expect(message.text()).toContain("Work is already related")

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -38,7 +38,7 @@ stylesheets:
 #   - helpers/**/*.js
 #
 helpers:
-  - 'helpers/**/*.js'
+  - 'helpers/**/*.{js,coffee,js.coffee}'
 
 # spec_files
 #

--- a/spec/views/curation_concerns/base/_form_child_work_relationships.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form_child_work_relationships.html.erb_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+describe "curation_concerns/base/_form_child_work_relationships.html.erb", type: :view do
+  let(:work) do
+    stub_model(GenericWork, id: '456', title: ["MyWork"])
+  end
+
+  let(:work_2) do
+    stub_model(GenericWork, id: '567', title: ["Child Work"])
+  end
+
+  let(:ability) { double }
+
+  let(:form) do
+    Sufia::Forms::WorkForm.new(work, ability)
+  end
+
+  let(:f) { double }
+
+  let(:page) do
+    render
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  before do
+    view.lookup_context.view_paths.push 'app/views/curation_concerns'
+    allow(view).to receive(:params).and_return(id: work.id)
+    allow(view).to receive(:curation_concern).and_return(work)
+    allow(view).to receive(:f).and_return(f)
+    allow(f).to receive(:object).and_return(form)
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    assign(:form, form)
+  end
+
+  context "When editing a work" do
+    context "and no children works are present" do
+      before do
+        allow(work).to receive(:ordered_members).and_return([])
+      end
+      it "has 1 empty child work input" do
+        expect(page).to have_selector("input[value='']", count: 1)
+      end
+
+      it "will not display the remove button in the actions" do
+        expect(page).to have_selector(".btn-remove-row", visible: false)
+      end
+
+      it "will display the add button in the actions" do
+        expect(page).to have_selector(".btn-add-row", visible: true, count: 1)
+      end
+    end
+    context "When 1 child work is present" do
+      let(:work_2) do
+        stub_model(GenericWork, id: '567', title: ["Test Child Work"])
+      end
+
+      before do
+        allow(work).to receive(:ordered_members).and_return([work_2])
+      end
+      it "has 1 empty child work input with add button" do
+        expect(page).to have_selector("input[value='']", count: 1)
+        expect(page).to have_selector(".btn-add-row", visible: true, count: 1)
+      end
+
+      it "has an input box that is filled in with the child id" do
+        expect(page).to have_selector("input[value='#{work_2.id}']", count: 1)
+      end
+
+      it "generates a link for the childs first title" do
+        expect(page).to have_link("Test Child Work")
+      end
+
+      it "has an edit and remove button" do
+        within ".old-row" do
+          expect(page).to have_selector(".btn-remove-row", visible: true, count: 1)
+          expect(page).to have_selector(".btn-edit-row", visible: true, count: 1)
+        end
+      end
+    end
+    context "When multiple child works are present" do
+      let(:work_2) do
+        stub_model(GenericWork, id: '567', title: ["Test Child Work"])
+      end
+      let(:work_3) do
+        stub_model(GenericWork, id: '789', title: ["Test Child Work 2"])
+      end
+      before do
+        allow(work).to receive(:ordered_members).and_return([work_2, work_3])
+      end
+      it "has 1 empty child work input with add button" do
+        expect(page).to have_selector("input[value='']", count: 1)
+        expect(page).to have_selector(".btn-add-row", visible: true, count: 1)
+      end
+
+      it "has an input box that is filled in with the child ids" do
+        expect(page).to have_selector("input[value='#{work_2.id}']", count: 1)
+        expect(page).to have_selector("input[value='#{work_3.id}']", count: 1)
+      end
+
+      it "generates a link for the childs first title" do
+        expect(page).to have_link("Test Child Work")
+        expect(page).to have_link("Test Child Work 2")
+      end
+
+      it "has an edit and remove button" do
+        within ".old-row" do
+          expect(page).to have_selector(".btn-remove-row", visible: true, count: 2)
+          expect(page).to have_selector(".btn-edit-row", visible: true, count: 2)
+        end
+      end
+    end
+  end
+end

--- a/spec/views/curation_concerns/base/_relationships.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_relationships.html.erb_spec.rb
@@ -4,20 +4,41 @@ describe 'curation_concerns/base/relationships', type: :view do
   let(:ability) { double }
   let(:solr_doc) { double(id: '123', human_readable_type: 'Work') }
   let(:presenter) { Sufia::WorkShowPresenter.new(solr_doc, ability) }
+  let(:generic_work) { GenericWork.new(id: '456', title: ['Containing work', 'barbaz']) }
+  let(:collection) { Collection.new(id: '345', title: ['Containing collection', 'foobar']) }
 
   context "when collections are not present" do
     before do
       render 'curation_concerns/base/relationships', presenter: presenter
     end
     it "shows the message" do
-      expect(rendered).to match %r{This Work is not currently in any collections\.}
+      expect(rendered).to match %r{There are no Collection relationships\.}
     end
   end
 
-  context "when collections are present" do
-    let(:collection_presenters) { [double(id: '456', title: ['Containing collection', 'foobar'], to_s: 'Containing collection')] }
+  context "when children are not present" do
+    before do
+      render 'curation_concerns/base/relationships', presenter: presenter
+    end
+    it "shows the message" do
+      expect(rendered).to match %r{This Work does not have any related works\.}
+    end
+  end
+
+  context "when parents are not present" do
+    before do
+      render 'curation_concerns/base/relationships', presenter: presenter
+    end
+    it "shows the message" do
+      expect(rendered).to match %r{There are no Generic work relationships\.}
+    end
+  end
+
+  context "when collections are present and no parents are present" do
+    let(:collection_presenters) { [collection] }
     let(:page) { Capybara::Node::Simple.new(rendered) }
     before do
+      allow(view).to receive(:contextual_path).and_return("/collections/456")
       allow(presenter).to receive(:collection_presenters).and_return(collection_presenters)
       render 'curation_concerns/base/relationships', presenter: presenter
     end
@@ -26,6 +47,71 @@ describe 'curation_concerns/base/relationships', type: :view do
     end
     it "labels the link using the presenter's #to_s method" do
       expect(page).not_to have_content 'foobar'
+    end
+    it "shows the empty messages for parents" do
+      expect(page).not_to have_content "There are no Collection relationships."
+      expect(page).to have_content "There are no Generic work relationships."
+    end
+  end
+
+  context "when parents are present and no collections are present" do
+    let(:collection_presenters) { [generic_work] }
+    let(:page) { Capybara::Node::Simple.new(rendered) }
+    before do
+      allow(view).to receive(:contextual_path).and_return("/concern/generic_works/456")
+      allow(presenter).to receive(:collection_presenters).and_return(collection_presenters)
+      render 'curation_concerns/base/relationships', presenter: presenter
+    end
+    it "links to work" do
+      expect(page).to have_link 'Containing work'
+    end
+    it "labels the link using the presenter's #to_s method" do
+      expect(page).not_to have_content 'barbaz'
+    end
+    it "shows the empty messages for collections" do
+      expect(page).to have_content "There are no Collection relationships."
+      expect(page).not_to have_content "There are no Generic work relationships."
+    end
+  end
+
+  context "when parents are present and collections are present" do
+    let(:collection_presenters) { [generic_work, collection] }
+    let(:page) { Capybara::Node::Simple.new(rendered) }
+    before do
+      allow(view).to receive(:contextual_path).and_return("/concern/generic_works/456")
+      allow(presenter).to receive(:collection_presenters).and_return(collection_presenters)
+      render 'curation_concerns/base/relationships', presenter: presenter
+    end
+    it "links to work and collection" do
+      expect(page).to have_link 'Containing work'
+      expect(page).to have_link 'Containing collection'
+    end
+    it "labels the link using the presenter's #to_s method" do
+      expect(page).not_to have_content 'barbaz'
+      expect(page).not_to have_content 'foobar'
+    end
+    it "does not show the empty messages" do
+      expect(page).not_to have_content "There are no Collection relationships."
+      expect(page).not_to have_content "There are no Generic work relationships."
+    end
+  end
+
+  context "when children are present" do
+    let(:member_presenters) { [generic_work] }
+    let(:page) { Capybara::Node::Simple.new(rendered) }
+    before do
+      allow(view).to receive(:contextual_path).and_return("/concern/generic_works/456")
+      allow(presenter).to receive(:member_presenters).and_return(member_presenters)
+      render 'curation_concerns/base/relationships', presenter: presenter
+    end
+    it "links to child work" do
+      expect(page).to have_link 'Containing work'
+    end
+    it "labels the link using the presenter's #to_s method" do
+      expect(page).not_to have_content 'barbaz'
+    end
+    it "does not show the empty message" do
+      expect(page).not_to have_content "This Work does not have any related works."
     end
   end
 end

--- a/spec/views/records/edit_fields/_in_works_ids.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_in_works_ids.html.erb_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+describe "records/edit_fields/_in_works_ids.html.erb", type: :view do
+  let(:work) do
+    stub_model(GenericWork, id: '456', title: ["MyWork"])
+  end
+
+  let(:work_2) do
+    stub_model(GenericWork, id: '567', title: ["Child Work"])
+  end
+
+  let(:ability) { double }
+
+  let(:form) do
+    CurationConcerns::GenericWorkForm.new(work, ability)
+  end
+
+  let(:f) { double(object: form) }
+
+  let(:page) do
+    render
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  before do
+    view.lookup_context.view_paths.push 'app/views/curation_concerns'
+    allow(::ActiveFedora::Base).to receive(:find).and_return(work_2)
+    allow(view).to receive(:curation_concern).and_return(work)
+    allow(view).to receive(:f).and_return(f)
+    allow(view).to receive(:key).and_return(:in_works_ids)
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    assign(:form, form)
+  end
+
+  context "When editing a work" do
+    context "and no parents are present" do
+      before do
+        allow(work).to receive(:in_works).and_return([])
+      end
+      it "has 1 empty parent work input" do
+        expect(page).to have_selector("input[value='']", count: 1)
+      end
+
+      it "does not display the remove button in the actions" do
+        expect(page).to have_selector(".btn-remove-row", visible: false)
+      end
+
+      it "displays the add button in the actions" do
+        expect(page).to have_selector(".btn-add-row", visible: true, count: 1)
+      end
+    end
+    context "When 1 parent work is present" do
+      let(:work_2) do
+        stub_model(GenericWork, id: '567', title: ["Test Parent Work"])
+      end
+
+      before do
+        allow(work).to receive(:in_works).and_return([work_2])
+      end
+      it "has 1 empty parent work input with add button" do
+        expect(page).to have_selector("input[value='']", count: 1)
+        expect(page).to have_selector(".btn-add-row", visible: true, count: 1)
+      end
+
+      it "has an input box that is filled in with the parent id" do
+        expect(page).to have_selector("input[value='#{work_2.id}']", count: 1)
+      end
+
+      it "generates a link for the parents first title" do
+        expect(page).to have_link("Test Parent Work")
+      end
+
+      it "has an edit and remove button" do
+        within ".old-row" do
+          expect(page).to have_selector(".btn-remove-row", visible: true, count: 1)
+          expect(page).to have_selector(".btn-edit-row", visible: true, count: 1)
+        end
+      end
+    end
+    context "When multiple parent works are present" do
+      let(:work_2) do
+        stub_model(GenericWork, id: '567', title: ["Test Parent Work"])
+      end
+      let(:work_3) do
+        stub_model(GenericWork, id: '789', title: ["Test Parent Work 2"])
+      end
+      before do
+        allow(work).to receive(:in_works).and_return([work_2, work_3])
+      end
+      it "has 1 empty parent work input with add button" do
+        expect(page).to have_selector("input[value='']", count: 1)
+        expect(page).to have_selector(".btn-add-row", visible: true, count: 1)
+      end
+
+      it "has an input box that is filled in with the parent ids" do
+        expect(page).to have_selector("input[value='#{work_2.id}']", count: 1)
+        expect(page).to have_selector("input[value='#{work_3.id}']", count: 1)
+      end
+
+      it "generates a link for the parents first title" do
+        expect(page).to have_link("Test Parent Work")
+        expect(page).to have_link("Test Parent Work 2")
+      end
+
+      it "has an edit and remove button" do
+        within ".old-row" do
+          expect(page).to have_selector(".btn-remove-row", visible: true, count: 2)
+          expect(page).to have_selector(".btn-edit-row", visible: true, count: 2)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1861, #2197, #2111 
Refs #1710, #1709, #1563, #2082 

A handful of folks at OSU (Greg, Brandon, Steve, Josh, Mike, Ryan) have been working on integrating curation concerns nested works into sufia. We intend on following this PR up with another (couple?) to address more functionality and UI described by the wireframes linked in tickets 1710, 1709, and 1563. The goal for this PR is to address some of the baseline functionality of adding new child/parent works in the edit form and showing links to existing child/parent works in the show views.

We would like to have the full team at OSU to join and discuss in greater detail on the Hydra Tech call on Wednesday June 22nd if possible. In the meantime, we're looking forward to your feedback!

Thanks,
OSULP

@projecthydra/sufia-code-reviewers

