### PR TITLE
Remove Linking from Collection Icon

### DIFF
--- a/app/assets/stylesheets/sufia/_collections.scss
+++ b/app/assets/stylesheets/sufia/_collections.scss
@@ -45,6 +45,7 @@ header {
 }
 
 .collection-icon-small {
+  padding-top: 0.2em;
   width: 1.5em;
 }
 

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,6 +1,4 @@
     <div class="col-sm-3">
-      <%= link_to document do %>
-          <span class="fa fa-cubes collection-icon-search"></span>
-      <% end %>
+      <span class="fa fa-cubes collection-icon-search"></span>
     </div>
 

--- a/app/views/collections/_media_display.html.erb
+++ b/app/views/collections/_media_display.html.erb
@@ -1,3 +1,1 @@
-<%= link_to presenter, target: '_new' do %>
-  <span class="fa fa-cubes collection-icon-search"></span>
-<% end %>
+<span class="fa fa-cubes collection-icon-search"></span>

--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -3,9 +3,7 @@
   <td></td>
   <td>
     <div class="media">
-      <%= link_to document, class: "pull-left", "aria-hidden" => true do %>
-          <span class="fa fa-cubes collection-icon-small"></span>
-      <% end %>
+      <span class="fa fa-cubes collection-icon-small pull-left"></span>
       <div class="media-body">
         <div class="media-heading">
           <%= link_to document, id: "src_copy_link#{id}" do %>

--- a/spec/views/catalog/_thumbnail_list_collection.html.erb_spec.rb
+++ b/spec/views/catalog/_thumbnail_list_collection.html.erb_spec.rb
@@ -1,0 +1,10 @@
+describe 'catalog/_thumbnail_list_collection.html.erb', type: :view do
+  before do
+    stub_template 'catalog/_thumbnail_list_collection.html.erb' => '<div class="col-sm-3"><span class="fa fa-cubes collection-icon-search"></span></div>'
+    render
+  end
+
+  it 'displays the collection icon in the search results' do
+    expect(rendered).to match '<div class="col-sm-3"><span class="fa fa-cubes collection-icon-search"></span></div>'
+  end
+end

--- a/spec/views/collections/show.html.erb_spec.rb
+++ b/spec/views/collections/show.html.erb_spec.rb
@@ -20,6 +20,7 @@ describe 'collections/show.html.erb', type: :view do
     stub_template 'collections/_sort_and_per_page.html.erb' => 'sort and per page'
     stub_template 'collections/_document_list.html.erb' => 'document list'
     stub_template 'collections/_paginate.html.erb' => 'paginate'
+    stub_template 'collections/_media_display.html.erb' => '<span class="fa fa-cubes collection-icon-search"></span>'
     render
   end
 
@@ -28,5 +29,6 @@ describe 'collections/show.html.erb', type: :view do
     expect(rendered).to have_link 'Edit'
     expect(rendered).to have_link 'Delete'
     expect(rendered).to have_link 'Add works'
+    expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
   end
 end

--- a/spec/views/my/_list_collections.html.erb_spec.rb
+++ b/spec/views/my/_list_collections.html.erb_spec.rb
@@ -33,5 +33,6 @@ describe 'my/_index_partials/_list_collections.html.erb', type: :view do
     expect(rendered).to have_link 'Delete Collection', href: collection_path(id)
     expect(rendered).to have_css 'a.visibility-link', text: 'Private'
     expect(rendered).to have_selector '.expanded-details dd', text: 'Collection Description'
+    expect(rendered).not_to include '<span class="fa fa-cubes collection-icon-small pull-left"></span></a>'
   end
 end


### PR DESCRIPTION
Fixes #2399 

Removes the link from around the collection icon since it is a default icon and not representative media, no longer duplicates the function of the linked Collection title, and no longer links to itself when on the show page


@projecthydra/sufia-code-reviewers

