### PR TITLE
Making global javascript name longer so it does not conflict with other gems

### DIFF
--- a/app/assets/javascripts/sufia/flot_stats.js
+++ b/app/assets/javascripts/sufia/flot_stats.js
@@ -1,5 +1,5 @@
 $(function() {
-  if (typeof stats === "undefined") {
+  if (typeof sufia_item_stats === "undefined") {
     return;
   }
 
@@ -55,7 +55,7 @@ $(function() {
     }
   };
 
-  var plot = $.plot("#usage-stats", stats, options);
+  var plot = $.plot("#usage-stats", sufia_item_stats, options);
 
   $("<div id='tooltip'></div>").css({
     position: "absolute",
@@ -79,7 +79,7 @@ $(function() {
     }
   });
 
-  var overview = $.plot("#overview", stats, {
+  var overview = $.plot("#overview", sufia_item_stats, {
     series: {
       lines: {
         show: true,
@@ -106,7 +106,7 @@ $(function() {
   });
 
   $("#usage-stats").bind("plotselected", function(event, ranges) {
-    plot = $.plot("#usage-stats", stats, $.extend(true, {}, options, {
+    plot = $.plot("#usage-stats", sufia_item_stats, $.extend(true, {}, options, {
       xaxis: {
         min: ranges.xaxis.from,
         max: ranges.xaxis.to

--- a/app/views/stats/file.html.erb
+++ b/app/views/stats/file.html.erb
@@ -1,6 +1,6 @@
 <!-- Adapted from jquery-flot examples https://github.com/flot/flot/blob/master/examples/visitors/index.html -->
 <%= javascript_tag do %>
-  var stats = <%= @stats.to_flot.to_json.html_safe %>;
+  var sufia_item_stats = <%= @stats.to_flot.to_json.html_safe %>;
 <% end %>
 
 <%= content_tag :h1, @file_set, class: "lower" %>

--- a/app/views/stats/work.html.erb
+++ b/app/views/stats/work.html.erb
@@ -1,6 +1,6 @@
 <!-- Adapted from jquery-flot examples https://github.com/flot/flot/blob/master/examples/visitors/index.html -->
 <%= javascript_tag do %>
-  var stats = <%= @stats.to_flot.to_json.html_safe %>;
+  var sufia_item_stats = <%= @stats.to_flot.to_json.html_safe %>;
 <% end %>
 
 <%= content_tag :h1, @stats, class: "lower" %>


### PR DESCRIPTION
We are getting feature test error in ScholarSphere becuase for some reason the stat variable is getting set by another gem we are using and the flot javascript is erroring since it is set but not with the expected data.

Since it is a global variable, making the name more verbose solves the issue.

@projecthydra/sufia-code-reviewers
