### PR TITLE
Re-add tab icons for creating works

### DIFF
--- a/app/assets/stylesheets/sufia/_collections.scss
+++ b/app/assets/stylesheets/sufia/_collections.scss
@@ -82,3 +82,19 @@ form.per_page {
 .presenter-title {
   padding-left: 20px;
 }
+
+.icon-metadata {
+  @extend .fa-tags;
+}
+
+.icon-files {
+  @extend .fa-files-o;
+}
+
+.icon-relationships {
+  @extend .fa-link;
+}
+
+.icon-share {
+  @extend .fa-key;
+}

--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -12,7 +12,7 @@
           <li role="presentation">
         <% end %>
             <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
-              <%= t("sufia.works.edit.tab.#{tab}") %>
+              <i class="fa icon-<%= tab %>"></i> <%= t("sufia.works.edit.tab.#{tab}") %>
             </a>
           </li>
       <% end %>


### PR DESCRIPTION
In #2449, we said to remove the tab icons from the `FileSet` form, but it makes more sense to me to re-add icons to the work form. Was there was a compelling reason we removed them in the first place? 

![screen shot 2016-08-29 at 10 48 47 am](https://cloud.githubusercontent.com/assets/111218/18061291/11b2fe2e-6dd7-11e6-8592-cbcf8026b6d5.png)


Fixes #2449.
