### PR TITLE
Remove single-use link dropdown option, fixes #2463

### DIFF
--- a/app/views/curation_concerns/file_sets/_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_actions.html.erb
@@ -18,16 +18,8 @@
       <%= link_to 'Versions',  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
         { title: "Display previous versions" } %>
     </li>
-
-    <li role="menuitem" tabindex="-1">
-      <%= link_to t('sufia.single_use_links.button'), '#',
-                  class: "copypaste",
-                  title: "Single-Use Link to File",
-                  data: { generate_single_use_link_url: curation_concerns.generate_show_single_use_link_url(file_set.id) },
-                  id: "copy_link_#{file_set.id}" %>
-    </li>
-
   <% end %>
+
   <% if can?(:destroy, file_set.id) %>
     <li role="menuitem" tabindex="-1">
       <%= link_to 'Delete', polymorphic_path([main_app, file_set]),

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -15,7 +15,6 @@ en:
     view_profile:       "View Profile"
     edit_profile:       "Edit Profile"
     single_use_links:
-      button:  "Single-Use Link to File"
       expiration_message: "Link %{link} expires %{time}"
     directory:
       suffix:           "@example.org"

--- a/spec/views/collections/_show_document_list_menu.html.erb_spec.rb
+++ b/spec/views/collections/_show_document_list_menu.html.erb_spec.rb
@@ -10,7 +10,6 @@ describe 'collections/_show_document_list_menu.html.erb', type: :view do
     it "displays the action list in individual work drop down" do
       render('collections/show_document_list_menu.html.erb', document: document, current_user: user)
       expect(rendered).to have_content 'Select an action'
-      expect(rendered).not_to have_content 'Single-Use Link to File'
       expect(rendered).to have_content 'Edit'
       expect(rendered).not_to have_content 'Download File'
       expect(rendered).to have_content 'Highlight Work on Profile'


### PR DESCRIPTION
Fixes #2463 

Removes the option to create a single-use link via dropdown since management of links is now in the file set show page.

@projecthydra/sufia-code-reviewers

