### PR TITLE
Auto-link description field, fixes #2348

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -121,13 +121,23 @@ module Sufia
       safe_join(values.map { |item| link_to_field(name, item, item) }, ", ".html_safe)
     end
 
-    # *Sometimes* a Blacklight helper_method
-    # @param text [String,Hash] string to format and escape or a hash as per helper_method
+    # Uses Rails auto_link to add links to fields
+    #
+    # @param field [String,Hash] string to format and escape, or a hash as per helper_method
+    # @option field [SolrDocument] :document
+    # @option field [String] :field name of the solr field
+    # @option field [Blacklight::Configuration::IndexField, Blacklight::Configuration::ShowField] :config
+    # @option field [Array] :value array of values for the field
     # @param show_link [Boolean]
     # @return [ActiveSupport::SafeBuffer]
     # @todo stop being a helper_method, start being part of the Blacklight render stack?
-    def iconify_auto_link(text, show_link = true)
-      text = index_presenter(text[:document]).field_value(text[:config].key, text[:config]) if text.is_a? Hash
+    def iconify_auto_link(field, show_link = true)
+      if field.is_a? Hash
+        options = field[:config].separator_options || {}
+        text = field[:value].to_sentence(options)
+      else
+        text = field
+      end
       # this block is only executed when a link is inserted;
       # if we pass text containing no links, it just returns text.
       auto_link(html_escape(text)) do |value|

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -210,8 +210,9 @@ describe SufiaHelper, type: :helper do
   end
 
   describe "#iconify_auto_link" do
-    let(:text) { 'Foo < http://www.example.com. & More text' }
-    let(:document) { SolrDocument.new(has_model_ssim: ['GenericWork'], id: 512, title_tesim: text, description_tesim: text) }
+    let(:text)              { 'Foo < http://www.example.com. & More text' }
+    let(:linked_text)       { 'Foo &lt; <a href="http://www.example.com"><span class="glyphicon glyphicon-new-window"></span> http://www.example.com</a>. &amp; More text' }
+    let(:document)          { SolrDocument.new(has_model_ssim: ['GenericWork'], id: 512, title_tesim: text, description_tesim: text) }
     let(:blacklight_config) { CatalogController.blacklight_config }
     before do
       allow(controller).to receive(:action_name).and_return('index')
@@ -233,16 +234,17 @@ describe SufiaHelper, type: :helper do
         expect(subject).to include('class="glyphicon glyphicon-new-window"')
       end
     end
-    context "Hash argument for title" do # note: title typically is NOT configured with an iconify_auto_link helper
-      subject { helper.iconify_auto_link(document: document, value: text, config: blacklight_config.index_fields['title_tesim']) }
-      it { is_expected.to eq '<span>Foo &lt; <a href="http://www.example.com"><span class="glyphicon glyphicon-new-window"></span> http://www.example.com</a>. &amp; More text</span>' }
-    end
-    context "Hash argument for description" do # note: description typically IS configured with an iconify_auto_link helper
-      let(:conf) { blacklight_config.index_fields['description_tesim'] }
-      subject { helper.iconify_auto_link(document: document, value: text, config: conf) }
-      it do
-        pending 'Need a different way to test description'
-        is_expected.to eq '<span>Foo &lt; <a href="http://www.example.com"><span class="glyphicon glyphicon-new-window"></span> http://www.example.com</a>. &amp; More text</span>'
+
+    context "when using a hash argument" do
+      subject { helper.iconify_auto_link(arg) }
+      describe "auto-linking in the title" do
+        let(:arg) { { document: document, value: [text], config: blacklight_config.index_fields['title_tesim'], field: 'title_tesim' } }
+        it { is_expected.to eq(linked_text) }
+      end
+
+      describe "auto-linking in the description" do
+        let(:arg) { { document: document, value: [text], config: blacklight_config.index_fields['description_tesim'], field: 'description_tesim' } }
+        it { is_expected.to eq(linked_text) }
       end
     end
   end


### PR DESCRIPTION
Fixes #2348 

Links in the description field now display properly.

![desc](https://cloud.githubusercontent.com/assets/312085/16745050/25c7ea76-4782-11e6-94a0-d331735c5c2b.png)


@projecthydra/sufia-code-reviewers

