### PR TITLE
Fix the fedora warning about path containing an empty element

### DIFF
--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -113,7 +113,7 @@ describe API::ItemsController, type: :controller do
 
     context 'post with a valid item and matching token' do
       let(:deposited_file) { FileSet.where(label: item_hash['file']['filename']).take }
-      let(:a_work) { build :generic_work, id: '123' }
+      let(:a_work) { build :generic_work, id: '123abcdef' }
       let!(:token) { user.arkivo_token }
       let(:item) { FactoryGirl.json(:post_item, token: token) }
       let(:item_hash) { JSON.parse(item) }
@@ -170,7 +170,7 @@ describe API::ItemsController, type: :controller do
   context 'with an HTTP PUT' do
     let(:put_item) { FactoryGirl.json(:put_item, token: token) }
     let(:token) { user.arkivo_token }
-    let(:gw) { build :generic_work, id: '123' }
+    let(:gw) { build :generic_work, id: '123abcdef' }
     let(:relation) { double }
 
     before do
@@ -293,7 +293,7 @@ describe API::ItemsController, type: :controller do
     let(:token) { user.arkivo_token }
     let(:item) { FactoryGirl.json(:post_item, token: token) }
     let(:item_hash) { JSON.parse(item) }
-    let(:gw) { build :generic_work, id: '123' }
+    let(:gw) { build :generic_work, id: '123abcdef' }
     let(:relation) { double }
 
     before do


### PR DESCRIPTION
before merging, check the travis output, we don't want to see any instances of `InvalidResourceIdentifierExceptionMapper`