### PR TITLE
Make the model argument to entries_by_term optional

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,7 +25,6 @@ Metrics/MethodLength:
     - 'lib/generators/sufia/templates/migrations/create_local_authorities.rb'
     - 'app/helpers/sufia/citations_behaviors/formatters/endnote_formatter.rb'
     - 'app/models/concerns/sufia/solr_document/export.rb'
-    - 'app/models/local_authority.rb'
     - 'lib/generators/sufia/install_generator.rb'
     - 'lib/sufia/arkivo/metadata_munger.rb'
 

--- a/app/authorities/local_languages.rb
+++ b/app/authorities/local_languages.rb
@@ -5,6 +5,6 @@ class LocalLanguages
   end
 
   def search(query)
-    LocalAuthority.entries_by_term('generic_works', 'language', query)
+    LocalAuthority.entries_by_term('language', query)
   end
 end

--- a/app/authorities/local_subjects.rb
+++ b/app/authorities/local_subjects.rb
@@ -5,6 +5,6 @@ class LocalSubjects
   end
 
   def search(query)
-    LocalAuthority.entries_by_term('generic_works', 'subject', query)
+    LocalAuthority.entries_by_term('subject', query)
   end
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -68,8 +68,7 @@ describe LocalAuthority, type: :model do
       describe "#entries_by_term" do
         let(:query) { 'A' }
         let(:term) { 'genre' }
-        let(:model) { 'manuscripts' }
-        subject { described_class.entries_by_term(model, term, query) }
+        subject { described_class.entries_by_term(term, query) }
 
         context "when the query is empty" do
           let(:query) { '' }
@@ -77,6 +76,7 @@ describe LocalAuthority, type: :model do
         end
 
         context "when the model is unregistered" do
+          subject { described_class.entries_by_term(term, query, model) }
           let(:model) { 'my_foobar' }
           it { is_expected.to be_empty }
         end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

We aren't using different vocabularies for different models at this
point, so there's no need to have it.

Also refactored LocalAuthority for better style.