### PR TITLE
Verify we have a tab to select so we do not get a js error

### DIFF
--- a/app/assets/javascripts/sufia/tabs.js
+++ b/app/assets/javascripts/sufia/tabs.js
@@ -1,3 +1,4 @@
+// This code is to implement the tabs on the home page
 Blacklight.onLoad(function () {
   // When we visit a link to a tab, open that tab.
   var url = document.location.toString();
@@ -16,7 +17,11 @@ Blacklight.onLoad(function () {
     if (activeTab.length) {
       activeTab.tab('show');
     } else {
-      $('.nav-tabs a:first').tab('show');
+      var firstTab = $('.nav-tabs a:first');
+      // select the first tab if it has an id and is expected to be selected
+      if (firstTab.id[0] != ""){
+        $(firstTab).tab('show');
+      }
     }
   });
 });


### PR DESCRIPTION
This code is for the tabs on the home page. On the dashboard the tabs are defined differently and showing a tab caused a javascript error.

To replicate the javascript error you need to got to the works listing, then click on the collections listing, then hit the back button and the error will show in the js console.  One of the feature tests in ScholarSphere just happened to use the back button, which then showed the js error.

@projecthydra/sufia-code-reviewers

