### PR TITLE
Updates text to instruct user to add more files by clicking edit.

### DIFF
--- a/app/views/curation_concerns/base/_items.html.erb
+++ b/app/views/curation_concerns/base/_items.html.erb
@@ -15,5 +15,5 @@
     </tbody>
   </table>
 <% elsif can? :edit, presenter.id %>
-  <p class="text-center"><em><%= t('.empty', type: presenter.human_readable_type) %></em></p>
+    <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>
 <% end %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -347,7 +347,7 @@ en:
         attribute_values_label: Values
       items:
         header: Items
-        empty:  "This %{type} has no files associated with it. You can add one using the \"Attach a File\" button below."
+        empty:  "This %{type} has no files associated with it. Click \"edit\" to add more files."
       citations:
         header: 'Citations:'
     visibility:

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_girl_rails", '~> 4.4'
   spec.add_development_dependency "equivalent-xml", '~> 0.5'
   spec.add_development_dependency "jasmine", '~> 2.3'
-  spec.add_development_dependency 'rubocop', '~> 0.40'
+  spec.add_development_dependency 'rubocop', '~> 0.40.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.5'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
 end


### PR DESCRIPTION
Fixes #2286 

When a user removes the only file in a work, a Bootstrap alert-warning is displayed with instructions to click edit.

Changes proposed in this pull request:
* Updates text in sufia.en.yml
* Replaces `<p>` element with Bootstrap `alert-warning`

@projecthydra/sufia-code-reviewers

![screen shot 2016-06-27 at 10 58 43 am](https://cloud.githubusercontent.com/assets/4163828/16384313/6d4f55a0-3c56-11e6-98ea-324f5f5610b4.png)

Depends on #2288 
