### PR TITLE
Log errors in contact form; correcting email fields

### DIFF
--- a/app/controllers/concerns/sufia/contact_form_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/contact_form_controller_behavior.rb
@@ -17,7 +17,8 @@ module Sufia
         flash.now[:error] << @contact_form.errors.full_messages.map(&:to_s).join(",")
       end
       render :new
-    rescue RuntimeError
+    rescue RuntimeError => e
+      logger.error("Contact form failed to send: #{e.inspect}")
       flash.now[:error] = 'Sorry, this message was not delivered.'
       render :new
     end

--- a/app/models/contact_form.rb
+++ b/app/models/contact_form.rb
@@ -21,8 +21,8 @@ class ContactForm < MailForm::Base
   def headers
     {
       subject: "#{Sufia.config.subject_prefix} #{subject}",
-      to: email,
-      from: Sufia.config.from_email
+      to: Sufia.config.contact_email,
+      from: email
     }
   end
 end

--- a/lib/generators/sufia/templates/config/sufia.rb
+++ b/lib/generators/sufia/templates/config/sufia.rb
@@ -1,8 +1,8 @@
 Sufia.config do |config|
   config.register_curation_concern :generic_work
 
-  # Account appearing in the "From" field of emails sent from the contact form
-  # config.from_email = "no-reply@example.org"
+  # Email recipient of messages sent via the contact form
+  # config.contact_email = "repo-admin@example.org"
 
   # Text prefacing the subject entered in the contact form
   # config.subject_prefix = "Contact form:"

--- a/lib/sufia/configuration.rb
+++ b/lib/sufia/configuration.rb
@@ -119,9 +119,9 @@ module Sufia
       @translate_id_to_uri ||= ActiveFedora::Noid.config.translate_id_to_uri
     end
 
-    attr_writer :from_email
-    def from_email
-      @from_email ||= "no-reply@example.org"
+    attr_writer :contact_email
+    def contact_email
+      @contact_email ||= "repo-admin@example.org"
     end
 
     attr_writer :subject_prefix

--- a/spec/controllers/contact_form_controller_spec.rb
+++ b/spec/controllers/contact_form_controller_spec.rb
@@ -73,4 +73,16 @@ describe ContactFormController do
       end
     end
   end
+
+  context "when encoutering a RuntimeError" do
+    let(:logger) { double }
+    before do
+      allow(controller).to receive(:logger).and_return(logger)
+      allow(ContactForm).to receive(:new).and_raise(RuntimeError)
+    end
+    it "is logged via Rails" do
+      expect(logger).to receive(:error).with("Contact form failed to send: #<RuntimeError: RuntimeError>")
+      post :create, contact_form: required_params
+    end
+  end
 end


### PR DESCRIPTION
My earlier fix for this was incorrect. Emails should be sent to the configured email, such as an admin or whomever responds to questions from the contact form, and the email should be from the actual sender.

Also logs any failed messages.