### PR TITLE
Import positioning css from CurationConcerns, fixes #2532

### DIFF
--- a/app/assets/stylesheets/sufia/_sufia.scss
+++ b/app/assets/stylesheets/sufia/_sufia.scss
@@ -1,6 +1,7 @@
 @import 'hydra-editor/multi_value_fields';
 @import 'curation_concerns/modules/forms';
 @import 'curation_concerns/modules/file_manager';
+@import "curation_concerns/positioning";
 @import 'sufia/file_sets';
 @import 'sufia/settings', 'sufia/header', 'sufia/styles', 'sufia/file-listing',
         'sufia/browse_everything_overrides', 'sufia/nestable',


### PR DESCRIPTION
Fixes #2532 

Imports the positioning css file from CurationConcerns to add the missing css class.

ping @mtribone to see if this is an acceptable fix.

@projecthydra/sufia-code-reviewers

