### PR TITLE
Adds Bootstrap media query for small devices and min-width to target the fixedsticky CSS and positioning ONLY if it is larger than 768px.

### DIFF
--- a/app/assets/stylesheets/sufia/_fixedsticky.scss
+++ b/app/assets/stylesheets/sufia/_fixedsticky.scss
@@ -1,26 +1,28 @@
-.fixedsticky {
-  position: -webkit-sticky;
-  position: -moz-sticky;
-  position: -ms-sticky;
-  position: -o-sticky;
-  position: sticky;
-}
+@media (min-width: $screen-sm-min) {
+  .fixedsticky {
+    position: -webkit-sticky;
+    position: -moz-sticky;
+    position: -ms-sticky;
+    position: -o-sticky;
+    position: sticky;
+  }
 
-/* When position: sticky is supported but native behavior is ignored */
-.fixedsticky-withoutfixedfixed .fixedsticky-off,
-.fixed-supported .fixedsticky-off {
-  position: static;
-}
+  /* When position: sticky is supported but native behavior is ignored */
+  .fixedsticky-withoutfixedfixed .fixedsticky-off,
+  .fixed-supported .fixedsticky-off {
+    position: static;
+  }
 
-.fixedsticky-withoutfixedfixed .fixedsticky-on,
-.fixed-supported .fixedsticky-on {
-  position: fixed;
-}
+  .fixedsticky-withoutfixedfixed .fixedsticky-on,
+  .fixed-supported .fixedsticky-on {
+    position: fixed;
+  }
 
-.fixedsticky-dummy {
-  display: none;
-}
+  .fixedsticky-dummy {
+    display: none;
+  }
 
-.fixedsticky-on + .fixedsticky-dummy {
-  display: block;
+  .fixedsticky-on + .fixedsticky-dummy {
+    display: block;
+  }
 }

--- a/app/assets/stylesheets/sufia/_form-progress.scss
+++ b/app/assets/stylesheets/sufia/_form-progress.scss
@@ -1,12 +1,21 @@
-.fixedsticky {
-  top: 0; /* Required to get consistent results in Safari and Chrome */
+@media (min-width: $screen-xs-min) {
+  .fixedsticky {
+    margin-top: 1em;
+  }
 }
 
-.fixedsticky-withoutfixedfixed .fixedsticky-on,
-.fixed-supported .fixedsticky-on {
-  left: $save-viz-widget-left;
-  /* Required so that the widget doesn't pop back to top when public desc long */
-  bottom: $save-viz-widget-bottom;
+@media (min-width: $screen-sm-min) {
+  .fixedsticky {
+    margin-top: 0;
+    top: 0; /* Required to get consistent results in Safari and Chrome */
+  }
+
+  .fixedsticky-withoutfixedfixed .fixedsticky-on,
+  .fixed-supported .fixedsticky-on {
+    left: $save-viz-widget-left;
+    /* Required so that the widget doesn't pop back to top when public desc long */
+    bottom: $save-viz-widget-bottom;
+  }
 }
 
 aside.form-progress {


### PR DESCRIPTION
Fixes #1968 

Fixed sticky save/visibility widget had display issues when the browser was smaller than 768 pixels and particularly for mobile devices. The widget would fall behind the metadata fields and made the whole thing unusable. Used Bootstrap media queries to target the JS on/off state _only_ at resolutions greater than 768 pixels.

Changes proposed in this pull request:
* media queries for both fixedsticky.scss and form-progress.scss
* small adjustment to the margin around the "Additional fields" button for mobile

@projecthydra/sufia-code-reviewers 