### PR TITLE
Verify we have a tab to select so we do not get a js error

### DIFF
--- a/app/assets/javascripts/sufia/tabs.js
+++ b/app/assets/javascripts/sufia/tabs.js
@@ -1,22 +1,30 @@
+// This code is to implement the tabs on the home page
+
+// navigate to the selected tab or the first tab
+function tabNavigation(e) {
+    var activeTab = $('[href="' + location.hash + '"]');
+    if (activeTab.length) {
+        activeTab.tab('show');
+    } else {
+        var firstTab = $('.nav-tabs a:first');
+        // select the first tab if it has an id and is expected to be selected
+        if ((firstTab[0] !== undefined) && (firstTab[0].id != "")){
+          $(firstTab).tab('show');
+        }
+    }
+}
+
 Blacklight.onLoad(function () {
   // When we visit a link to a tab, open that tab.
   var url = document.location.toString();
   if (url.match('#')) {
     $('.nav-tabs a[href="#' + url.split('#')[1] + '"]').tab('show');
   }
-  
+
   // Change the url when a tab is clicked.
   $('a[data-toggle="tab"]').on('click', function(e) {
     history.pushState(null, null, $(this).attr('href'));
   });
-
-  // navigate to a tab when the history changes
-  window.addEventListener("popstate", function(e) {
-    var activeTab = $('[href="' + location.hash + '"]');
-    if (activeTab.length) {
-      activeTab.tab('show');
-    } else {
-      $('.nav-tabs a:first').tab('show');
-    }
-  });
+  // navigate to a tab when the history changes (back button)
+  window.addEventListener("popstate", tabNavigation);
 });

--- a/spec/javascripts/tabs_spec.js.coffee
+++ b/spec/javascripts/tabs_spec.js.coffee
@@ -1,0 +1,38 @@
+describe "tabs", ->
+  beforeEach ->
+    # run all Blacklight.onload functions
+    Blacklight.activate()
+
+  describe "dashboard tabs", ->
+    beforeEach ->
+      # setup the tabs like the homepage featured and recent tabs
+      setFixtures '<ul id="homeTabs" class="nav nav-tabs">
+                               <li><a href="#featured_container" data-toggle="tab" role="tab" id="featureTab">Featured Works</a></li>
+                               <li><a href="#recently_uploaded" data-toggle="tab" role="tab" id="recentTab">Recently Uploaded</a></li>
+                             </ul>'
+
+
+    describe "tabNavigation", ->
+
+      it "It sets the first tab to active", ->
+        expect($('#homeTabs li').attr('class')).toBeUndefined()
+        tabNavigation();
+        expect($('#homeTabs li').attr('class')).toBe('active')
+
+  describe "dashboard tabs", ->
+    beforeEach ->
+      # setup the tabs like the my listing on the dashboards
+      setFixtures '<ul class="nav nav-tabs" id="my_nav" role="navigation">
+                     <span class="sr-only">You are currently listing your works .  You have 1 works </span>
+                     <li>
+                       <a href="/dashboard/works">My Works</a>
+                     </li>
+                     <li class="">
+                       <a href="/dashboard/collections">My Collections</a>
+                     </li>
+                   </ul>'
+
+    describe "tabNavigation", ->
+
+      it "It does not error", ->
+        tabNavigation();


### PR DESCRIPTION
This code is for the tabs on the home page. On the dashboard the tabs are defined differently and showing a tab caused a javascript error.

To replicate the javascript error you need to got to the works listing, then click on the collections listing, then hit the back button and the error will show in the js console. One of the feature tests in ScholarSphere just happened to use the back button, which then showed the js error.

@projecthydra/sufia-code-reviewers