### PR TITLE
Add test to make sure member_presenters gets the right class

### DIFF
--- a/spec/presenters/sufia/work_show_presenter_spec.rb
+++ b/spec/presenters/sufia/work_show_presenter_spec.rb
@@ -67,4 +67,14 @@ describe Sufia::WorkShowPresenter do
       it { is_expected.to be true }
     end
   end
+
+  describe "#member_presenters" do
+    let(:work) { create(:work_with_one_file) }
+    let(:ability) { double "Ability" }
+
+    it "returns appropriate classes for each" do
+      expect(presenter.member_presenters.size).to eq 1
+      expect(presenter.member_presenters.first).to be_instance_of(::Sufia::FileSetPresenter)
+    end
+  end
 end


### PR DESCRIPTION
Fails as below:

> .............F
>
> Failures:
> 
>   1) Sufia::WorkShowPresenter#member_presenters returns appropriate classes for each
>      Failure/Error: expect(presenter.member_presenters.size).to eq 1
>      
>      RSolr::Error::Http:
>        RSolr::Error::Http - 400 Bad Request
>        Error: 'org.apache.solr.search.SyntaxError: Cannot parse \'proxy_in_ssi:\': Encountered "<EOF>" at line 1, column 13.
>      
>        URI: http://127.0.0.1:8985/solr/hydra-test/select?wt=ruby&fl=ordered_targets_ssim&q=proxy_in_ssi%3A&qt=standard
>      
>        Backtrace: /usr/local/lib/ruby/gems/2.2.0/gems/rsolr-1.1.2/lib/rsolr/client.rb:288:in `adapt_response'
>        /usr/local/lib/ruby/gems/2.2.0/gems/rsolr-1.1.2/lib/rsolr/client.rb:189:in `execute'
>        /usr/local/lib/ruby/gems/2.2.0/gems/rsolr-1.1.2/lib/rsolr/client.rb:175:in `send_and_receive'
>        (eval):2:in `get'
>        /usr/local/lib/ruby/gems/2.2.0/gems/active-fedora-11.0.0.rc7/lib/active_fedora/solr_service.rb:41:in `get'
>        /usr/local/lib/ruby/gems/2.2.0/gems/active-fedora-11.0.0.rc7/lib/active_fedora/solr_service.rb:45:in `query'
>        /usr/local/lib/ruby/gems/2.2.0/gems/curation_concerns-1.4.0/app/presenters/curation_concerns/work_show_presenter.rb:123:in `ordered_ids'
>        /usr/local/lib/ruby/gems/2.2.0/gems/curation_concerns-1.4.0/app/presenters/curation_concerns/work_show_presenter.rb:70:in `member_presenters'
>        /home/ubuntu/src/sufia/spec/presenters/sufia/work_show_presenter_spec.rb:76:in `block (3 levels) in <top (required)>'
>        /usr/local/lib/ruby/gems/2.2.0/gems/rspec-core-3.5.2/lib/rspec/core/example.rb:254:in `instance_exec'
>        /usr/local/lib/ruby/gems/2.2.0/gems/rspec-core-3.5.2/lib/rspec/core/example.rb:254:in `block in run'
>      # (eval):2:in `get'
>      # ./spec/presenters/sufia/work_show_presenter_spec.rb:76:in `block (3 levels) in <top (required)>'
> 
> 