### PR TITLE
[WIP] remove outmoded from_field line

### DIFF
--- a/app/search_builders/collection_search_builder.rb
+++ b/app/search_builders/collection_search_builder.rb
@@ -2,7 +2,6 @@
 class CollectionSearchBuilder < CurationConcerns::MemberSearchBuilder
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
 
-  self.from_field = 'child_object_ids_ssim'
   self.default_processor_chain += [:include_contained_files]
 
   # This is like include_collection_ids, but it also joins the files.


### PR DESCRIPTION
It doesn't mean anything to any other code in Sufia and it is inaccurate, since our 2 join queries have *different* from_fields.