### PR TITLE
Work Show – Location Label and Source Field

### DIFF
--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,5 +1,5 @@
 <%= presenter.attribute_to_html(:creator, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:contributor, label: 'Contributors', render_as: :faceted) %>
+<%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>
@@ -10,3 +10,4 @@
 <%= presenter.attribute_to_html(:based_near, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:related_url) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:source) %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -400,6 +400,8 @@ en:
     search:
       fields:
         show:
+          based_near: Location
+          contributor: Contributors
           keyword: Keyword
 
 

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -2,7 +2,7 @@ describe "display a work as its owner" do
   let(:work_path) { "/concern/generic_works/#{work.id}" }
 
   context "as the work owner" do
-    let(:work) { create(:work_with_one_file, title: ["Magnificent splendor"], user: user) }
+    let(:work) { create(:work_with_one_file, title: ["Magnificent splendor"], source: ["The Internet"], based_near: ["USA"], user: user) }
     let(:user) { create(:user) }
     before do
       sign_in user
@@ -11,6 +11,9 @@ describe "display a work as its owner" do
 
     it "shows a work" do
       expect(page).to have_selector 'h1', text: 'Magnificent splendor'
+      expect(page).to have_selector 'li', text: 'The Internet'
+      expect(page).to have_selector 'th', text: 'Location'
+      expect(page).not_to have_selector 'th', text: 'Based near'
 
       # Displays FileSets already attached to this work
       within '.related-files' do
@@ -20,13 +23,16 @@ describe "display a work as its owner" do
   end
 
   context "as a user who is not logged in" do
-    let(:work) { create(:public_generic_work, title: ["Magnificent splendor"]) }
+    let(:work) { create(:public_generic_work, title: ["Magnificent splendor"], source: ["The Internet"], based_near: ["USA"]) }
     before do
       visit work_path
     end
 
     it "shows a work" do
       expect(page).to have_selector 'h1', text: 'Magnificent splendor'
+      expect(page).to have_selector 'li', text: 'The Internet'
+      expect(page).to have_selector 'th', text: 'Location'
+      expect(page).not_to have_selector 'th', text: 'Based near'
 
       # Doesn't have the upload form for uploading more files
       expect(page).not_to have_selector "form#fileupload"


### PR DESCRIPTION
Fixes #2401, #2403 

Updates based near to use label "Location" on the work show page.

@projecthydra/sufia-code-reviewers

![screen shot 2016-08-25 at 3 34 41 pm](https://cloud.githubusercontent.com/assets/4163828/17983340/181268b8-6ada-11e6-8e0b-d52669a22b52.png)

