### PR TITLE
Restore translation for single-use-link button

### DIFF
--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -15,6 +15,7 @@ en:
     view_profile:       "View Profile"
     edit_profile:       "Edit Profile"
     single_use_links:
+      button: "Single-Use Link to File"
       expiration_message: "Link %{link} expires %{time}"
     directory:
       suffix:           "@example.org"

--- a/spec/views/curation_concerns/file_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/_show_actions.html.erb_spec.rb
@@ -20,8 +20,8 @@ describe 'curation_concerns/file_sets/_show_actions.html.erb', type: :view do
   let(:presenter) do
     Sufia::WorkShowPresenter.new(solr_document, ability)
   end
+  let(:page) { Capybara::Node::Simple.new(rendered) }
   describe 'citations' do
-    let(:page) { Capybara::Node::Simple.new(rendered) }
     before do
       Sufia.config.citations = citations
       allow(controller).to receive(:can?).with(:edit, presenter).and_return(false)
@@ -44,6 +44,21 @@ describe 'curation_concerns/file_sets/_show_actions.html.erb', type: :view do
       it 'does not appear on page' do
         expect(page).to have_no_selector('a#citations')
       end
+    end
+  end
+
+  describe 'editor' do
+    before do
+      allow(presenter).to receive(:editor?).and_return(true)
+      assign(:presenter, presenter)
+      view.lookup_context.view_paths.push 'app/views/curation_concerns/base'
+      render
+    end
+
+    it 'renders actions for the user' do
+      expect(page).to have_link("Edit This File")
+      expect(page).to have_link("Delete This File")
+      expect(page).to have_link("Single-Use Link to File")
     end
   end
 end


### PR DESCRIPTION
Translation was inadvertently removed in 32f711c563c30d684798ae95e1de4d0a85e86c33

@projecthydra/sufia-code-reviewers

