### PR TITLE
Overrides CC and adds standard date to embargo/lease in the show pages

### DIFF
--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -57,6 +57,16 @@ module Sufia
       Array.wrap(self['collection_ids_tesim'])
     end
 
+    def embargo_release_date
+      date_field_name = Hydra.config.permissions.embargo.release_date.sub(/_dtsi/, '')
+      date_field(date_field_name)
+    end
+
+    def lease_expiration_date
+      date_field_name = Hydra.config.permissions.lease.expiration_date.sub(/_dtsi/, '')
+      date_field(date_field_name)
+    end
+
     # Find the solr documents for the collections this object belongs to
     def collections
       return @collections if @collections

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -30,6 +30,34 @@ describe ::SolrDocument, type: :model do
     end
   end
 
+  describe "embargo_release_date" do
+    let(:attributes) { { 'embargo_release_date_dtsi' => '2013-03-14T00:00:00Z' } }
+    subject { document.embargo_release_date }
+    it { is_expected.to eq '03/14/2013' }
+
+    context "when an invalid type is provided" do
+      let(:attributes) { { 'embargo_release_date_dtsi' => 'Test' } }
+      it "logs parse errors" do
+        expect(ActiveFedora::Base.logger).to receive(:info).with(/Unable to parse date.*/)
+        subject
+      end
+    end
+  end
+
+  describe "lease_expiration_date" do
+    let(:attributes) { { 'lease_expiration_date_dtsi' => '2013-03-14T00:00:00Z' } }
+    subject { document.lease_expiration_date }
+    it { is_expected.to eq '03/14/2013' }
+
+    context "when an invalid type is provided" do
+      let(:attributes) { { 'lease_expiration_date_dtsi' => 'Test' } }
+      it "logs parse errors" do
+        expect(ActiveFedora::Base.logger).to receive(:info).with(/Unable to parse date.*/)
+        subject
+      end
+    end
+  end
+
   describe "resource_type" do
     let(:attributes) { { 'resource_type_tesim' => ['Image'] } }
     subject { document.resource_type }


### PR DESCRIPTION
Fixes #2325 

Changes proposed in this pull request:
* Overrides CC methods for embargo and lease
* Replaces previous formatting with :standard
* 

@projecthydra/sufia-code-reviewers


![screen shot 2016-07-18 at 1 05 41 pm](https://cloud.githubusercontent.com/assets/4163828/16923475/792f4c8e-4ce8-11e6-8e7c-451523e80a98.png)

![screen shot 2016-07-18 at 1 06 01 pm](https://cloud.githubusercontent.com/assets/4163828/16923501/9b6c911c-4ce8-11e6-9ce4-d65cf46f08eb.png)

