### PR TITLE
showing works instead of files in user index view

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -61,12 +61,6 @@ module Sufia
       !params[:cq].blank?
     end
 
-    def number_of_deposits(user)
-      ActiveFedora::Base.where(DepositSearchBuilder.depositor_field => user.user_key).count
-    rescue RSolr::Error::ConnectionRefused
-      'n/a'
-    end
-
     # @param item [Object]
     # @param field [String]
     # @return [ActiveSupport::SafeBuffer] the html_safe link

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,19 +2,19 @@
   <%= render partial: 'search_form' %>
   <h1><%= application_name %> Users</h1>
 </div>
-<table class="table table-striped"> 
-    <thead> 
-        <tr> 
-            <th>Avatar</th> 
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Avatar</th>
             <th class="sorts"><i id="name" class="<%=params[:sort].blank? ? 'caret up' : params[:sort]== "name desc" ? 'caret' : params[:sort]== "name" ? 'caret up' : ''%>"></i> User Name</th>
             <th class="sorts"><i id="login" class="<%=params[:sort]== "login desc" ? 'caret' : params[:sort]== "login" ? 'caret up' : ''%>"></i> User Id</th>
             <th class="sorts"><i id="department" class="<%=params[:sort]== "department desc" ? 'caret' : params[:sort]== "department" ? 'caret up' : ''%>"></i> Department</th>
-            <th>Files Deposited</th> 
-        </tr> 
-    </thead> 
-    <tbody> 
-        <% @users.each do |user| %> 
-            <tr> 
+            <th>Works Created</th>
+        </tr>
+    </thead>
+    <tbody>
+        <% @users.each do |user| %>
+            <tr>
               <td><%= link_to sufia.profile_path(user) do %>
                     <%= image_tag(user.avatar.url(:thumb), width: 30) if user.avatar.file %>
                   <% end %>
@@ -22,11 +22,11 @@
                <td><%= link_to user.name, sufia.profile_path(user) %></td>
                <td><%= link_to user.user_key, sufia.profile_path(user) %></td>
                <td><%= user.department %></td>
-               <td><%= number_of_deposits(user) %></td>
-            </tr> 
-         <% end %> 
-    </tbody> 
-</table> 
+               <td><%= number_of_works(user) %></td>
+            </tr>
+         <% end %>
+    </tbody>
+</table>
 <div class="pager">
   <%= paginate @users, theme: 'blacklight', route_set: sufia %>
 </div>

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -183,32 +183,6 @@ describe SufiaHelper, type: :helper do
     it { is_expected.to respond_to(:zotero_label) }
   end
 
-  describe "#number_of_deposits" do
-    let(:conn) { ActiveFedora::SolrService.instance.conn }
-    let(:user1) { User.new(email: "abc@test") }
-    let(:user2) { User.new(email: "abc@test.123") }
-    before do
-      create_models("Collection", user1, user2)
-    end
-
-    it "finds only 3 files" do
-      expect(helper.number_of_deposits(user1)).to eq(3)
-    end
-
-    def create_models(model, user1, user2)
-      # deposited by the first user
-      3.times do |t|
-        conn.add id: "199#{t}", Solrizer.solr_name('depositor', :stored_searchable) => user1.user_key, "has_model_ssim" => [model],
-                 Solrizer.solr_name('depositor', :symbol) => user1.user_key
-      end
-
-      # deposited by the second user, but editable by the first
-      conn.add id: "1994", Solrizer.solr_name('depositor', :stored_searchable) => user2.user_key, "has_model_ssim" => [model],
-               Solrizer.solr_name('depositor', :symbol) => user2.user_key, "edit_access_person_ssim" => user1.user_key
-      conn.commit
-    end
-  end
-
   describe "#iconify_auto_link" do
     let(:text)              { 'Foo < http://www.example.com. & More text' }
     let(:linked_text)       { 'Foo &lt; <a href="http://www.example.com"><span class="glyphicon glyphicon-new-window"></span> http://www.example.com</a>. &amp; More text' }

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -17,6 +17,7 @@ describe 'users/index.html.erb', type: :view do
     render
     page = Capybara::Node::Simple.new(rendered)
     expect(page).to have_content("Sufia Users")
+    expect(page).to have_content("Works Created")
     (1..10).each do |i|
       expect(page).to have_content("user#{i}")
     end


### PR DESCRIPTION
fixes #2453.

Shows User's works instead of uploaded files.


Uses number_of_works helper method instead of number_of_deposits.

@projecthydra/sufia-code-reviewers

