### PR TITLE
Fix logger instantiation of stat import service.

### DIFF
--- a/app/services/sufia/user_stat_importer.rb
+++ b/app/services/sufia/user_stat_importer.rb
@@ -6,7 +6,7 @@ module Sufia
 
     def initialize(options = {})
       if options[:verbose]
-        stdout_logger = Logger.new(Logger.new(STDOUT))
+        stdout_logger = Logger.new(STDOUT)
         stdout_logger.level = Logger::INFO
         Rails.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
       end

--- a/spec/services/sufia/user_stat_importer_spec.rb
+++ b/spec/services/sufia/user_stat_importer_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe Sufia::UserStatImporter do
+  it 'can be instantiated without throwing an error.' do
+    expect { described_class.new(verbose: true, logging: true) }.not_to raise_error(StandardError)
+  end
+end


### PR DESCRIPTION
Fixes #2375

Very simple fix to very simple typo of Logger.new

Changes proposed in this pull request:
*  Call `Logger.new(STDOUT)` instead of `Logger.new(Logger.new(STDOUT))`
*  Add dead simple smoke test to prevent regression in `initialize` of service.

@projecthydra/sufia-code-reviewers
