### PR TITLE
adds solr & fedora version prereqs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ After installing the Prerequisites:
 
 ## Prerequisites
 
-Sufia requires the following software to work:
+Sufia 7.x requires the following software to work:
 
-1. Solr
-1. [Fedora Commons](http://www.fedora-commons.org/) digital repository
+1. Solr version >= 5.x
+1. [Fedora Commons](http://www.fedora-commons.org/) digital repository version >= 4.5.1
 1. A SQL RDBMS (MySQL, PostgreSQL), though **note** that SQLite will be used by default if you're looking to get up and running quickly
 1. [Redis](http://redis.io/), a key-value store
 1. [ImageMagick](http://www.imagemagick.org/) with JPEG-2000 support


### PR DESCRIPTION
When I was having trouble running an app based on Sufia 7.0 rc 4, @mjgiarlo pointed out that I needed fcrepo 4.5.1 or greater. Thanks! My app runs now. Here's a PR for the README. I added the Solr version dependency too - feedback/additional suggestions welcome.

Calls out dependency on Fedora 4.5.1 or greater and on Solr 5.x or greater.

@projecthydra/sufia-code-reviewers
