### PR TITLE
Remove edit option from collection menu if not available to user.

### DIFF
--- a/app/views/collections/_show_document_list_menu.html.erb
+++ b/app/views/collections/_show_document_list_menu.html.erb
@@ -1,16 +1,18 @@
 <div class="btn-group">
-  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">Select an action <span class="caret"></span>
+  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">Select an action<span class="caret"></span>
   </button>
   <ul class="dropdown-menu dropdown-menu-right">
-    <li>
-      <%= link_to [:edit, document],
-                  class: "itemicon itemedit",
-                  title: t('sufia.collection.document_list.edit'),
-                  id: "edit_work_link_#{document.id}" do %>
-        <i class='glyphicon glyphicon-pencil'></i> <%= t('sufia.collection.document_list.edit') %>
-      <% end %>
-    </li>
     <% if current_user %>
+      <% if can? :edit, document %>
+      <li>
+        <%= link_to [:edit, document],
+                    class: "itemicon itemedit",
+                    title: t('sufia.collection.document_list.edit'),
+                    id: "edit_work_link_#{document.id}" do %>
+          <i class='glyphicon glyphicon-pencil'></i> <%= t('sufia.collection.document_list.edit') %>
+        <% end %>
+      </li>
+      <% end %>
       <li>
         <%= display_trophy_link(current_user, document.id) do |text| %>
           <i class='glyphicon glyphicon-star'></i> <%= text %>

--- a/spec/views/collections/_show_document_list_menu.html.erb_spec.rb
+++ b/spec/views/collections/_show_document_list_menu.html.erb_spec.rb
@@ -1,18 +1,38 @@
 
 describe 'collections/_show_document_list_menu.html.erb', type: :view do
-  context 'when user logged in displaying the collections of current user' do
+  context 'when user is viewing a collection' do
     let(:user) { create :user }
+    let(:ability) { instance_double("Ability") }
     let(:document) { SolrDocument.new(id: '1234') }
     before do
       allow(document).to receive(:to_model).and_return(stub_model(GenericWork))
+      allow(controller).to receive(:current_ability).and_return(ability)
     end
 
-    it "displays the action list in individual work drop down" do
+    it "displays the action list in a drop down for an individual work user can edit" do
+      allow(ability).to receive(:can?).with(:edit, document).and_return(true)
       render('collections/show_document_list_menu.html.erb', document: document, current_user: user)
       expect(rendered).to have_content 'Select an action'
       expect(rendered).to have_content 'Edit'
       expect(rendered).not_to have_content 'Download File'
       expect(rendered).to have_content 'Highlight Work on Profile'
+    end
+
+    it "displays the action list in a drop down for individual work user can not edit" do
+      allow(ability).to receive(:can?).with(:edit, document).and_return(false)
+      render('collections/show_document_list_menu.html.erb', document: document, current_user: user)
+      expect(rendered).to have_content 'Select an action'
+      expect(rendered).not_to have_content 'Edit'
+      expect(rendered).not_to have_content 'Download File'
+      expect(rendered).to have_content 'Highlight Work on Profile'
+    end
+
+    it "displays the action list in a drop down for individual work without being logged in" do
+      render('collections/show_document_list_menu.html.erb', document: document, current_user: false)
+      expect(rendered).to have_content 'Select an action'
+      expect(rendered).not_to have_content 'Edit'
+      expect(rendered).not_to have_content 'Download File'
+      expect(rendered).not_to have_content 'Highlight Work on Profile'
     end
   end
 end


### PR DESCRIPTION
Fixes #2400 

Removes edit option when unavailable.

This should remove the edit option when a user clicks on the "Select an Action" for an individual work being viewed from a collection page if that user does not have edit rights to the work.

@projecthydra/sufia-code-reviewers
