### PR TITLE
Add New Work - Bootlint Errors and HTML Refactor 

### DIFF
--- a/app/assets/stylesheets/sufia/_form-progress.scss
+++ b/app/assets/stylesheets/sufia/_form-progress.scss
@@ -18,12 +18,18 @@
   }
 }
 
-aside.form-progress {
-  ul.requirements {
-    list-style-type: none;
-    padding-left: 8px;
-  }
+.legend-save-work {
+  border: none;
+  font-size: $save-viz-widget-legend-font;
+  margin-bottom: $save-viz-widget-legend-margin;
+}
 
+.requirements, .visibility {
+  list-style-type: none;
+  padding-left: 8px;
+}
+
+aside.form-progress {
   .incomplete::before {
     content: "\e101";
     color: $brand-danger;
@@ -37,11 +43,4 @@ aside.form-progress {
     font-family: 'Glyphicons Halflings';
     padding-right: 5px;
   }
-
-  h3 {
-    margin: 0;
-    padding: 5px;
-    font-size: 12pt;
-  }
-
 }

--- a/app/assets/stylesheets/sufia/_settings.scss
+++ b/app/assets/stylesheets/sufia/_settings.scss
@@ -35,3 +35,5 @@ $related-files-thumbnail-width: 150px;
 // Save Visibility Widget
 $save-viz-widget-bottom: 8.57em;
 $save-viz-widget-left: 66.66666667%;
+$save-viz-widget-legend-font: 1.15em;
+$save-viz-widget-legend-margin: 0.5em;

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -1,15 +1,16 @@
 <aside id="form-progress" class="form-progress panel panel-default">
   <div class="panel-heading">
-
-    <h2><%= t("sufia.works.progress.header") %></h2>
+    <h3 class="panel-title"><%= t("sufia.works.progress.header") %></h3>
   </div>
   <div class="list-group">
     <div class="list-group-item">
-      <h3>Requirements</h3>
-      <ul class="requirements">
-        <li class="incomplete" id="required-metadata">Enter required metadata</li>
-        <li class="incomplete" id="required-files">Add files</li>
-      </ul>
+      <fieldset>
+        <legend class="legend-save-work">Requirements</legend>
+        <ul class="requirements">
+          <li class="incomplete" id="required-metadata">Enter required metadata</li>
+          <li class="incomplete" id="required-files">Add files</li>
+        </ul>
+      </fieldset>
     </div>
 
     <div class="set-access-controls list-group-item">
@@ -20,26 +21,26 @@
           <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
         </div>
     <% end %>
-    <div class="panel-footer text-center">
-      <% if Sufia.config.active_deposit_agreement_acceptance %>
-          <label>
-            <%= check_box_tag 'agreement', 1, f.object.agreement_accepted, required: true %>
-            <%= t('sufia.active_consent_to_agreement') %><br>
-            <%= link_to t('sufia.deposit_agreement'),
-                        sufia.static_path('agreement'),
-                        target: '_blank' %>
-          </label>
-      <% else %>
-          <%= t('sufia.passive_consent_to_agreement') %><br>
+  </div>
+  <div class="panel-footer text-center">
+    <% if Sufia.config.active_deposit_agreement_acceptance %>
+        <label>
+          <%= check_box_tag 'agreement', 1, f.object.agreement_accepted, required: true %>
+          <%= t('sufia.active_consent_to_agreement') %><br>
           <%= link_to t('sufia.deposit_agreement'),
                       sufia.static_path('agreement'),
                       target: '_blank' %>
-      <% end %>
-      <br>
-      <%= link_to t(:'helpers.action.cancel'),
-                  sufia.dashboard_index_path,
-                  class: 'btn btn-default' %>
-      <%= f.submit 'Save', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
-    </div>
+        </label>
+    <% else %>
+        <%= t('sufia.passive_consent_to_agreement') %><br>
+        <%= link_to t('sufia.deposit_agreement'),
+                    sufia.static_path('agreement'),
+                    target: '_blank' %>
+    <% end %>
+    <br>
+    <%= link_to t(:'helpers.action.cancel'),
+                sufia.dashboard_index_path,
+                class: 'btn btn-default' %>
+    <%= f.submit 'Save', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
   </div>
 </aside>

--- a/app/views/curation_concerns/base/_form_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_relationships.html.erb
@@ -1,4 +1,4 @@
-<h3><%= t("sufia.works.#{action_name}.in_collections") %></h3>
+<h2><%= t("sufia.works.#{action_name}.in_collections") %></h2>
 <div id="collection-widget">
   <%= f.input :collection_ids, as: :select,
       collection: available_collections(nil),

--- a/app/views/curation_concerns/base/_form_share.html.erb
+++ b/app/views/curation_concerns/base/_form_share.html.erb
@@ -1,4 +1,4 @@
-<h3>Sharing With</h3>
+<h2>Sharing With</h2>
 <% depositor = f.object.depositor %>
 
 <div class="alert alert-info hidden" id="save_perm_note">Permissions are
@@ -38,10 +38,12 @@
 </table>
 
 
-<h3>Share work with other users</h3>
-
+<h2>Share work with other users</h2>
+<p class="sr-only">Use the add button to give access to one <%=t('sufia.account_label') %> at a time (it will be added to the list below).
+  Select the user, by name or <%= t('sufia.account_label') %>. Then select the access level you wish to grant and click on Add this
+  <%= t('sufia.account_label') %> to complete adding the permission.
+</p>
 <div class="form-group row">
-  <p class="sr-only">Use the add button to give access to one <%=t('sufia.account_label') %> at a time (it will be added to the list below).  Select the user, by name or <%= t('sufia.account_label') %>. Then select the access level you wish to grant and click on Add this <%= t('sufia.account_label') %> to complete adding the permission.</p>
   <div class="col-sm-5">
     <label for="new_user_name_skel" class="sr-only"><%= t('sufia.account_label') %> (without the <%= t('sufia.directory.suffix') %> part)</label>
     <%= text_field_tag 'new_user_name_skel', nil %>
@@ -59,10 +61,9 @@
   </div>
 </div>
 
-<h3>Share work with groups of users</h3>
-
+<h2>Share work with groups of users</h2>
+<p class="sr-only">Use the add button to give access to one group at a time (it will be added to the list below).</p>
 <div class="form-group row">
-  <p class="sr-only">Use the add button to give access to one group at a time (it will be added to the list below).</p>
   <div class="col-sm-5">
     <label for="new_group_name_skel" class="sr-only">Group</label>
     <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>

--- a/app/views/curation_concerns/base/_form_visibility_component.html.erb
+++ b/app/views/curation_concerns/base/_form_visibility_component.html.erb
@@ -1,60 +1,70 @@
-<h3>Visibility</h3>
 <% if f.object.embargo_release_date %>
   <%= render 'form_permission_under_embargo', f: f %>
 <% elsif f.object.lease_expiration_date %>
   <%= render 'form_permission_under_lease', f: f %>
 <% else %>
-  <div class="form-group visibility">
-    <label class="radio">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
-      <%= t('curation_concerns.visibility.open.label_html') %>
-      <section class="collapse" id="collapsePublic">
-        <p>
-          <strong>Please note</strong>, making something visible to the world (i.e.
-          marking this as <%= t('curation_concerns.visibility.open.label_html') %>) may be
-          viewed as publishing which could impact your ability to:
-        </p>
-        <ul>
-          <li>Patent your work</li>
-          <li>Publish your work in a journal</li>
-        </ul>
-        <p>
-          Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more
-          information about publisher copyright policies.
-        </p>
-      </section>
-    </label>
-    <label class="radio">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
-      <%= t('curation_concerns.visibility.authenticated.label_html', institution: t('curation_concerns.institution.name')) %>
-    </label>
-    <label class="radio">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
-      <%= t('curation_concerns.visibility.embargo.label_html') %>
-      <div class="collapse" id="collapseEmbargo">
-        <div class="form-inline">
-          <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
-          <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
-          <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
-        </div>
-      </div>
-    </label>
-    <label class="radio">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
-      <%= t('curation_concerns.visibility.lease.label_html') %>
-      <div class="collapse" id="collapseLease">
-        <div class="form-inline">
-          <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
-          <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
-          <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
-        </div>
-      </div>
-
-    </label>
-    <label class="radio">
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
-      <%= t('curation_concerns.visibility.private.label_html') %>
-    </label>
-  </div>
+    <fieldset>
+      <legend class="legend-save-work">Visibility</legend>
+      <ul class="visibility">
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
+            <%= t('curation_concerns.visibility.open.label_html') %>
+            <div class="collapse" id="collapsePublic">
+              <p>
+                <strong>Please note</strong>, making something visible to the world (i.e.
+                marking this as <%= t('curation_concerns.visibility.open.label_html') %>) may be
+                viewed as publishing which could impact your ability to:
+              </p>
+              <ul>
+                <li>Patent your work</li>
+                <li>Publish your work in a journal</li>
+              </ul>
+              <p>
+                Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more
+                information about publisher copyright policies.
+              </p>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+            <%= t('curation_concerns.visibility.authenticated.label_html', institution: t('curation_concerns.institution.name')) %>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
+            <%= t('curation_concerns.visibility.embargo.label_html') %>
+            <div class="collapse" id="collapseEmbargo">
+              <div class="form-inline">
+                <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+                <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+              </div>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
+            <%= t('curation_concerns.visibility.lease.label_html') %>
+            <div class="collapse" id="collapseLease">
+              <div class="form-inline">
+                <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+                <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+              </div>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+            <%= t('curation_concerns.visibility.private.label_html') %>
+          </label>
+        </li>
+      </ul>
+    </fieldset>
 <% end %>
-


### PR DESCRIPTION
Fixes #2373 

Present tense short summary (50 characters or less)

Addresses most of the Bootlint errors except for some that are in Hydra Editor. Adds and removes HTML/CSS to pass Bootlint check and remove unnecessary HTML that doesn't impact display. Also adjusts heading levels for better semantics.
 
Changes proposed in this pull request:
* Adds non-nested classes to style `<legend>` and `<ul>`
* Variables for CSS values
* Adds `<fieldset>`, `<legend>`, and `<ul>` for lists
* Moves `panel-footer` for Bootlint
* Adjusts heading levels
* Moves `sr-only` text to be with heading and out of Bootstrap `col-*`
* Moves visibility component out of `form-group` and into a `<ul>` with `<fieldset>` and `<legend>`
* Moves `class="radio"` to `<li>` for Bootlint
* Replaces `<section>` element with `<div>`

@projecthydra/sufia-code-reviewers

Addresses Bootlint errors, refactor save viz widget a bit, and refactors HTML and CSS