### PR TITLE
Adding executable to run surveyor from the command line.

### DIFF
--- a/exe/sufia_survey
+++ b/exe/sufia_survey
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+require 'rails'
+
+require ::File.join(File.dirname(Bundler.default_gemfile), 'config/environment')
+
+options = {}
+
+subtext = <<HELP
+Commonly used commands are:
+   clean :     cleans all Sufia::Migration::Survey::Items from the database
+See 'sufia_survey COMMAND --help' for more information on a specific command.
+HELP
+
+args = OptionParser.new do |opts|
+  opts.banner = "Survey model objects in fedora and store survey results in an ActiveRecord table. Usage: sufia_survey [options]"
+
+  opts.on("-v", "--[no-]verbose", "Run [not] verbosely") do |v|
+    options[:verbose] = v
+  end
+
+  opts.on("--limit NUMBER_OF_OBJECTS", Integer, "Survey a maximum number of objects (defaults to all)") do |v|
+    options[:limit] = v
+  end
+
+  opts.on("--ids ID_LIST", Array, "Survey only the objects in the list of IDs",
+          "For example to survey a Collection with the id abc123 and a GenericFile with an id def456:",
+          "  --ids abc123,def456") do |v|
+    options[:ids] = v
+  end
+
+  opts.on("--models MODEL_LIST", Array, "Specify the models to be surveyed (defaults to GenericFile,Collection)") do |v|
+    options[:models] = v
+  end
+
+  opts.separator ""
+  opts.separator subtext
+end
+
+subcommands = {
+  'clean' => OptionParser.new do |opts|
+    opts.banner = "Usage: sufia_survey clean"
+  end
+}
+
+begin
+  args.order!
+  command = ARGV.shift
+  if command
+    raise "Bad subcommand: #{command}" unless subcommands[command]
+    subcommands[command].order!
+  end
+  args.parse!
+rescue => error
+  $stderr.puts "ERROR: #{error}\n"
+  $stderr.puts args.help
+  exit 1
+end
+
+if command == 'clean'
+  $stdout.puts "cleaning Sufia::Migration::Survey::Items"
+  Sufia::Migration::Survey::Item.delete_all
+  exit 0
+end
+
+verbose = options[:verbose]
+
+$stdout.puts "running with #{options}" if verbose
+id_service = Sufia::Migration::Survey::FedoraIdService.new
+
+if options[:models]
+  model_options = options.delete(:models)
+  $stdout.puts "processing models #{model_options}" if verbose
+  model_options.each do |model_str|
+    model_class = Object.const_get(model_str)
+    id_service.register_model(model_class)
+  end
+end
+
+if options[:ids]
+  ids = options[:ids]
+else
+  $stdout.puts "Sending fedora_id with #{id_service.model_registry} and  #{options}" if verbose
+  ids = id_service.call(options[:limit] || :all)
+end
+
+$stdout.puts "Sending call with ids: #{ids}" if verbose
+Sufia::Migration::Survey::Surveyor.call(ids)

--- a/lib/sufia/migration/survey/fedora_id_service.rb
+++ b/lib/sufia/migration/survey/fedora_id_service.rb
@@ -17,6 +17,7 @@ module Sufia
         # @raise [RegistryError] if the class is not an ActiveFedora based class
         def register_model(model_class)
           raise(RegistryError, "Model (#{model_class.name}) for conversion must be an ActiveFedora::Base") unless model_class.ancestors.include?(ActiveFedora::Base)
+          return if @model_registry.include? model_class
           @model_registry << model_class
         end
 

--- a/lib/sufia/migration/survey/surveyor.rb
+++ b/lib/sufia/migration/survey/surveyor.rb
@@ -9,7 +9,9 @@ module Sufia
           # @param [Array] id_list a list of ids to be surveyed
           def call(id_list)
             ActiveFedora::Base.find(id_list).each do |object|
-              Item.create(object_id: object.id, object_class: object.class, object_title: object.title, migration_status: :initial_state)
+              Item.find_or_create_by(object_id: object.id) do |item|
+                item.assign_attributes(object_class: object.class, object_title: object.title, migration_status: :initial_state)
+              end
             end
           end
         end

--- a/spec/lib/sufia/migration/survey_fedora_id_service_spec.rb
+++ b/spec/lib/sufia/migration/survey_fedora_id_service_spec.rb
@@ -26,6 +26,12 @@ describe Sufia::Migration::Survey::FedoraIdService do
       service.register_model(model_class)
       is_expected.to include(model_class)
     end
+
+    it "registers a model once" do
+      service.register_model(model_class)
+      service.register_model(model_class)
+      expect(subject.count(model_class)).to eq(1)
+    end
     context "invalid model" do
       let(:model_class) { String }
       it "throws an error" do

--- a/spec/lib/sufia/migration/surveyor_spec.rb
+++ b/spec/lib/sufia/migration/surveyor_spec.rb
@@ -53,6 +53,17 @@ describe Sufia::Migration::Survey::Surveyor, type: :model do
         expect(collection_survey).not_to be_nil
       end
     end
+
+    context "when item is surveyed twice" do
+      let(:object) { file }
+      before do
+        described_class.call(ids)
+        described_class.call(ids)
+      end
+      it "creates a single item" do
+        expect(Sufia::Migration::Survey::Item.where(object_id: object.id).count).to eq 1
+      end
+    end
   end
 
   context "when one of the objects does not exist" do


### PR DESCRIPTION
Fixes #2128

Adds an executable to run the surveyor from the command line.  In addition this PR fixes a "bug" in the surveyor, to update an Survey::Item instead of always creating one.  That way if you run the sufia_survey 3 times you only get one item per Fedora object instead of 3.

@projecthydra/sufia-code-reviewers
