### PR TITLE
Adding ActiveRecord class for Sufia::Migration::Survey::item

### DIFF
--- a/db/migrate/20160706132422_create_sufia_migration_survey_items.rb
+++ b/db/migrate/20160706132422_create_sufia_migration_survey_items.rb
@@ -1,0 +1,12 @@
+class CreateSufiaMigrationSurveyItems < ActiveRecord::Migration
+  def change
+    create_table :sufia_migration_survey_items do |t|
+      t.string :object_id
+      t.string :object_class
+      t.text :object_title
+      t.integer :migration_status
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -113,5 +113,10 @@ module Sufia
     def install_admin_stats
       generate "sufia:admin_stat"
     end
+
+    # Setup the database migrations
+    def copy_migrations
+      rake 'sufia:install:migrations'
+    end
   end
 end

--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -12,6 +12,7 @@ require 'sufia/inflections'
 require 'sufia/arkivo'
 require 'sufia/zotero'
 require 'sufia/export'
+require 'sufia/migration'
 
 require 'rails_autolink'
 require 'font-awesome-rails'

--- a/lib/sufia/migration.rb
+++ b/lib/sufia/migration.rb
@@ -1,0 +1,7 @@
+require 'sufia/migration/survey'
+
+module Sufia
+  module Migration
+    VERSION = Sufia::VERSION
+  end
+end

--- a/lib/sufia/migration/survey.rb
+++ b/lib/sufia/migration/survey.rb
@@ -1,0 +1,13 @@
+require 'sufia/migration/survey/item'
+
+module Sufia
+  module Migration
+    module Survey
+      VERSION = Sufia::VERSION
+
+      def self.table_name_prefix
+        'sufia_migration_survey_'
+      end
+    end
+  end
+end

--- a/lib/sufia/migration/survey/item.rb
+++ b/lib/sufia/migration/survey/item.rb
@@ -1,0 +1,18 @@
+# ActiveRecord class to store the current migration status of an object in ActiveFedora.
+#
+# @attr [String] object_id fedora id of the object being migrated
+# @attr [String] object_class fedora class of the object being migrated (Collection, GenericFile)
+# @attr [String] object_title title of the object being migrated
+# @attr [int]    migration_status - Status of the object's migration
+# @option migration_status -1 initial state before migration
+# @option migration_status 0 migrated successfully
+# @option migration_status 1 Missing when verified
+# @option migration_status 2 Migrated but wrong type
+module Sufia
+  module Migration
+    module Survey
+      class Item < ActiveRecord::Base
+      end
+    end
+  end
+end

--- a/spec/lib/sufia/migration/survey_item_spec.rb
+++ b/spec/lib/sufia/migration/survey_item_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Sufia::Migration::Survey::Item, type: :model do
+  it { is_expected.to respond_to(:object_id) }
+  it { is_expected.to respond_to(:object_class) }
+  it { is_expected.to respond_to(:object_title) }
+  it { is_expected.to respond_to(:migration_status) }
+
+  context "with specific values" do
+    let(:item) { described_class.create(object_id: "myid", object_class: "MyClass", object_title: "My Title", migration_status: 99) }
+    subject { described_class.find(item.id) }
+    it "stores the attributes" do
+      expect(subject.object_id).to eq "myid"
+      expect(subject.object_class).to eq "MyClass"
+      expect(subject.object_title).to eq "My Title"
+      expect(subject.migration_status).to eq 99
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2131

Adding an ActiveRecord Class so we can create a survey of our ActiveFedora objects before we migrate.  This survey will be used to verify that all our objects made it after the migration has completed.

@projecthydra/sufia-code-reviewers

