### PR TITLE
Export GenericFile metdata, versions, and permissions

### DIFF
--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -11,6 +11,7 @@ require 'sufia/models'
 require 'sufia/inflections'
 require 'sufia/arkivo'
 require 'sufia/zotero'
+require 'sufia/export'
 
 require 'rails_autolink'
 require 'font-awesome-rails'

--- a/lib/sufia/export.rb
+++ b/lib/sufia/export.rb
@@ -1,0 +1,10 @@
+require 'sufia/export/generic_file_converter'
+require 'sufia/export/version_graph_converter'
+require 'sufia/export/version_converter'
+require 'sufia/export/permission_converter'
+
+module Sufia
+  module Export
+    VERSION = Sufia::VERSION
+  end
+end

--- a/lib/sufia/export/generic_file_converter.rb
+++ b/lib/sufia/export/generic_file_converter.rb
@@ -1,0 +1,61 @@
+module Sufia
+  module Export
+    # Convert a GenericFile including metadata, permissions and version metadata into a PORO
+    # so that the metadata can be exported in json format using to_json
+    #
+    class GenericFileConverter
+      # Create an instance of a GenericFile converter containing all the metadata for json export
+      #
+      # @param [GenericFile] generc_file file to be converted for export
+      def initialize(generc_file)
+        @id = generc_file.id
+        @label = generc_file.label
+        @depositor = generc_file.depositor
+        @arkivo_checksum = generc_file.arkivo_checksum
+        @relative_path = generc_file.relative_path
+        @import_url = generc_file.import_url
+        @resource_type = generc_file.resource_type
+        @title = generc_file.title
+        @creator = generc_file.creator
+        @contributor = generc_file.contributor
+        @description = generc_file.description
+        @tag = generc_file.tag
+        @rights = generc_file.rights
+        @publisher = generc_file.publisher
+        @date_created = generc_file.date_created
+        @date_uploaded = generc_file.date_uploaded
+        @date_modified = generc_file.date_modified
+        @subject = generc_file.subject
+        @language = generc_file.language
+        @identifier = generc_file.identifier
+        @based_near = generc_file.based_near
+        @related_url = generc_file.related_url
+        @bibliographic_citation = generc_file.bibliographic_citation
+        @source = generc_file.source
+        @batch_id = generc_file.batch.id if generc_file.batch
+        @visibility = generc_file.visibility
+        @versions = versions(generc_file)
+        @permissions = permissions(generc_file)
+      end
+
+      # overrides to_json to optionally allow for a pretty version of the json to be outputted
+      #
+      # @param [Boolean] pretty pass true to output formatted json using pretty_generate
+      def to_json(pretty = false)
+        return super unless pretty
+        JSON.pretty_generate(JSON.parse(to_json))
+      end
+
+      private
+
+        def versions(gf)
+          return [] unless gf.content.has_versions?
+          Sufia::Export::VersionGraphConverter.new(gf.content.versions).versions
+        end
+
+        def permissions(gf)
+          gf.permissions.map { |p| PermissionConverter.new(p) }
+        end
+    end
+  end
+end

--- a/lib/sufia/export/permission_converter.rb
+++ b/lib/sufia/export/permission_converter.rb
@@ -1,0 +1,19 @@
+module Sufia
+  module Export
+    # Convert a permission record from a ActiveFedora:Base into a PORO so that the metadata
+    #  can be exported in json format using to_json
+    #
+    class PermissionConverter
+      # Create an instance of a Object Permission containing all the metadata for the permission
+      #
+      # @param [Hydra::AccessControls::Permission] permission the permission associated with one access record
+      def initialize(permission)
+        @id = permission.id
+        @agent = permission.agent.first.rdf_subject.to_s
+        @mode = permission.mode.first.rdf_subject.to_s
+        # Using .id instead of .uri allows us to rebuild the URI later on with a new base URI
+        @access_to = permission.access_to.id
+      end
+    end
+  end
+end

--- a/lib/sufia/export/version_converter.rb
+++ b/lib/sufia/export/version_converter.rb
@@ -1,0 +1,30 @@
+module Sufia
+  module Export
+    # Convert a single version of a GenericFile content into a PORO so that the metadata
+    #  ()including pointers to the version content) can be exported in json format using to_json
+    #
+    # @attr_reader [String] uri     location of version in fedora (also id of version)
+    # @attr_reader [String] label   version label extracted from the graph for the version identified by the url
+    # @attr_reader [String] created version creation date extracted from the graph for the version identified by the url
+    class VersionConverter
+      attr_reader :uri, :label, :created
+
+      # Create an instance of a GenericFile version containing all the metadata for json export
+      #
+      # @param [String] uri location of version to be converted in fedora (also id of version)
+      # @param [ActiveFedora::VersionsGraph] version_graph the graph of versions associated with one GenericFile (gf.content.versions)
+      def initialize(uri, version_graph)
+        @uri = uri
+        @created = find_triple(RDF::Vocab::Fcrepo4.created, version_graph)
+        @label = find_triple(RDF::Vocab::Fcrepo4.hasVersionLabel, version_graph)
+      end
+
+      private
+
+        def find_triple(predicate, graph)
+          triple = graph.find { |t| t.subject == uri && t.predicate == predicate }
+          triple.object.to_s
+        end
+    end
+  end
+end

--- a/lib/sufia/export/version_graph_converter.rb
+++ b/lib/sufia/export/version_graph_converter.rb
@@ -1,0 +1,35 @@
+module Sufia
+  module Export
+    # Convert a graph of versions from a GenericFile into a list of POROs so that the metadata
+    #  (including pointers to the version content) can be exported in json format using to_json
+    #
+    # @attr_reader [Array<VersionConverter] versions list of VersionConverters extracted from the graph
+    class VersionGraphConverter
+      attr_reader :versions
+
+      # Create an instance of a GenericFile version graph containing all the metadata for each version
+      #
+      # @param [ActiveFedora::VersionsGraph] version_graph the graph of versions associated with one GenericFile (gf.content.versions)
+      def initialize(version_graph)
+        @versions = []
+        parse(version_graph)
+      end
+
+      private
+
+        def parse(graph)
+          find_uris(graph).each do |uri|
+            versions << VersionConverter.new(uri, graph)
+          end
+        end
+
+        def find_uris(graph)
+          uris = []
+          graph.query(predicate: RDF::Vocab::Fcrepo4.hasVersion).each do |triple|
+            uris << triple.object.to_s
+          end
+          uris
+        end
+    end
+  end
+end

--- a/spec/factories/generic_files.rb
+++ b/spec/factories/generic_files.rb
@@ -52,5 +52,39 @@ FactoryGirl.define do
         subject %w(sed do eiusmod tempor incididunt ut labore)
       end
     end
+
+    trait :with_content do
+      before(:create) do |gf|
+        gf.add_file(File.open(File.expand_path("../../fixtures", __FILE__) + '/small_file.txt'), path: 'content', original_name: 'world.png')
+      end
+    end
+
+    trait :with_complete_metadata do
+      title         ['titletitle']
+      label         'labellabel'
+      filename      ['filename.filename']
+      tag           ['tagtag']
+      based_near    ['based_nearbased_near']
+      language      ['languagelanguage']
+      creator       ['creatorcreator']
+      contributor   ['contributorcontributor']
+      publisher     ['publisherpublisher']
+      subject       ['subjectsubject']
+      resource_type ['resource_typeresource_type']
+      description   ['descriptiondescription']
+      format_label  ['format_labelformat_label']
+      related_url   ['http://example.org/TheRelatedURLLink/']
+      date_created  ['date_createddate_created']
+      bibliographic_citation ['bibliographic_citationbibliographic_citation']
+    end
+
+    trait :with_system_metadata do
+      arkivo_checksum 'checksumchecksum'
+      relative_path 'relpathrelpath'
+      import_url 'importurlimporturl'
+      date_uploaded DateTime.new(2016, 6, 21, 9, 8)
+      date_modified DateTime.new(2016, 6, 21, 9, 8)
+      source ['sourcesource']
+    end
   end
 end

--- a/spec/lib/sufia/export/generic_file_converter_spec.rb
+++ b/spec/lib/sufia/export/generic_file_converter_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Sufia::Export::GenericFileConverter do
+  let(:file) { create :generic_file }
+  let(:permission) { file.permissions.first }
+  let(:json) { "{\"id\":\"#{file.id}\",\"label\":null,\"depositor\":\"archivist1@example.com\",\"arkivo_checksum\":null,\"relative_path\":null,\"import_url\":null,\"resource_type\":[],\"title\":[],\"creator\":[],\"contributor\":[],\"description\":[],\"tag\":[],\"rights\":[],\"publisher\":[],\"date_created\":[],\"date_uploaded\":null,\"date_modified\":null,\"subject\":[],\"language\":[],\"identifier\":[],\"based_near\":[],\"related_url\":[],\"bibliographic_citation\":[],\"source\":[],\"visibility\":\"restricted\",\"versions\":[],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#archivist1@example.com\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{file.id}\"}]}" }
+  subject { described_class.new(file) }
+  describe "to_json" do
+    subject { described_class.new(file).to_json }
+    it { is_expected.to eq json }
+
+    context "pretty json" do
+      subject { described_class.new(file).to_json(true) }
+      let(:json) { "{\n  \"id\": \"#{file.id}\",\n  \"label\": null,\n  \"depositor\": \"archivist1@example.com\",\n  \"arkivo_checksum\": null,\n  \"relative_path\": null,\n  \"import_url\": null,\n  \"resource_type\": [\n\n  ],\n  \"title\": [\n\n  ],\n  \"creator\": [\n\n  ],\n  \"contributor\": [\n\n  ],\n  \"description\": [\n\n  ],\n  \"tag\": [\n\n  ],\n  \"rights\": [\n\n  ],\n  \"publisher\": [\n\n  ],\n  \"date_created\": [\n\n  ],\n  \"date_uploaded\": null,\n  \"date_modified\": null,\n  \"subject\": [\n\n  ],\n  \"language\": [\n\n  ],\n  \"identifier\": [\n\n  ],\n  \"based_near\": [\n\n  ],\n  \"related_url\": [\n\n  ],\n  \"bibliographic_citation\": [\n\n  ],\n  \"source\": [\n\n  ],\n  \"visibility\": \"restricted\",\n  \"versions\": [\n\n  ],\n  \"permissions\": [\n    {\n      \"id\": \"#{permission.id}\",\n      \"agent\": \"http://projecthydra.org/ns/auth/person#archivist1@example.com\",\n      \"mode\": \"http://www.w3.org/ns/auth/acl#Write\",\n      \"access_to\": \"#{file.id}\"\n    }\n  ]\n}" }
+      it { is_expected.to eq json }
+    end
+
+    context "file with metdata" do
+      let(:file) { create :generic_file, :with_complete_metadata, :with_system_metadata }
+      let(:json) { "{\"id\":\"#{file.id}\",\"label\":\"labellabel\",\"depositor\":\"archivist1@example.com\",\"arkivo_checksum\":\"checksumchecksum\",\"relative_path\":\"relpathrelpath\",\"import_url\":\"importurlimporturl\",\"resource_type\":[\"resource_typeresource_type\"],\"title\":[\"titletitle\"],\"creator\":[\"creatorcreator\"],\"contributor\":[\"contributorcontributor\"],\"description\":[\"descriptiondescription\"],\"tag\":[\"tagtag\"],\"rights\":[],\"publisher\":[\"publisherpublisher\"],\"date_created\":[\"date_createddate_created\"],\"date_uploaded\":\"2016-06-21T09:08:00.000+00:00\",\"date_modified\":\"2016-06-21T09:08:00.000+00:00\",\"subject\":[\"subjectsubject\"],\"language\":[\"languagelanguage\"],\"identifier\":[],\"based_near\":[\"based_nearbased_near\"],\"related_url\":[\"http://example.org/TheRelatedURLLink/\"],\"bibliographic_citation\":[\"bibliographic_citationbibliographic_citation\"],\"source\":[\"sourcesource\"],\"visibility\":\"restricted\",\"versions\":[],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#archivist1@example.com\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{file.id}\"}]}" }
+
+      it { is_expected.to eq json }
+    end
+
+    context "file with metdata and content" do
+      let(:file) { create :generic_file, :with_content, :with_complete_metadata, :with_system_metadata, id: 'abc123' }
+      let(:graph) { file.content.versions }
+      let(:version) { graph.all.first }
+      let(:created) { version.created }
+      let(:json) { "{\"id\":\"#{file.id}\",\"label\":\"labellabel\",\"depositor\":\"archivist1@example.com\",\"arkivo_checksum\":\"checksumchecksum\",\"relative_path\":\"relpathrelpath\",\"import_url\":\"importurlimporturl\",\"resource_type\":[\"resource_typeresource_type\"],\"title\":[\"titletitle\"],\"creator\":[\"creatorcreator\"],\"contributor\":[\"contributorcontributor\"],\"description\":[\"descriptiondescription\"],\"tag\":[\"tagtag\"],\"rights\":[],\"publisher\":[\"publisherpublisher\"],\"date_created\":[\"date_createddate_created\"],\"date_uploaded\":\"2016-06-21T09:08:00.000+00:00\",\"date_modified\":\"2016-06-21T09:08:00.000+00:00\",\"subject\":[\"subjectsubject\"],\"language\":[\"languagelanguage\"],\"identifier\":[],\"based_near\":[\"based_nearbased_near\"],\"related_url\":[\"http://example.org/TheRelatedURLLink/\"],\"bibliographic_citation\":[\"bibliographic_citationbibliographic_citation\"],\"source\":[\"sourcesource\"],\"visibility\":\"restricted\",\"versions\":[{\"uri\":\"http://localhost:8983/fedora/rest/test/ab/c1/23/abc123/content/fcr:versions/version1\",\"created\":\"#{created}\",\"label\":\"version1\"}],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#archivist1@example.com\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{file.id}\"}]}" }
+
+      it { is_expected.to eq json }
+    end
+
+    context "file with write groups" do
+      let(:file) { create :generic_file, read_groups: ["group1", "group2"] }
+      let(:graph) { file.content.versions }
+      let(:version) { graph.all.first }
+      let(:created) { version.created }
+      let(:permission2) { file.permissions[1] }
+      let(:permission3) { file.permissions[2] }
+      let(:json) { "{\"id\":\"#{file.id}\",\"label\":null,\"depositor\":\"archivist1@example.com\",\"arkivo_checksum\":null,\"relative_path\":null,\"import_url\":null,\"resource_type\":[],\"title\":[],\"creator\":[],\"contributor\":[],\"description\":[],\"tag\":[],\"rights\":[],\"publisher\":[],\"date_created\":[],\"date_uploaded\":null,\"date_modified\":null,\"subject\":[],\"language\":[],\"identifier\":[],\"based_near\":[],\"related_url\":[],\"bibliographic_citation\":[],\"source\":[],\"visibility\":\"restricted\",\"versions\":[],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#group1\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{file.id}\"},{\"id\":\"#{permission2.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#group2\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{file.id}\"},{\"id\":\"#{permission3.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#archivist1@example.com\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{file.id}\"}]}" }
+
+      it { is_expected.to eq json }
+    end
+  end
+end

--- a/spec/lib/sufia/export/permission_converter_spec.rb
+++ b/spec/lib/sufia/export/permission_converter_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Sufia::Export::PermissionConverter do
+  let(:file) { create :generic_file }
+  let(:permission) { file.permissions.first }
+  let(:json) { "{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#archivist1@example.com\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{file.id}\"}" }
+
+  subject { described_class.new(permission).to_json }
+
+  describe "to_json" do
+    it { is_expected.to eq json }
+
+    context "with group permissions" do
+      let(:file) { create :generic_file, read_groups: ["group1"] }
+      let(:json) { "{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#group1\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{file.id}\"}" }
+      it { is_expected.to eq json }
+    end
+  end
+end

--- a/spec/lib/sufia/export/version_converter_spec.rb
+++ b/spec/lib/sufia/export/version_converter_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Sufia::Export::VersionConverter do
+  let(:file) { create :generic_file, :with_content, id: 'abc123' }
+  let(:graph) { file.content.versions }
+  let(:version) { graph.all.first }
+  let(:created) { version.created }
+  let(:json) { "{\"uri\":\"http://localhost:8983/fedora/rest/test/ab/c1/23/abc123/content/fcr:versions/version1\",\"created\":\"#{created}\",\"label\":\"version1\"}" }
+
+  subject { described_class.new(graph.all.first.uri, graph).to_json }
+
+  describe "to_json" do
+    it { is_expected.to eq json }
+  end
+end

--- a/spec/lib/sufia/export/version_graph_converter_spec.rb
+++ b/spec/lib/sufia/export/version_graph_converter_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Sufia::Export::VersionGraphConverter do
+  let(:file) { create :generic_file, :with_content, id: 'abc123' }
+  let(:graph) { file.content.versions }
+  let(:version1) { graph.all.first }
+  let(:version2) { graph.all.last }
+  let(:created1) { version1.created }
+  let(:created2) { version2.created }
+  let(:json) { "{\"versions\":[{\"uri\":\"http://localhost:8983/fedora/rest/test/ab/c1/23/abc123/content/fcr:versions/version1\",\"created\":\"#{created1}\",\"label\":\"version1\"},{\"uri\":\"http://localhost:8983/fedora/rest/test/ab/c1/23/abc123/content/fcr:versions/version2\",\"created\":\"#{created2}\",\"label\":\"version2\"}]}" }
+  let(:user) { FactoryGirl.create(:user) }
+
+  subject { described_class.new(graph).to_json }
+
+  # add a second version
+  before do
+    file.add_file(File.open(fixture_path + '/small_file.txt'), path: 'content', original_name: 'test2.png')
+    file.save
+  end
+
+  describe "to_json" do
+    it { is_expected.to eq json }
+  end
+end


### PR DESCRIPTION
Fixes #2153; fixes #2151; fixes #2154

Exports GenericFile to json format including metadata, version metadata, and permissions.

The intention of this class is to act as a way to transfer data from Sufia 6 so that it can be imported into Sufia 7. See #2136 for user story.

I pulled much of the code from a branch in ScholarSphere written by @hectorcorrea [export_s6](https://github.com/psu-stewardship/scholarsphere/tree/export_s6)

@projecthydra/sufia-code-reviewers

