### PR TITLE
Additional i18n config option for dashboard

### DIFF
--- a/app/views/users/_vitals.html.erb
+++ b/app/views/users/_vitals.html.erb
@@ -9,7 +9,7 @@
 
 <div class="list-group-item">
   <span class="badge"><%= number_of_works(user) %></span>
-  <span class="glyphicon glyphicon-upload"></span> <%= link_to_field('depositor', user.to_s, 'Works created',  human_readable_type: "Work") %>
+  <span class="glyphicon glyphicon-upload"></span> <%= link_to_field('depositor', user.to_s, t("sufia.dashboard.stats.works"),  human_readable_type: "Work") %>
 
   <ul class="views-downloads-dashboard list-unstyled">
       <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("sufia.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -121,6 +121,7 @@ en:
         files:              "Files deposited"
         file_views:         "View"
         file_downloads:     "Download"
+        works:              "Works created"
         collections:        "Collections created"
         following:          "People you follow"
         followers:          "People who are following you"


### PR DESCRIPTION
Adds another i18n configuration option for specifying the language of the "Works created" link in the dashboard.

@projecthydra/sufia-code-reviewers

