### PR TITLE
Add google_analytics_id to Sufia configuration

### DIFF
--- a/lib/sufia/configuration.rb
+++ b/lib/sufia/configuration.rb
@@ -86,6 +86,11 @@ module Sufia
       @always_display_share_button
     end
 
+    attr_writer :google_analytics_id
+    def google_analytics_id
+      @google_analytics_id ||= nil
+    end
+
     # Defaulting analytic start date to whenever the file was uploaded by leaving it blank
     attr_writer :analytic_start_date
     attr_reader :analytic_start_date

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe BlacklightHelper, type: :helper do
   let(:document) { SolrDocument.new(attributes) }
   before do
     allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
+    allow(controller).to receive(:action_name).and_return('index')
   end
 
   describe "render_index_field_value" do
@@ -44,17 +45,17 @@ RSpec.describe BlacklightHelper, type: :helper do
 
       context "keyword_tesim" do
         let(:field_name) { 'keyword_tesim' }
-        it { is_expected.to eq "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco\"><span itemprop=\"keywords\">taco</span></a></span> and <span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache\"><span itemprop=\"keywords\">mustache</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco\">taco</a></span> and <span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache\">mustache</a></span>" }
       end
 
       context "subject_tesim" do
         let(:field_name) { 'subject_tesim' }
-        it { is_expected.to eq "<span itemprop=\"about\"><a href=\"/catalog?f%5Bsubject_sim%5D%5B%5D=Awesome\"><span itemprop=\"about\">Awesome</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"about\"><a href=\"/catalog?f%5Bsubject_sim%5D%5B%5D=Awesome\">Awesome</a></span>" }
       end
 
       context "creator_tesim" do
         let(:field_name) { 'creator_tesim' }
-        it { is_expected.to eq "<span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Justin\"><span itemprop=\"creator\">Justin</span></a></span> and <span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Joe\"><span itemprop=\"creator\">Joe</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Justin\">Justin</a></span> and <span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Joe\">Joe</a></span>" }
       end
 
       context "contributor_tesim" do
@@ -64,17 +65,17 @@ RSpec.describe BlacklightHelper, type: :helper do
 
       context "publisher_tesim" do
         let(:field_name) { 'publisher_tesim' }
-        it { is_expected.to eq "<span itemprop=\"publisher\"><a href=\"/catalog?f%5Bpublisher_sim%5D%5B%5D=Penguin+Random+House\"><span itemprop=\"publisher\">Penguin Random House</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"publisher\"><a href=\"/catalog?f%5Bpublisher_sim%5D%5B%5D=Penguin+Random+House\">Penguin Random House</a></span>" }
       end
 
       context "location_tesim" do
         let(:field_name) { 'based_near_tesim' }
-        it { is_expected.to eq "<span itemprop=\"contentLocation\"><a href=\"/catalog?f%5Bbased_near_sim%5D%5B%5D=Pennsylvania\"><span itemprop=\"contentLocation\">Pennsylvania</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"contentLocation\"><a href=\"/catalog?f%5Bbased_near_sim%5D%5B%5D=Pennsylvania\">Pennsylvania</a></span>" }
       end
 
       context "language_tesim" do
         let(:field_name) { 'language_tesim' }
-        it { is_expected.to eq "<span itemprop=\"inLanguage\"><a href=\"/catalog?f%5Blanguage_sim%5D%5B%5D=English\"><span itemprop=\"inLanguage\">English</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"inLanguage\"><a href=\"/catalog?f%5Blanguage_sim%5D%5B%5D=English\">English</a></span>" }
       end
 
       context "resource_type_tesim" do

--- a/spec/lib/sufia/configuration_spec.rb
+++ b/spec/lib/sufia/configuration_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Sufia::Configuration do
+  subject { described_class.new }
+
+  it { is_expected.to respond_to(:persistent_hostpath) }
+  it { is_expected.to respond_to(:redis_namespace) }
+  it { is_expected.to respond_to(:libreoffice_path) }
+  it { is_expected.to respond_to(:browse_everything) }
+  it { is_expected.to respond_to(:analytics) }
+  it { is_expected.to respond_to(:citations) }
+  it { is_expected.to respond_to(:max_notifications_for_dashboard) }
+  it { is_expected.to respond_to(:activity_to_show_default_seconds_since_now) }
+  it { is_expected.to respond_to(:arkivo_api) }
+  it { is_expected.to respond_to(:active_deposit_agreement_acceptance) }
+  it { is_expected.to respond_to(:batch_user_key) }
+  it { is_expected.to respond_to(:audit_user_key) }
+  it { is_expected.to respond_to(:upload_path) }
+  it { is_expected.to respond_to(:always_display_share_button) }
+  it { is_expected.to respond_to(:google_analytics_id) }
+  it { is_expected.to respond_to(:analytic_start_date) }
+  it { is_expected.to respond_to(:display_media_download_link) }
+  it { is_expected.to respond_to(:permission_levels) }
+  it { is_expected.to respond_to(:owner_permission_levels) }
+  it { is_expected.to respond_to(:translate_uri_to_id) }
+  it { is_expected.to respond_to(:translate_id_to_uri) }
+  it { is_expected.to respond_to(:contact_email) }
+  it { is_expected.to respond_to(:subject_prefix) }
+  it { is_expected.to respond_to(:model_to_create) }
+end


### PR DESCRIPTION
Fixes #2295 

This was removed in CurationConcerns, https://github.com/projecthydra/curation_concerns/pull/867

@projecthydra/sufia-code-reviewers

