### PR TITLE
Exporting a Collection's metadata, permissions, and members

### DIFF
--- a/lib/sufia/export.rb
+++ b/lib/sufia/export.rb
@@ -1,7 +1,9 @@
+require 'sufia/export/converter'
 require 'sufia/export/generic_file_converter'
 require 'sufia/export/version_graph_converter'
 require 'sufia/export/version_converter'
 require 'sufia/export/permission_converter'
+require 'sufia/export/collection_converter'
 
 module Sufia
   module Export

--- a/lib/sufia/export/collection_converter.rb
+++ b/lib/sufia/export/collection_converter.rb
@@ -1,0 +1,20 @@
+module Sufia
+  module Export
+    # Convert a Collection including metadata, permissions and member ids into a PORO
+    # so that the metadata can be exported in json format using to_json
+    #
+    class CollectionConverter < Converter
+      # Create an instance of a Collection converter containing all the metadata for json export
+      #
+      # @param [Collection] collection to be converted for export
+      def initialize(collection)
+        @id = collection.id
+        @title = collection.title
+        @description = collection.description
+        @creator = collection.creator.map { |c| c }
+        @members = collection.members.map(&:id)
+        @permissions = permissions(collection)
+      end
+    end
+  end
+end

--- a/lib/sufia/export/converter.rb
+++ b/lib/sufia/export/converter.rb
@@ -1,0 +1,23 @@
+module Sufia
+  module Export
+    # a base class to convert an ActiveFedora object that contains permissions and allow for pretty json.
+    #
+    class Converter
+      # overrides to_json to optionally allow for a pretty version of the json to be outputted
+      #
+      # @param [Boolean] pretty pass true to output formatted json using pretty_generate
+      def to_json(options = {})
+        pretty = options.delete(:pretty)
+        json = super
+        return json unless pretty
+        JSON.pretty_generate(JSON.parse(json))
+      end
+
+      private
+
+        def permissions(object)
+          object.permissions.map { |p| PermissionConverter.new(p) }
+        end
+    end
+  end
+end

--- a/lib/sufia/export/generic_file_converter.rb
+++ b/lib/sufia/export/generic_file_converter.rb
@@ -3,7 +3,7 @@ module Sufia
     # Convert a GenericFile including metadata, permissions and version metadata into a PORO
     # so that the metadata can be exported in json format using to_json
     #
-    class GenericFileConverter
+    class GenericFileConverter < Converter
       # Create an instance of a GenericFile converter containing all the metadata for json export
       #
       # @param [GenericFile] generc_file file to be converted for export
@@ -38,23 +38,11 @@ module Sufia
         @permissions = permissions(generc_file)
       end
 
-      # overrides to_json to optionally allow for a pretty version of the json to be outputted
-      #
-      # @param [Boolean] pretty pass true to output formatted json using pretty_generate
-      def to_json(pretty = false)
-        return super unless pretty
-        JSON.pretty_generate(JSON.parse(to_json))
-      end
-
       private
 
         def versions(gf)
           return [] unless gf.content.has_versions?
           Sufia::Export::VersionGraphConverter.new(gf.content.versions).versions
-        end
-
-        def permissions(gf)
-          gf.permissions.map { |p| PermissionConverter.new(p) }
         end
     end
   end

--- a/spec/lib/sufia/export/collection_converter_spec.rb
+++ b/spec/lib/sufia/export/collection_converter_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Sufia::Export::CollectionConverter do
+  let(:collection) do
+    Collection.create(title: "title1", creator: ["creator1"], description: "description1") do |col|
+      col.apply_depositor_metadata("jilluser")
+    end
+  end
+  let(:permission) { collection.permissions.first }
+  let(:permission2) { collection.permissions.last }
+  let(:json) { "{\"id\":\"#{collection.id}\",\"title\":\"title1\",\"description\":\"description1\",\"creator\":[\"creator1\"],\"members\":[],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#jilluser\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{collection.id}\"},{\"id\":\"#{permission2.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#public\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{collection.id}\"}]}" }
+  describe "to_json" do
+    subject { described_class.new(collection).to_json }
+    it { is_expected.to eq json }
+
+    context "pretty to_json" do
+      subject { described_class.new(collection).to_json(pretty: true) }
+      let(:json) { "{\n  \"id\": \"#{collection.id}\",\n  \"title\": \"title1\",\n  \"description\": \"description1\",\n  \"creator\": [\n    \"creator1\"\n  ],\n  \"members\": [\n\n  ],\n  \"permissions\": [\n    {\n      \"id\": \"#{permission.id}\",\n      \"agent\": \"http://projecthydra.org/ns/auth/person#jilluser\",\n      \"mode\": \"http://www.w3.org/ns/auth/acl#Write\",\n      \"access_to\": \"#{collection.id}\"\n    },\n    {\n      \"id\": \"#{permission2.id}\",\n      \"agent\": \"http://projecthydra.org/ns/auth/group#public\",\n      \"mode\": \"http://www.w3.org/ns/auth/acl#Read\",\n      \"access_to\": \"#{collection.id}\"\n    }\n  ]\n}" }
+      it { is_expected.to eq json }
+    end
+
+    context "with members" do
+      let(:file1) { create(:generic_file) }
+      let(:file2) { create(:generic_file) }
+      before do
+        collection.members = [file1, file2]
+      end
+      let(:json) { "{\"id\":\"#{collection.id}\",\"title\":\"title1\",\"description\":\"description1\",\"creator\":[\"creator1\"],\"members\":[\"#{file1.id}\",\"#{file2.id}\"],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#jilluser\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{collection.id}\"},{\"id\":\"#{permission2.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#public\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{collection.id}\"}]}" }
+      it { is_expected.to eq json }
+    end
+  end
+end

--- a/spec/lib/sufia/export/generic_file_converter_spec.rb
+++ b/spec/lib/sufia/export/generic_file_converter_spec.rb
@@ -10,7 +10,7 @@ describe Sufia::Export::GenericFileConverter do
     it { is_expected.to eq json }
 
     context "pretty json" do
-      subject { described_class.new(file).to_json(true) }
+      subject { described_class.new(file).to_json(pretty: true) }
       let(:json) { "{\n  \"id\": \"#{file.id}\",\n  \"label\": null,\n  \"depositor\": \"archivist1@example.com\",\n  \"arkivo_checksum\": null,\n  \"relative_path\": null,\n  \"import_url\": null,\n  \"resource_type\": [\n\n  ],\n  \"title\": [\n\n  ],\n  \"creator\": [\n\n  ],\n  \"contributor\": [\n\n  ],\n  \"description\": [\n\n  ],\n  \"tag\": [\n\n  ],\n  \"rights\": [\n\n  ],\n  \"publisher\": [\n\n  ],\n  \"date_created\": [\n\n  ],\n  \"date_uploaded\": null,\n  \"date_modified\": null,\n  \"subject\": [\n\n  ],\n  \"language\": [\n\n  ],\n  \"identifier\": [\n\n  ],\n  \"based_near\": [\n\n  ],\n  \"related_url\": [\n\n  ],\n  \"bibliographic_citation\": [\n\n  ],\n  \"source\": [\n\n  ],\n  \"visibility\": \"restricted\",\n  \"versions\": [\n\n  ],\n  \"permissions\": [\n    {\n      \"id\": \"#{permission.id}\",\n      \"agent\": \"http://projecthydra.org/ns/auth/person#archivist1@example.com\",\n      \"mode\": \"http://www.w3.org/ns/auth/acl#Write\",\n      \"access_to\": \"#{file.id}\"\n    }\n  ]\n}" }
       it { is_expected.to eq json }
     end


### PR DESCRIPTION
Fixes #2155 

Exports a Collection to json format including metadata, permissions and member ids (the members are expected to be exported separately see #2268).

The intention of this class is to act as a way to transfer data from Sufia 6 so that it can be imported into Sufia 7. See #2136 for user story.

I pulled much of the code from a branch in ScholarSphere written by @hectorcorrea export_s6

@projecthydra/sufia-code-reviewers