### PR TITLE
Export Actor which will export ActiveFedora classes to json files

### DIFF
--- a/lib/sufia/export.rb
+++ b/lib/sufia/export.rb
@@ -4,6 +4,7 @@ require 'sufia/export/version_graph_converter'
 require 'sufia/export/version_converter'
 require 'sufia/export/permission_converter'
 require 'sufia/export/collection_converter'
+require 'sufia/export/actor'
 
 module Sufia
   module Export

--- a/lib/sufia/export/actor.rb
+++ b/lib/sufia/export/actor.rb
@@ -1,0 +1,98 @@
+module Sufia
+  module Export
+    # Convert a GenericFile including metadata, permissions and version metadata into a PORO
+    # so that the metadata can be exported in json format using to_json
+    #
+    class Actor
+      attr_reader :converter_registry, :limit, :ids
+      attr_accessor :conversion_count
+
+      # initialize the class with the default registry
+      def initialize
+        @converter_registry = default_registry
+      end
+
+      # register a converter for a new class or overwrite the converter for a default class
+      #
+      # @param [Class] model_class     The ActiveFedora model class to be converter to json
+      # @param [Class] converter_class The class that will convert from ActiveFedora to json
+      def register_converter(model_class, converter_class)
+        raise(RegistryError, "Model (#{model_class.name}) for conversion must be an ActiveFedora::Base") unless model_class.ancestors.include?(ActiveFedora::Base)
+        raise(RegistryError, "Converter (#{converter_class.name}) for conversion must be an Sufia::Export::Converter") unless converter_class.ancestors.include?(Sufia::Export::Converter)
+        converter_registry[model_class] = converter_class
+      end
+
+      # Convert the classes using the registered converters from ActiveFedora to json files
+      #
+      # @param [Array] model_class_list list of classes to be converter
+      # @param [Hash]  opts
+      # @option opts [Number] :limit Limits the number of conversion done (defaults to -1 or all)
+      # @option opts [Array]  :ids   List of ids to be converted.  Can be from any model
+      def call(model_class_list = converter_registry.keys, opts = {})
+        @conversion_count = 0
+        validate_class_list(model_class_list)
+        parse_options(opts)
+        export_models(model_class_list)
+      end
+
+      private
+
+        def parse_options(opts)
+          @limit = opts[:limit] || -1
+          @ids = opts[:ids]
+        end
+
+        def model_scope(model_class)
+          scope = model_class.all
+          scope  = scope.where(id: ids) unless ids.blank?
+          scope  = scope.limit(limit - conversion_count) unless limit == -1
+          scope
+        end
+
+        def validate_class_list(model_class_list)
+          model_class_list.each do |model_class|
+            converter_class = converter_registry[model_class]
+            raise(RegistryError, "Undefined Model for conversion (#{model_class.name})") if converter_class.blank?
+          end
+        end
+
+        def export_models(model_class_list)
+          model_class_list.each do |model_class|
+            converter_class = converter_registry[model_class]
+            export_model_list(model_scope(model_class), converter_class)
+          end
+        end
+
+        def export_model_list(model_list, converter_class)
+          model_list.each do |model|
+            export_one(converter_class, model)
+          end
+        end
+
+        def export_one(converter_class, model)
+          converter = converter_class.new(model)
+          path = file_name(model)
+          json = converter.to_json(pretty: true)
+          File.write(path, json)
+          @conversion_count += 1
+        end
+
+        def file_name(model)
+          File.join(file_path, "#{model.class.name.underscore}_#{model.id}.json")
+        end
+
+        def default_registry
+          { ::GenericFile => Sufia::Export::GenericFileConverter, ::Collection => Sufia::Export::CollectionConverter }
+        end
+
+        def file_path
+          return @file_path unless @file_path.blank?
+          @file_path = "tmp/export"
+          FileUtils.mkdir_p @file_path
+          @file_path
+        end
+    end
+
+    class RegistryError < RuntimeError; end
+  end
+end

--- a/spec/lib/sufia/export/actor_spec.rb
+++ b/spec/lib/sufia/export/actor_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+describe Sufia::Export::Actor do
+  let(:actor) { described_class.new }
+  subject { actor }
+  describe "methods" do
+    it { is_expected.to respond_to(:register_converter) }
+    it { is_expected.to respond_to(:call) }
+  end
+  describe "register_convertor" do
+    let(:model_class) { TestModel }
+    let(:converter_class) { TestConverter }
+    before do
+      class TestModel < ActiveFedora::Base; end
+      class TestConverter < Sufia::Export::Converter; end
+    end
+
+    after do
+      Object.send(:remove_const, :TestModel)
+      Object.send(:remove_const, :TestConverter)
+    end
+
+    subject { actor.converter_registry }
+    it "registers a converter" do
+      actor.register_converter(model_class, converter_class)
+      is_expected.to have_key(model_class)
+      is_expected.to have_value(converter_class)
+    end
+    context "invalid model" do
+      let(:model_class) { String.class }
+      it "throws an error" do
+        expect { actor.register_converter(model_class, converter_class) }.to raise_error(Sufia::Export::RegistryError)
+        is_expected.not_to have_key(model_class)
+        is_expected.not_to have_value(converter_class)
+      end
+    end
+    context "invalid converter" do
+      let(:converter_class) { String.class }
+      it "throws an error" do
+        expect { actor.register_converter(model_class, converter_class) }.to raise_error(Sufia::Export::RegistryError)
+        is_expected.not_to have_key(model_class)
+        is_expected.not_to have_value(converter_class)
+      end
+    end
+    context "default values" do
+      it { is_expected.to eq(GenericFile => Sufia::Export::GenericFileConverter, Collection => Sufia::Export::CollectionConverter) }
+    end
+  end
+
+  describe "call" do
+    let!(:file) { create :generic_file }
+    let!(:collection) do
+      Collection.create(title: "title1", creator: ["creator1"], description: "description1") do |col|
+        col.apply_depositor_metadata("jilluser")
+      end
+    end
+    let(:options) { {} }
+    let(:generic_file_converter) { Sufia::Export::GenericFileConverter.new(file) }
+    let(:generic_file_file_name) { "tmp/export/generic_file_#{file.id}.json" }
+    let(:collection_converter) { Sufia::Export::CollectionConverter.new(collection) }
+    let(:collection_file_name) { "tmp/export/collection_#{collection.id}.json" }
+    after do
+      FileUtils.rm_r("tmp/export") if Dir.exist?("tmp/export")
+    end
+
+    it "converts files and collections by default" do
+      expect(Sufia::Export::GenericFileConverter).to receive(:new).and_return(generic_file_converter)
+      expect(Sufia::Export::CollectionConverter).to receive(:new).and_return(collection_converter)
+      expect(collection_converter).to receive(:to_json).and_return("collection json goes here")
+      expect(generic_file_converter).to receive(:to_json).and_return("generic file json goes here")
+      expect { actor.call }.not_to raise_error
+      expect(File.exist?(generic_file_file_name)).to be_truthy
+      expect(File.exist?(collection_file_name)).to be_truthy
+      expect(File.read(collection_file_name)).to eq("collection json goes here")
+      expect(File.read(generic_file_file_name)).to eq("generic file json goes here")
+    end
+
+    it "converts files" do
+      expect(Sufia::Export::GenericFileConverter).to receive(:new).and_return(generic_file_converter)
+      expect(generic_file_converter).to receive(:to_json).and_return("generic file json goes here")
+      expect { actor.call([GenericFile], options) }.not_to raise_error
+      expect(File.exist?(generic_file_file_name)).to be_truthy
+      expect(File.read(generic_file_file_name)).to eq("generic file json goes here")
+    end
+
+    it "limits the files created" do
+      expect { actor.call([GenericFile, Collection], limit: 1) }.not_to raise_error
+      expect(File.exist?(generic_file_file_name)).to be_truthy
+      expect(File.exist?(collection_file_name)).to be_falsey
+    end
+
+    it "validates the class list" do
+      expect { actor.call([GenericFile, Collection, String]) }.to raise_error(Sufia::Export::RegistryError)
+    end
+
+    context "with multiple files" do
+      let!(:file2) { create :generic_file }
+      let!(:file3) { create :generic_file }
+      let(:generic_file2_file_name) { "tmp/export/generic_file_#{file2.id}.json" }
+      let(:generic_file3_file_name) { "tmp/export/generic_file_#{file3.id}.json" }
+      it "limits by id" do
+        expect { actor.call([GenericFile, Collection], ids: [file2.id, file3.id]) }.not_to raise_error
+        expect(File.exist?(generic_file2_file_name)).to be_truthy
+        expect(File.exist?(generic_file3_file_name)).to be_truthy
+        expect(File.exist?(generic_file_file_name)).to be_falsey
+        expect(File.exist?(collection_file_name)).to be_falsey
+      end
+
+      it "limits by id and number" do
+        expect { actor.call([GenericFile, Collection], ids: [file2.id, file3.id], limit: 1) }.not_to raise_error
+        expect(File.exist?(generic_file2_file_name)).to be_truthy
+        expect(File.exist?(generic_file3_file_name)).to be_falsey
+        expect(File.exist?(generic_file_file_name)).to be_falsey
+        expect(File.exist?(collection_file_name)).to be_falsey
+      end
+    end
+  end
+end

--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activeresource', "~> 4.0" # No longer a dependency of rails 4.0
 
   spec.add_dependency "hydra-head", "< 9.6"
-  spec.add_dependency "active-fedora", "~> 9.4", "< 9.8"
+  spec.add_dependency "active-fedora", "~> 9.7.2", "< 9.8"
   spec.add_dependency "hydra-collections", [">= 5.0.3", "< 6.0"]
   spec.add_dependency 'hydra-derivatives', '~> 1.0'
   spec.add_dependency 'active_fedora-noid', '~> 1.0'

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'oauth'
   gem.add_dependency 'redlock', '~> 0.1.2'
 
-  gem.add_development_dependency 'engine_cart', '~> 0.8'
+  gem.add_development_dependency 'engine_cart', '~> 0.8.2'
   gem.add_development_dependency 'mida', '~> 0.3'
   gem.add_development_dependency 'database_cleaner', '~> 1.3'
   gem.add_development_dependency 'rspec-rails', '~> 3.1'


### PR DESCRIPTION
Fixes #2147 for Sufia 6.x

Creates the Actor to export all the ActiveFedora Models using the Converters to json files.

Uses the latest Active Fedora 6.7.x branch to get the correct operation for the where(id: [id1,id2]), which would create a solr query like `q: (id_si: id1 OR id_si: id2)` instead of the released version which creates a solr query like  `q:  (id_si: id1 AND id_si: id2)` 

@projecthydra/sufia-code-reviewers

