### PR TITLE
Adds Human Readable Embargo and Lease Dates to Index View

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -104,7 +104,8 @@ module Sufia
     # @see #index_field_link params
     # @return [Date]
     def human_readable_date(options)
-      Date.parse(options[:value]).to_formatted_s(:standard)
+      value = options[:value].first
+      Date.parse(value).to_formatted_s(:standard)
     end
 
     # A Blacklight helper_method

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -80,6 +80,8 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)
     config.add_index_field solr_name("file_format", :stored_searchable), label: "File Format", link_to_search: solr_name("file_format", :facetable)
     config.add_index_field solr_name("identifier", :stored_searchable), label: "Identifier", helper_method: :index_field_link, field_name: 'identifier'
+    config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date
+    config.add_index_field solr_name("lease_expiration_date", :stored_sortable, type: :date), label: "Lease expiration date", helper_method: :human_readable_date
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -264,4 +264,10 @@ describe SufiaHelper, type: :helper do
       )).to eq("<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\">CC0 1.0 Universal</a>, <a href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Public Domain Mark 1.0</a>, and <a href=\"http://www.europeana.eu/portal/rights/rr-r.html\">All rights reserved</a>")
     end
   end
+
+  describe "#human_readable_date" do
+    it "ensures that the display of the date is human-readable" do
+      expect(helper.human_readable_date(value: ["2016-08-15T00:00:00Z"])).to eq("08/15/2016")
+    end
+  end
 end

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -6,7 +6,9 @@ describe 'catalog/_index_list_default', type: :view do
       'proxy_depositor_ssim' => [''],
       'description_tesim'    => [''],
       'date_uploaded_dtsi'   => 'a date',
-      'rights_tesim'         => [''] }
+      'rights_tesim'         => [''],
+      'embargo_release_date_dtsi' => 'a date',
+      'lease_expiration_date_dtsi' => 'a date' }
   end
   let(:document) { SolrDocument.new(attributes) }
   let(:blacklight_configuration_context) do
@@ -35,5 +37,9 @@ describe 'catalog/_index_list_default', type: :view do
     expect(rendered).to include 'Test depositor_tesim'
     expect(rendered).to include '<span class="attribute-label h4">Rights:</span>'
     expect(rendered).to include 'Test rights_tesim'
+    expect(rendered).to include '<span class="attribute-label h4">Embargo release date:</span>'
+    expect(rendered).to include 'Test embargo_release_date_dtsi'
+    expect(rendered).to include '<span class="attribute-label h4">Lease expiration date:</span>'
+    expect(rendered).to include 'Test lease_expiration_date_dtsi'
   end
 end


### PR DESCRIPTION
Fixes #2327 

Adds Solrizer for embargo and lease in catalog controller. Updates and uses helper method for human readable dates by grabbing the first value in the array.

Changes proposed in this pull request:
* Grabs the first value from the array
* Formats the date as standard
* Uses `:stored_sortable` and `human-readable-date` helper method

@projecthydra/sufia-code-reviewers
