### PR TITLE
Adding FedoraIdService to create a list of all the ids in fedora

### DIFF
--- a/lib/sufia/migration/survey.rb
+++ b/lib/sufia/migration/survey.rb
@@ -1,4 +1,5 @@
 require 'sufia/migration/survey/item'
+require 'sufia/migration/survey/fedora_id_service'
 
 module Sufia
   module Migration

--- a/lib/sufia/migration/survey/fedora_id_service.rb
+++ b/lib/sufia/migration/survey/fedora_id_service.rb
@@ -1,0 +1,62 @@
+# Class to extract all the ids from fedora for registered classes.  By default GenericFile and Collection are registered.
+#
+module Sufia
+  module Migration
+    module Survey
+      class FedoraIdService
+        attr_accessor :model_registry
+
+        # initialize the service with the default models (GenericFile & Collection) registered
+        def initialize
+          @model_registry = default_registry
+        end
+
+        # regesiter an additional ActiveFedora Model to extract ids for
+        #
+        # @param [Class] model_class additional class that you would like to be in the output
+        # @raise [RegistryError] if the class is not an ActiveFedora based class
+        def register_model(model_class)
+          raise(RegistryError, "Model (#{model_class.name}) for conversion must be an ActiveFedora::Base") unless model_class.ancestors.include?(ActiveFedora::Base)
+          @model_registry << model_class
+        end
+
+        # returns a list of ids for all the registered classes in the repository
+        #
+        # @param [Number] limit limits the number of results (default is all)
+        def call(limit = :all)
+          ids = all_ids.select { |id| registered_model?(id) }
+          return ids if limit == :all
+          ids.take(limit)
+        end
+
+        private
+
+          def default_registry
+            [::GenericFile, ::Collection]
+          end
+
+          def all_ids
+            root_uri = ActiveFedora::Base.id_to_uri('')
+            # Fetches all the Fedora 4 descendant URIs for a given URI.
+            # Stolen from: https://github.com/projecthydra/active_fedora/blob/master/lib/active_fedora/indexing.rb#L72-L79
+            resource = Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, root_uri)
+            children = resource.graph.query(predicate: ::RDF::Vocab::LDP.contains).map { |descendant| descendant.object.to_s }
+            children.map { |uri| uri.split("/").last }
+          end
+
+          def active_fedora_model(id)
+            query = 'id:"' + id + '"'
+            matches = ActiveFedora::SolrService.query(query)
+            return nil if matches.count == 0
+            model_str = matches.first["active_fedora_model_ssi"]
+            Object.const_get(model_str)
+          end
+
+          def registered_model?(id)
+            model_registry.include?(active_fedora_model(id))
+          end
+      end
+      class RegistryError < RuntimeError; end
+    end
+  end
+end

--- a/spec/lib/sufia/migration/survey_fedora_id_service_spec.rb
+++ b/spec/lib/sufia/migration/survey_fedora_id_service_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Sufia::Migration::Survey::FedoraIdService do
+  it { is_expected.to respond_to(:register_model) }
+  it { is_expected.to respond_to(:call) }
+
+  let(:service) { described_class.new }
+
+  describe "default registry" do
+    subject { service.model_registry }
+    it { is_expected.to eq([::GenericFile, ::Collection]) }
+  end
+
+  describe "#register_model" do
+    subject { service.model_registry }
+
+    let(:model_class) { TestModel }
+    before do
+      class TestModel < ActiveFedora::Base; end
+    end
+    after do
+      Object.send(:remove_const, :TestModel)
+    end
+
+    it "registers a model" do
+      service.register_model(model_class)
+      is_expected.to include(model_class)
+    end
+    context "invalid model" do
+      let(:model_class) { String }
+      it "throws an error" do
+        expect { service.register_model(model_class) }.to raise_error(Sufia::Migration::Survey::RegistryError)
+        is_expected.not_to include(model_class)
+      end
+    end
+  end
+
+  describe "#call" do
+    let!(:file) { create :generic_file }
+    let!(:collection) do
+      Collection.create(title: "title1", creator: ["creator1"], description: "description1") do |col|
+        col.apply_depositor_metadata("jilluser")
+      end
+    end
+    subject { service.call }
+
+    it "finds the model ids" do
+      is_expected.to include(file.id, collection.id)
+      subject.count eq 2
+    end
+
+    context "we only want a limited set" do
+      subject { service.call(1) }
+
+      it "finds the model ids" do
+        is_expected.to include(file.id)
+        subject.count eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2132

This service creates a list of ids for all the top level objects in a fedora repository.  By default top level object is defined as GenericFiles and Collections.  You may register additional top level objects before you call the service.

@projecthydra/sufia-code-reviewers
