### PR TITLE
Using Blacklight.onload instead of turbolinks 

### DIFF
--- a/app/assets/javascripts/sufia/browse_everything.js
+++ b/app/assets/javascripts/sufia/browse_everything.js
@@ -1,7 +1,7 @@
 //= require browse_everything
 
 // Show the files in the queue
-$(document).on('turbolinks:load', function() {
+Blacklight.onLoad( function() {
   $('#browse-btn').browseEverything()
   .done(function(data) {
     var evt = { isDefaultPrevented: function() { return false; } };


### PR DESCRIPTION
This allows the javascript to fire on a turbolinks page load OR a normal (non turbolinks) page load.

This was causing issues in feature tests in ScholarSphere that do not use turbolinks.  Not sure if this would ever cause a problem in real life, but since Blacklight is handeling it and we are using the BlackLight.onload many other places it also seems good to standardize.

@projecthydra/sufia-code-reviewers

