### PR TITLE
Update to BrowseEverything 0.10.3

### DIFF
--- a/app/actors/sufia/create_with_remote_files_actor.rb
+++ b/app/actors/sufia/create_with_remote_files_actor.rb
@@ -33,10 +33,7 @@ module Sufia
           fs.save!
           uri = URI.parse(url)
           if uri.scheme == 'file'
-            IngestLocalFileJob.perform_later(fs.id,
-                                             File.dirname(uri.path),
-                                             File.basename(uri.path),
-                                             user.user_key)
+            IngestLocalFileJob.perform_later(fs, uri.path, user)
           else
             ImportUrlJob.perform_later(fs, log(actor.user))
           end

--- a/app/assets/javascripts/sufia.js
+++ b/app/assets/javascripts/sufia.js
@@ -34,6 +34,7 @@
 //= require sufia/featured_works
 //= require sufia/featured_researcher
 //= require sufia/batch_select_all
+//= require sufia/browse_everything
 //= require sufia/single_use_link
 //= require sufia/search
 //= require sufia/editor
@@ -59,7 +60,6 @@
 
 //= require curation_concerns/collections
 //= require hydra-editor/hydra-editor
-//= require browse_everything
 //= require nestable
 
 // this needs to be after batch_select so that the form ids get setup correctly

--- a/app/assets/javascripts/sufia/browse_everything.js
+++ b/app/assets/javascripts/sufia/browse_everything.js
@@ -1,0 +1,11 @@
+//= require browse_everything
+
+// Show the files in the queue
+$(document).on('turbolinks:load', function() {
+  $('#browse-btn').browseEverything()
+  .done(function(data) {
+    var evt = { isDefaultPrevented: function() { return false; } };
+    var files = $.map(data, function(d) { return { name: d.file_name, size: d.file_size, id: d.url } });
+    $.blueimp.fileupload.prototype.options.done.call($('#fileupload').fileupload(), evt, { result: { files: files }});
+  })
+});

--- a/app/views/curation_concerns/base/_browse_everything.html.erb
+++ b/app/views/curation_concerns/base/_browse_everything.html.erb
@@ -4,18 +4,3 @@
 <%= button_tag(t('sufia.upload.browse_everything.browse_files_button'), type: 'button', class: 'btn btn-lg btn-success', id: "browse-btn",
   'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,
   'data-target' => "##{f.object.persisted? ? 'edit' : 'new'}_#{f.object.model.model_name.param_key}" ) %>
-
-<p id="status">0 items selected</p>
-<script>
-  // Update the count in #status element when user selects files.
-  $(document).on('page:change', function() {
-    $('#browse-btn').browseEverything()
-      .done(function(data) {
-	$('#status').html(data.length.toString() + " <%= t('sufia.upload.browse_everything.files_selected')%>")
-        $('#submit-btn').html("Submit "+data.length.toString() + " selected files")
-	var evt = { isDefaultPrevented: function() { return false; } };
-	var files = $.map(data, function(d) { return { name: d.file_name, size: d.file_size, id: d.url } });
-	$.blueimp.fileupload.prototype.options.done.call($('#fileupload').fileupload(), evt, { result: { files: files }});
-      })
-  });
-</script>

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'curation_concerns', '~> 1.1'
   spec.add_dependency 'hydra-batch-edit', '~> 2.0'
-  spec.add_dependency 'browse-everything', '~> 0.10'
+  spec.add_dependency 'browse-everything', '>= 0.10.3'
   spec.add_dependency 'blacklight-gallery', '~> 0.1'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
   spec.add_dependency 'tinymce-rails-imageupload', '~> 4.0.16.beta'


### PR DESCRIPTION
Fixes #2356 

Adds support for turbolinks 5 and tests loading local files from the filesystem via BrowseEverything via CreateWithRemoteFilesActor.

@projecthydra/sufia-code-reviewers
