### PR TITLE
Display the admin page

### DIFF
--- a/app/models/concerns/sufia/ability.rb
+++ b/app/models/concerns/sufia/ability.rb
@@ -41,6 +41,7 @@ module Sufia
       can :read, ContentBlock
       return unless admin?
 
+      can :read, :admin_dashboard
       can :create, TinymceAsset
       can [:create, :update], ContentBlock
       can :edit, ::SolrDocument

--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? %>
   <ul class="nav navbar-nav">
-    <%= render '/admin/menu' if can? :manage, :all %>
+    <%= render '/admin/menu' if can? :read, :admin_dashboard %>
     <li class="dropdown">
       <%= link_to sufia.dashboard_index_path, role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
         <span class="fa fa-tachometer"></span> <%= t("sufia.toolbar.dashboard.menu") %> <span class="caret"></span>

--- a/spec/models/sufia/ability_spec.rb
+++ b/spec/models/sufia/ability_spec.rb
@@ -23,6 +23,7 @@ describe Sufia::Ability, type: :model do
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
     it { is_expected.to be_able_to(:read, ContentBlock) }
     it { is_expected.not_to be_able_to(:read, Sufia::Statistics) }
+    it { is_expected.not_to be_able_to(:read, :admin_dashboard) }
   end
 
   describe "a user in the admin group" do
@@ -34,6 +35,7 @@ describe Sufia::Ability, type: :model do
     it { is_expected.to be_able_to(:update, ContentBlock) }
     it { is_expected.to be_able_to(:read, ContentBlock) }
     it { is_expected.to be_able_to(:read, Sufia::Statistics) }
+    it { is_expected.to be_able_to(:read, :admin_dashboard) }
   end
 
   describe "proxies and transfers" do

--- a/spec/views/_toolbar.html.erb_spec.rb
+++ b/spec/views/_toolbar.html.erb_spec.rb
@@ -21,7 +21,7 @@ describe '/_toolbar.html.erb', type: :view do
 
   context 'with an admin user' do
     before do
-      allow(view).to receive(:can?).with(:manage, :all).and_return(true)
+      allow(view).to receive(:can?).with(:read, :admin_dashboard).and_return(true)
     end
 
     it 'shows the admin menu' do


### PR DESCRIPTION
The `:manage, :all` ability was removed in
https://github.com/projecthydra/curation_concerns/commit/f81fee5ea8dfe47890316fbee72af8a4c481e059 so the link to the admin page wasn't showing.

This grants a more explicit permission for viewing the admin page.