### PR TITLE
Updates metadata to include renderer for embargo and lease.

### DIFF
--- a/app/views/curation_concerns/base/_metadata.html.erb
+++ b/app/views/curation_concerns/base/_metadata.html.erb
@@ -5,8 +5,8 @@
   </thead>
   <tbody>
     <%= render 'attribute_rows', presenter: presenter %>
-    <%= presenter.attribute_to_html(:embargo_release_date) %>
-    <%= presenter.attribute_to_html(:lease_expiration_date) %>
+    <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date) %>
+    <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date) %>
     <%= presenter.attribute_to_html(:rights, render_as: :rights) %>
   </tbody>
 </table>


### PR DESCRIPTION
Fixes #2325 

Updates the metadata on the work show page for embargo and leases to use date renderer from CC.

Changes proposed in this pull request:
* Adds `render_as: :date`

@projecthydra/sufia-code-reviewers

![screen shot 2016-08-02 at 2 39 05 pm](https://cloud.githubusercontent.com/assets/4163828/17341476/cc6e28e4-58c2-11e6-9f37-17f19f4508c4.png)


