### PR TITLE
Adding a surveyor to create survey items for an id list

### DIFF
--- a/lib/sufia/migration/survey.rb
+++ b/lib/sufia/migration/survey.rb
@@ -1,5 +1,6 @@
 require 'sufia/migration/survey/item'
 require 'sufia/migration/survey/fedora_id_service'
+require 'sufia/migration/survey/surveyor'
 
 module Sufia
   module Migration

--- a/lib/sufia/migration/survey/item.rb
+++ b/lib/sufia/migration/survey/item.rb
@@ -3,15 +3,16 @@
 # @attr [String] object_id fedora id of the object being migrated
 # @attr [String] object_class fedora class of the object being migrated (Collection, GenericFile)
 # @attr [String] object_title title of the object being migrated
-# @attr [int]    migration_status - Status of the object's migration
-# @option migration_status -1 initial state before migration
-# @option migration_status 0 migrated successfully
-# @option migration_status 1 Missing when verified
-# @option migration_status 2 Migrated but wrong type
+# @attr [enum]   migration_status - Status of the object's migration
+# @option migration_status :initial_state initial state before migration
+# @option migration_status :successful migrated successfully
+# @option migration_status :missing Missing when verified
+# @option migration_status :wrong_type Migrated but wrong type
 module Sufia
   module Migration
     module Survey
       class Item < ActiveRecord::Base
+        enum migration_status: [:initial_state, :successful, :missing, :wrong_type]
       end
     end
   end

--- a/lib/sufia/migration/survey/surveyor.rb
+++ b/lib/sufia/migration/survey/surveyor.rb
@@ -1,0 +1,19 @@
+# Class that will survey Fedora based on a list of ids
+module Sufia
+  module Migration
+    module Survey
+      class Surveyor
+        class << self
+          # call causes the surveyor to create a survey item for each id in the list
+          #
+          # @param [Array] id_list a list of ids to be surveyed
+          def call(id_list)
+            ActiveFedora::Base.find(id_list).each do |object|
+              Item.create(object_id: object.id, object_class: object.class, object_title: object.title, migration_status: :initial_state)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/sufia/migration/survey_item_spec.rb
+++ b/spec/lib/sufia/migration/survey_item_spec.rb
@@ -7,13 +7,13 @@ describe Sufia::Migration::Survey::Item, type: :model do
   it { is_expected.to respond_to(:migration_status) }
 
   context "with specific values" do
-    let(:item) { described_class.create(object_id: "myid", object_class: "MyClass", object_title: "My Title", migration_status: 99) }
+    let(:item) { described_class.create(object_id: "myid", object_class: "MyClass", object_title: "My Title", migration_status: :successful) }
     subject { described_class.find(item.id) }
     it "stores the attributes" do
       expect(subject.object_id).to eq "myid"
       expect(subject.object_class).to eq "MyClass"
       expect(subject.object_title).to eq "My Title"
-      expect(subject.migration_status).to eq 99
+      expect(subject.successful?).to be_truthy
     end
   end
 end

--- a/spec/lib/sufia/migration/surveyor_spec.rb
+++ b/spec/lib/sufia/migration/surveyor_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Sufia::Migration::Survey::Surveyor, type: :model do
+  let(:collection) do
+    Collection.create(title: "title1", creator: ["creator1"], description: "description1") do |col|
+      col.apply_depositor_metadata("jilluser")
+    end
+  end
+  let(:file) { create :generic_file, title: ["my title"] }
+
+  subject { described_class }
+  it { is_expected.to respond_to(:call) }
+
+  describe "#call" do
+    let(:ids) { [object.id] }
+    subject { Sufia::Migration::Survey::Item.where(object_id: object.id).first }
+
+    before do
+      described_class.call(ids)
+    end
+
+    context "when object is a file" do
+      let(:object) { file }
+
+      it "creates a survey item for a file" do
+        is_expected.not_to be_nil
+        expect(subject.object_id).to eq file.id
+        expect(subject.object_class).to eq "GenericFile"
+        expect(subject.object_title).to eq file.title.to_s
+        expect(subject.initial_state?).to be_truthy
+      end
+    end
+
+    context "when object is a collection" do
+      let(:object) { collection }
+
+      it "creates a survey item for a file" do
+        is_expected.not_to be_nil
+        expect(subject.object_id).to eq collection.id
+        expect(subject.object_class).to eq "Collection"
+        expect(subject.object_title).to eq collection.title.to_s
+        expect(subject.initial_state?).to be_truthy
+      end
+    end
+
+    context "when multiple types of objects are passed" do
+      let(:ids) { [file.id, collection.id] }
+      let(:file_survey) { Sufia::Migration::Survey::Item.where(object_id: file.id).first }
+      let(:collection_survey) { Sufia::Migration::Survey::Item.where(object_id: collection.id).first }
+
+      it "creates a survey item for each" do
+        expect(file_survey).not_to be_nil
+        expect(collection_survey).not_to be_nil
+      end
+    end
+  end
+
+  context "when one of the objects does not exist" do
+    let(:ids) { [file.id, "abc123"] }
+
+    it "Errors with out creating any survey items" do
+      expect { described_class.call(ids) }.to raise_error(ActiveFedora::ObjectNotFoundError)
+      expect(Sufia::Migration::Survey::Item.find_by(object_id: file.id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
fixes #2133 

Creates a Sufia::Migration::Survey::Item for each id passed into the call.  If any id does not exists the entire call should fail.

The id list is generated by the code in #2335.

@projecthydra/sufia-code-reviewers
