### PR TITLE
Add Google analytics config and update to Blacklight 6.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ group :development, :test do
 end
 
 # BEGIN ENGINE_CART BLOCK
-# engine_cart: 0.8.0
-# engine_cart stanza: 0.8.0
+# engine_cart: 0.10.0
+# engine_cart stanza: 0.10.0
 # the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
-file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path(".internal_test_app", File.dirname(__FILE__)))
+file = File.expand_path('Gemfile', ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path('.internal_test_app', File.dirname(__FILE__)))
 if File.exist?(file)
   begin
     eval_gemfile file
@@ -24,13 +24,22 @@ if File.exist?(file)
 else
   Bundler.ui.warn "[EngineCart] Unable to find test application dependencies in #{file}, using placeholder dependencies"
 
-  gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+  if ENV['RAILS_VERSION']
+    if ENV['RAILS_VERSION'] == 'edge'
+      gem 'rails', github: 'rails/rails'
+      ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
+    else
+      gem 'rails', ENV['RAILS_VERSION']
+    end
+  end
 
-  if ENV['RAILS_VERSION'].nil? || ENV['RAILS_VERSION'] =~ /^4.2/
-    gem 'responders', "~> 2.0"
-    gem 'sass-rails', ">= 5.0"
-  else
-    gem 'sass-rails', "< 5.0"
+  case ENV['RAILS_VERSION']
+  when /^4.2/
+    gem 'responders', '~> 2.0'
+    gem 'sass-rails', '>= 5.0'
+    gem 'coffee-rails', '~> 4.1.0'
+  when /^4.[01]/
+    gem 'sass-rails', '< 5.0'
   end
 end
 # END ENGINE_CART BLOCK

--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -107,7 +107,7 @@ module Sufia
     # @param [String,Hash] text either the string to escape or a hash containing the
     #                           string to escape under the :value key.
     def iconify_auto_link(text, showLink = true)
-      text = presenter(text[:document]).render_values(text[:value], text[:config]) if text.is_a? Hash
+      text = presenter(text[:document]).field_value(Array.wrap(text[:value]).first, text[:config]) if text.is_a? Hash
       # this block is only executed when a link is inserted;
       # if we pass text containing no links, it just returns text.
       auto_link(html_escape(text)) do |value|

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -47,6 +47,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 5
     config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5
     config.add_facet_field solr_name("creator", :facetable), label: "Creator", limit: 5
+    config.add_facet_field solr_name("contributor", :facetable), label: "Contributor", limit: 5
     config.add_facet_field solr_name("keyword", :facetable), label: "Keyword", limit: 5
     config.add_facet_field solr_name("subject", :facetable), label: "Subject", limit: 5
     config.add_facet_field solr_name("language", :facetable), label: "Language", limit: 5
@@ -66,14 +67,14 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("keyword", :stored_searchable), label: "Keyword", itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
     config.add_index_field solr_name("subject", :stored_searchable), label: "Subject", itemprop: 'about', link_to_search: solr_name("subject", :facetable)
     config.add_index_field solr_name("creator", :stored_searchable), label: "Creator", itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
-    config.add_index_field solr_name("contributor", :stored_searchable), label: "Contributor", itemprop: 'contributor', helper_method: :index_field_link, field_name: 'contributor'
+    config.add_index_field solr_name("contributor", :stored_searchable), label: "Contributor", itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
     config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
     config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
     config.add_index_field solr_name("publisher", :stored_searchable), label: "Publisher", itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
     config.add_index_field solr_name("based_near", :stored_searchable), label: "Location", itemprop: 'contentLocation', link_to_search: solr_name("based_near", :facetable)
     config.add_index_field solr_name("language", :stored_searchable), label: "Language", itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
-    config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: "Date Uploaded", itemprop: 'datePublished', helper_method: :human_readable_date
-    config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), label: "Date Modified", itemprop: 'dateModified', helper_method: :human_readable_date
+    config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: "Date Uploaded", itemprop: 'datePublished'
+    config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), label: "Date Modified", itemprop: 'dateModified'
     config.add_index_field solr_name("date_created", :stored_searchable), label: "Date Created", itemprop: 'dateCreated'
     config.add_index_field solr_name("rights", :stored_searchable), label: "Rights", helper_method: :rights_statement_links
     config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)

--- a/lib/sufia/configuration.rb
+++ b/lib/sufia/configuration.rb
@@ -86,6 +86,11 @@ module Sufia
       @always_display_share_button
     end
 
+    attr_writer :google_analytics_id
+    def google_analytics_id
+      @google_analytics_id ||= nil
+    end
+
     # Defaulting analytic start date to whenever the file was uploaded by leaving it blank
     attr_writer :analytic_start_date
     attr_reader :analytic_start_date

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe BlacklightHelper, type: :helper do
   let(:document) { SolrDocument.new(attributes) }
   before do
     allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
+    allow(controller).to receive(:action_name).and_return('index')
   end
 
   describe "render_index_field_value" do
@@ -44,37 +45,37 @@ RSpec.describe BlacklightHelper, type: :helper do
 
       context "keyword_tesim" do
         let(:field_name) { 'keyword_tesim' }
-        it { is_expected.to eq "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco\"><span itemprop=\"keywords\">taco</span></a></span> and <span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache\"><span itemprop=\"keywords\">mustache</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco\">taco</a></span> and <span itemprop=\"keywords\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache\">mustache</a></span>" }
       end
 
       context "subject_tesim" do
         let(:field_name) { 'subject_tesim' }
-        it { is_expected.to eq "<span itemprop=\"about\"><a href=\"/catalog?f%5Bsubject_sim%5D%5B%5D=Awesome\"><span itemprop=\"about\">Awesome</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"about\"><a href=\"/catalog?f%5Bsubject_sim%5D%5B%5D=Awesome\">Awesome</a></span>" }
       end
 
       context "creator_tesim" do
         let(:field_name) { 'creator_tesim' }
-        it { is_expected.to eq "<span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Justin\"><span itemprop=\"creator\">Justin</span></a></span> and <span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Joe\"><span itemprop=\"creator\">Joe</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Justin\">Justin</a></span> and <span itemprop=\"creator\"><a href=\"/catalog?f%5Bcreator_sim%5D%5B%5D=Joe\">Joe</a></span>" }
       end
 
       context "contributor_tesim" do
         let(:field_name) { 'contributor_tesim' }
-        it { is_expected.to eq "<span itemprop=\"contributor\"><a href=\"/catalog?Bird%2C+Big=%22contributor%22&amp;search_field=advanced\">Bird, Big</a></span>" }
+        it { is_expected.to eq "<span itemprop=\"contributor\"><a href=\"/catalog?f%5Bcontributor_sim%5D%5B%5D=Bird%2C+Big\">Bird, Big</a></span>" }
       end
 
       context "publisher_tesim" do
         let(:field_name) { 'publisher_tesim' }
-        it { is_expected.to eq "<span itemprop=\"publisher\"><a href=\"/catalog?f%5Bpublisher_sim%5D%5B%5D=Penguin+Random+House\"><span itemprop=\"publisher\">Penguin Random House</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"publisher\"><a href=\"/catalog?f%5Bpublisher_sim%5D%5B%5D=Penguin+Random+House\">Penguin Random House</a></span>" }
       end
 
       context "location_tesim" do
         let(:field_name) { 'based_near_tesim' }
-        it { is_expected.to eq "<span itemprop=\"contentLocation\"><a href=\"/catalog?f%5Bbased_near_sim%5D%5B%5D=Pennsylvania\"><span itemprop=\"contentLocation\">Pennsylvania</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"contentLocation\"><a href=\"/catalog?f%5Bbased_near_sim%5D%5B%5D=Pennsylvania\">Pennsylvania</a></span>" }
       end
 
       context "language_tesim" do
         let(:field_name) { 'language_tesim' }
-        it { is_expected.to eq "<span itemprop=\"inLanguage\"><a href=\"/catalog?f%5Blanguage_sim%5D%5B%5D=English\"><span itemprop=\"inLanguage\">English</span></a></span>" }
+        it { is_expected.to eq "<span itemprop=\"inLanguage\"><a href=\"/catalog?f%5Blanguage_sim%5D%5B%5D=English\">English</a></span>" }
       end
 
       context "resource_type_tesim" do

--- a/spec/lib/sufia/configuration_spec.rb
+++ b/spec/lib/sufia/configuration_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Sufia::Configuration do
+  subject { described_class.new }
+
+  it { is_expected.to respond_to(:persistent_hostpath) }
+  it { is_expected.to respond_to(:redis_namespace) }
+  it { is_expected.to respond_to(:libreoffice_path) }
+  it { is_expected.to respond_to(:browse_everything) }
+  it { is_expected.to respond_to(:analytics) }
+  it { is_expected.to respond_to(:citations) }
+  it { is_expected.to respond_to(:max_notifications_for_dashboard) }
+  it { is_expected.to respond_to(:activity_to_show_default_seconds_since_now) }
+  it { is_expected.to respond_to(:arkivo_api) }
+  it { is_expected.to respond_to(:active_deposit_agreement_acceptance) }
+  it { is_expected.to respond_to(:batch_user_key) }
+  it { is_expected.to respond_to(:audit_user_key) }
+  it { is_expected.to respond_to(:upload_path) }
+  it { is_expected.to respond_to(:always_display_share_button) }
+  it { is_expected.to respond_to(:google_analytics_id) }
+  it { is_expected.to respond_to(:analytic_start_date) }
+  it { is_expected.to respond_to(:display_media_download_link) }
+  it { is_expected.to respond_to(:permission_levels) }
+  it { is_expected.to respond_to(:owner_permission_levels) }
+  it { is_expected.to respond_to(:translate_uri_to_id) }
+  it { is_expected.to respond_to(:translate_id_to_uri) }
+  it { is_expected.to respond_to(:contact_email) }
+  it { is_expected.to respond_to(:subject_prefix) }
+  it { is_expected.to respond_to(:model_to_create) }
+end

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.version       = Sufia::VERSION
   spec.license       = 'Apache2'
 
-  spec.add_dependency 'curation_concerns', '>= 1.0.0', '< 2'
+  spec.add_dependency 'curation_concerns', '>= 1.1.0', '< 2'
   spec.add_dependency 'hydra-batch-edit', '~> 2.0'
   spec.add_dependency 'browse-everything', '~> 0.10'
   spec.add_dependency 'blacklight-gallery', '~> 0.1'

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.version       = Sufia::VERSION
   spec.license       = 'Apache2'
 
-  spec.add_dependency 'curation_concerns', '>= 1.1.0', '< 2'
+  spec.add_dependency 'curation_concerns', '~> 1.1'
   spec.add_dependency 'hydra-batch-edit', '~> 2.0'
   spec.add_dependency 'browse-everything', '~> 0.10'
   spec.add_dependency 'blacklight-gallery', '~> 0.1'

--- a/tasks/noid.rake
+++ b/tasks/noid.rake
@@ -1,6 +1,6 @@
 # Pull in tasks from AF::Noid
-af_noid = Gem::Specification.find_by_name 'active_fedora-noid'
-load "#{af_noid.gem_dir}/lib/tasks/noid_tasks.rake"
+af_noid_path = Gem.loaded_specs['active_fedora-noid'].full_gem_path
+load "#{af_noid_path}/lib/tasks/noid_tasks.rake"
 
 namespace :sufia do
   namespace :noid do


### PR DESCRIPTION
Fixes a number of problems: #2295, #2317, #2323, and #2322

1. Adds config value for GA back into Sufia config
2. Gets Sufia working with Blacklight 6.3.
3. Adds `contributor` facet for consistency with other searched fields and to display microdata properly.

Note the changes in the helper expectations. These seem to be more correct than the previous ones.

@projecthydra/sufia-code-reviewers
