### PR TITLE
Fix the has_link assertion

### DIFF
--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -33,22 +33,22 @@ RSpec.describe "dashboard/index.html.erb", type: :view do
     let(:heading) { view.content_for(:page_header) }
 
     it "displays welcome message and links" do
-      expect(heading).to have_link("Create Work", new_curation_concerns_generic_work_path)
-      expect(heading).to have_link("Create Collection", new_collection_path)
-      expect(heading).to have_link("View Works", sufia.dashboard_works_path)
+      expect(heading).to have_link("Create Work", href: new_curation_concerns_generic_work_path)
+      expect(heading).to have_link("Create Collection", href: new_collection_path)
+      expect(heading).to have_link("View Works", href: sufia.dashboard_works_path)
       expect(heading).to include "My Dashboard"
     end
 
     context "when the user can't create works" do
       let(:can_create_work) { false }
       it "does not display the create work button" do
-        expect(heading).not_to have_link("Create Work", new_curation_concerns_generic_work_path)
+        expect(heading).not_to have_link("Create Work", href: new_curation_concerns_generic_work_path)
       end
     end
     context "when the user can't create collections" do
       let(:can_create_collection) { false }
       it "does not display the create collection button" do
-        expect(heading).not_to have_link("Create Collection", new_collection_path)
+        expect(heading).not_to have_link("Create Collection", href: new_collection_path)
       end
     end
   end


### PR DESCRIPTION

@projecthydra/sufia-code-reviewers

This avoids errors like:
`Unused parameters passed to Capybara::Queries::SelectorQuery :
["/collections/new"]`