### PR TITLE
Adding characterization terms for documents of other types than images

### DIFF
--- a/app/indexers/sufia/file_set_indexer.rb
+++ b/app/indexers/sufia/file_set_indexer.rb
@@ -1,0 +1,12 @@
+module Sufia
+  class FileSetIndexer < CurationConcerns::FileSetIndexer
+    def generate_solr_document
+      super.tap do |solr_doc|
+        solr_doc[Solrizer.solr_name('page_count')] = object.page_count
+        solr_doc[Solrizer.solr_name('file_title')] = object.file_title
+        solr_doc[Solrizer.solr_name('duration')] = object.duration
+        solr_doc[Solrizer.solr_name('sample_rate')] = object.sample_rate
+      end
+    end
+  end
+end

--- a/app/models/concerns/sufia/file_set_behavior.rb
+++ b/app/models/concerns/sufia/file_set_behavior.rb
@@ -7,5 +7,12 @@ module Sufia
     def to_presenter
       CatalogController.new.fetch(id).last
     end
+
+    included do
+      self.characterization_terms += [:duration, :sample_rate]
+      delegate(*characterization_terms, to: :characterization_proxy)
+
+      self.indexer = Sufia::FileSetIndexer
+    end
   end
 end

--- a/app/models/concerns/sufia/solr_document/characterization.rb
+++ b/app/models/concerns/sufia/solr_document/characterization.rb
@@ -61,6 +61,22 @@ module Sufia
       def width
         self['width_is']
       end
+
+      def page_count
+        self[Solrizer.solr_name("page_count")]
+      end
+
+      def file_title
+        self[Solrizer.solr_name("file_title")]
+      end
+
+      def duration
+        self[Solrizer.solr_name("duration")]
+      end
+
+      def sample_rate
+        self[Solrizer.solr_name("sample_rate")]
+      end
     end
   end
 end

--- a/app/presenters/sufia/characterization_behavior.rb
+++ b/app/presenters/sufia/characterization_behavior.rb
@@ -7,7 +7,8 @@ module Sufia
         [
           :byte_order, :compression, :height, :width, :height, :color_space,
           :profile_name, :profile_version, :orientation, :color_map, :image_producer,
-          :capture_device, :scanning_software, :gps_timestamp, :latitude, :longitude
+          :capture_device, :scanning_software, :gps_timestamp, :latitude, :longitude,
+          :file_format, :file_title, :page_count, :duration, :sample_rate
         ]
       end
     end
@@ -72,7 +73,8 @@ module Sufia
 
       def build_characterization_metadata
         self.class.characterization_terms.each do |term|
-          additional_characterization_metadata[term.to_sym] = send(term)
+          value = send(term)
+          additional_characterization_metadata[term.to_sym] = value unless value.blank?
         end
         additional_characterization_metadata
       end

--- a/spec/indexers/sufia/file_set_indexer_spec.rb
+++ b/spec/indexers/sufia/file_set_indexer_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Sufia::FileSetIndexer do
+  let(:user) { create(:user) }
+  let!(:file_set) { create(:file_set, user: user) }
+  let(:service) { described_class.new(file_set) }
+  let(:file) { File.open(fixture_path + '/world.png') }
+
+  before do
+    Hydra::Works::AddFileToFileSet.call(file_set, file, :original_file)
+    file_set.original_file.page_count = ['1']
+    file_set.original_file.file_title = ['title']
+    file_set.original_file.duration = ['0:1']
+    file_set.original_file.sample_rate = ['sample rate']
+  end
+  subject { service.generate_solr_document }
+
+  it 'indexes audio and pdf characterization attributes' do
+    expect(subject['page_count_tesim']).to eq file_set.page_count
+    expect(subject['file_title_tesim']).to eq file_set.file_title
+    expect(subject['duration_tesim']).to eq file_set.duration
+    expect(subject['sample_rate_tesim']).to eq file_set.sample_rate
+  end
+end

--- a/spec/indexers/sufia/work_indexer_spec.rb
+++ b/spec/indexers/sufia/work_indexer_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Sufia::WorkIndexer do
+  let(:user) { create(:user) }
+  let!(:generic_work) { create(:work_with_one_file, user: user, resource_type: ['abc123']) }
+  let(:service) { described_class.new(generic_work) }
+
+  subject { service.generate_solr_document }
+
+  it 'indexes FileSet ids separate from other members and resource type' do
+    expect(subject['file_set_ids_ssim']).to eq generic_work.member_ids
+    expect(subject['resource_type_sim']).to eq generic_work.resource_type
+  end
+end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+# This tests the FileSet model that is inserted into the host app by curation_concerns:models:install
+# It includes the CurationConcerns::FileSetBehavior module and Sufia::FileSetBehavior
+# So this test covers both the FileSetBehavior module and the generated FileSet model
+describe FileSet do
+  it 'has properties from characterization metadata' do
+    expect(subject).to respond_to(:duration)
+    expect(subject).to respond_to(:sample_rate)
+  end
+
+  describe '#indexer' do
+    subject { described_class.indexer }
+    it { is_expected.to eq Sufia::FileSetIndexer }
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -122,4 +122,28 @@ describe ::SolrDocument, type: :model do
     subject { document.width }
     it { is_expected.to eq '555' }
   end
+
+  describe "#page_count" do
+    let(:attributes) { { page_count_tesim: ['1'] } }
+    subject { document.page_count }
+    it { is_expected.to eq ['1'] }
+  end
+
+  describe "#file_title" do
+    let(:attributes) { { file_title_tesim: ['title'] } }
+    subject { document.file_title }
+    it { is_expected.to eq ['title'] }
+  end
+
+  describe "#duration" do
+    let(:attributes) { { duration_tesim: ['time'] } }
+    subject { document.duration }
+    it { is_expected.to eq ['time'] }
+  end
+
+  describe "#sample_rate" do
+    let(:attributes) { { sample_rate_tesim: ['rate'] } }
+    subject { document.sample_rate }
+    it { is_expected.to eq ['rate'] }
+  end
 end

--- a/spec/presenters/sufia/file_set_presenter_spec.rb
+++ b/spec/presenters/sufia/file_set_presenter_spec.rb
@@ -16,6 +16,11 @@ describe Sufia::FileSetPresenter do
   it { is_expected.to delegate_method(:date_created).to(:solr_document) }
   it { is_expected.to delegate_method(:date_modified).to(:solr_document) }
   it { is_expected.to delegate_method(:itemtype).to(:solr_document) }
+  it { is_expected.to delegate_method(:page_count).to(:solr_document) }
+  it { is_expected.to delegate_method(:file_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:duration).to(:solr_document) }
+  it { is_expected.to delegate_method(:sample_rate).to(:solr_document) }
+  it { is_expected.to delegate_method(:file_format).to(:solr_document) }
 
   describe '#tweeter' do
     subject { presenter.tweeter }
@@ -42,6 +47,19 @@ describe Sufia::FileSetPresenter do
     describe "#characterization_metadata" do
       subject { presenter.characterization_metadata }
       it { is_expected.to be_kind_of(Hash) }
+
+      it "only has set attributes are in the metadata" do
+        expect(subject[:height]).to be_blank
+        expect(subject[:page_count]).to be_blank
+      end
+
+      context "when height is set" do
+        let(:attributes) { { height_is: '444' } }
+        it "only has set attributes are in the metadata" do
+          expect(subject[:height]).not_to be_blank
+          expect(subject[:page_count]).to be_blank
+        end
+      end
     end
 
     describe "#characterized?" do
@@ -50,6 +68,11 @@ describe Sufia::FileSetPresenter do
 
       context "when height is set" do
         let(:attributes) { { height_is: '444' } }
+        it { is_expected.to be_characterized }
+      end
+
+      context "when file_format is set" do
+        let(:attributes) { { file_format_tesim: ['format'] } }
         it { is_expected.to be_characterized }
       end
     end

--- a/spec/services/sufia/file_set_csv_service_spec.rb
+++ b/spec/services/sufia/file_set_csv_service_spec.rb
@@ -6,7 +6,11 @@ describe Sufia::FileSetCSVService do
            width: '',
            format_label: '',
            digest: '',
-           mime_type: 'application/pdf')
+           mime_type: 'application/pdf',
+           page_count: '1',
+           file_title: 'My PDF',
+           duration: '',
+           sample_rate: '')
   end
   let(:file) do
     FileSet.new(id: '123abc', title: ['My Title'], creator: ['Von, Creator'],


### PR DESCRIPTION
Fixes #2431 

Adding characterization terms including file_format which should be on any characterized file to the presenter terms so that characterization gets displayed for all types of files after it is completed. 

Also included audio & PDF characterization terms into the indexer for file sets.

Changes proposed in this pull request:
* Additional Characterization terms for all file types 
* Only show characterization Terms that are populated  (see ticket for before after images)
* Indexer to include characterization terms for audio and PDF files
@projecthydra/sufia-code-reviewers

