### PR TITLE
Disabling the save button after the form submit 

### DIFF
--- a/app/assets/javascripts/sufia/save_work/save_work_control.es6
+++ b/app/assets/javascripts/sufia/save_work/save_work_control.es6
@@ -43,6 +43,17 @@ export class SaveWorkControl {
   }
 
   /**
+   * Keep the form from being submitted many times.
+   *
+   */
+  preventSubmitIfAlreadyInProgress() {
+    this.form.on('submit', (evt) => {
+      if (this.isValid())
+        this.saveButton.prop("disabled", true);
+    })
+  }
+
+  /**
    * Is the form for a new object (vs edit an exisiting object)
    */
   get isNew() {
@@ -68,6 +79,7 @@ export class SaveWorkControl {
     this.requiredFiles = new ChecklistItem(this.element.find('#required-files'))
     new VisibilityComponent(this.element.find('.visibility'))
     this.preventSubmitUnlessValid()
+    this.preventSubmitIfAlreadyInProgress()
     $('.multi_value.form-group', this.form).bind('managed_field:add', () => this.formChanged())
     $('.multi_value.form-group', this.form).bind('managed_field:remove', () => this.formChanged())
     this.formChanged()

--- a/spec/javascripts/save_work_spec.js
+++ b/spec/javascripts/save_work_spec.js
@@ -180,6 +180,15 @@ describe("SaveWorkControl", function() {
         $('#new_generic_work').submit();
         expect(spyEvent).not.toHaveBeenPrevented();
       });
+
+      it("disables save after submission", function() {
+        spyOn(target, 'isValid').and.returnValue(true);
+        expect(target.saveButton).toBeDisabled();
+        target.saveButton.prop("disabled", false);
+        expect(target.saveButton).not.toBeDisabled();
+        $('#new_generic_work').submit();
+        expect(target.saveButton).toBeDisabled();
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #2397
Disabling the save button after the form submit so the user can not create multiple works

If the save button is not disabled the user can double click, triple click, even click many more times and create multiple works from a single form
