### PR TITLE
Adding a download link to the no preview override

### DIFF
--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -1,3 +1,6 @@
 <div class="no-preview">
   <%= t('sufia.works.show.no_preview') %>
+  <% if CurationConcerns.config.display_media_download_link %>
+    <p/><%= link_to t('sufia.file_set.show.download'), main_app.download_path(file_set), target: "_new" %>
+  <% end %>
 </div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -278,6 +278,8 @@ en:
       notifications_deleted: "Notifications have been deleted"
     file_set:
       browse_view: "Browse View"
+      show:
+        download: "Download the file"
     work:
       browse_view: "Browse View"
     footer:

--- a/spec/views/curation_concerns/file_sets/media_display/_default.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/media_display/_default.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'curation_concerns/file_sets/mdeia_display/_default.html.erb', type: :view do
+  let(:file_set) { stub_model(FileSet) }
+  let(:config) { double }
+  let(:link) { true }
+
+  before do
+    allow(CurationConcerns.config).to receive(:display_media_download_link).and_return(link)
+    render 'curation_concerns/file_sets/media_display/default', file_set: file_set
+  end
+
+  it "draws the view with the link" do
+    expect(rendered).to have_css('div.no-preview')
+    expect(rendered).to have_css('a', text: 'Download the file')
+  end
+
+  context "no download links" do
+    let(:link) { false }
+
+    it "draws the view without the link" do
+      expect(rendered).to have_css('div.no-preview')
+      expect(rendered).not_to have_css('a', text: 'Download the file')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2478 

Adds a download link to the no preview override.

<img width="1353" alt="screen shot 2016-08-23 at 8 58 45 am" src="https://cloud.githubusercontent.com/assets/1599081/17892570/fe33a1ee-690f-11e6-952b-a886969b699a.png">

@projecthydra/sufia-code-reviewers

