### PR TITLE
Additional Margin - Additional Fields Button

### DIFF
--- a/app/assets/stylesheets/sufia/_buttons.scss
+++ b/app/assets/stylesheets/sufia/_buttons.scss
@@ -28,3 +28,7 @@ span.appliedFilter .remove {
 .button_to-inline {
   display: inline-block;
 }
+
+.additional-fields {
+  margin-bottom: 1.5em;
+}

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -8,7 +8,7 @@
     </div>
     <%= link_to t('sufia.collection.edit.additional_fields'),
             '#extended-terms',
-            class: 'btn btn-default',
+            class: 'btn btn-default additional-fields',
             data: { toggle: 'collapse' },
             role: "button",
             'aria-expanded'=> "false",

--- a/app/views/curation_concerns/base/_form_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_metadata.html.erb
@@ -9,7 +9,7 @@
         </div>
         <%= link_to t('sufia.works.edit.additional_fields'),
                     '#extended-terms',
-                    class: 'btn btn-default',
+                    class: 'btn btn-default additional-fields',
                     data: { toggle: 'collapse' },
                     role: "button",
                     'aria-expanded'=> "false",


### PR DESCRIPTION
Fixes #2393 

Present tense short summary (50 characters or less)

Additional metadata fields hug the bottom of the "Additional Fields" button when clicked. Added an additional class for the metadata when creating/editing a Work. 

Changes proposed in this pull request:
* New class
* Use class
* Much margin

@projecthydra/sufia-code-reviewers

Fixes the bottom margin around the additional fields button to give the content under it more room.