### PR TITLE
Human-readable Dates for Date Uploaded and Modified

### DIFF
--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -73,8 +73,8 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("publisher", :stored_searchable), label: "Publisher", itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
     config.add_index_field solr_name("based_near", :stored_searchable), label: "Location", itemprop: 'contentLocation', link_to_search: solr_name("based_near", :facetable)
     config.add_index_field solr_name("language", :stored_searchable), label: "Language", itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
-    config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: "Date Uploaded", itemprop: 'datePublished'
-    config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), label: "Date Modified", itemprop: 'dateModified'
+    config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: "Date Uploaded", itemprop: 'datePublished', helper_method: :human_readable_date
+    config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), label: "Date Modified", itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field solr_name("date_created", :stored_searchable), label: "Date Created", itemprop: 'dateCreated'
     config.add_index_field solr_name("rights", :stored_searchable), label: "Rights", helper_method: :rights_statement_links
     config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe 'catalog/_index_list_default', type: :view do
       'proxy_depositor_ssim' => [''],
       'description_tesim'    => [''],
       'date_uploaded_dtsi'   => 'a date',
+      'date_modified_dtsi'   => 'a date',
       'rights_tesim'         => [''],
       'embargo_release_date_dtsi' => 'a date',
       'lease_expiration_date_dtsi' => 'a date' }
@@ -31,6 +32,8 @@ describe 'catalog/_index_list_default', type: :view do
     expect(rendered).to include 'Test description_tesim'
     expect(rendered).to include '<span class="attribute-label h4">Date Uploaded:</span>'
     expect(rendered).to include 'Test date_uploaded_dtsi'
+    expect(rendered).to include '<span class="attribute-label h4">Date Modified:</span>'
+    expect(rendered).to include 'Test date_modified_dtsi'
     expect(rendered).to include '<span class="attribute-label h4">Depositor:</span>'
     expect(rendered).to include 'Test proxy_depositor_ssim'
     expect(rendered).to include '<span class="attribute-label h4">Owner:</span>'


### PR DESCRIPTION
Fixes #2461 

Present tense short summary (50 characters or less)

Updates date uploaded and ate modified fields in the search index view to be displayed as human-readable dates.

Changes proposed in this pull request:
*  Adds `helper_method: :human_readable_date` to catalog controller
* Adds `date modified` to view test
* 

@projecthydra/sufia-code-reviewers
