### PR TITLE
Remove unnecessary route injection from install generator

### DIFF
--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -123,8 +123,7 @@ module Sufia
       gsub_file 'config/routes.rb', /root (:to =>|to:) "catalog#index"/, ''
       gsub_file 'config/routes.rb', /'welcome#index'/, "'sufia/homepage#index'" # Replace the root path injected by CurationConcerns
 
-      routing_code = "\n  Hydra::BatchEdit.add_routes(self)\n" \
-        "  # This must be the very last route in the file because it has a catch-all route for 404 errors.\n" \
+      routing_code = "\n  # This must be the very last route in the file because it has a catch-all route for 404 errors.\n" \
         "  # This behavior seems to show up only in production mode.\n" \
         "  mount Sufia::Engine => '/'\n"
 

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -42,8 +42,6 @@ class TestAppGenerator < Rails::Generators::Base
   end
 
   def enable_i18n_translation_errors
-    say_status("info", "Adding i18n_translation_errors = true to dev and test", :blue)
-
     gsub_file "config/environments/development.rb",
               "# config.action_view.raise_on_missing_translations = true", "config.action_view.raise_on_missing_translations = true"
     gsub_file "config/environments/test.rb",


### PR DESCRIPTION
The Hydra::BatchEdit generator does this itself.

Also, remove unnecessary status line from test app generator. Fixes #2462