### PR TITLE
Add ability to set visibility for collections

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  enabled: false

--- a/app/controllers/concerns/sufia/collections_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/collections_controller_behavior.rb
@@ -17,6 +17,7 @@ module Sufia
 
     def new
       super
+      @collection.visibility = 'open' # default to open access
       form
     end
 
@@ -56,10 +57,23 @@ module Sufia
 
       def collection_params
         form_class.model_attributes(
-          params.require(:collection).permit(:title, :description, :members, part_of: [],
-                                                                             contributor: [], creator: [], publisher: [], date_created: [], subject: [],
-                                                                             language: [], rights: [], resource_type: [], identifier: [], based_near: [],
-                                                                             tag: [], related_url: [])
+          params.require(:collection).permit(
+            :title,
+            :description,
+            :members,
+            part_of: [],
+            contributor: [],
+            creator: [],
+            publisher: [],
+            date_created: [],
+            subject: [],
+            language: [],
+            rights: [],
+            resource_type: [],
+            identifier: [],
+            ßbased_near: [],
+            tag: [],
+            related_url: []).merge(params.permit(:visibility))
         )
       end
 

--- a/app/forms/sufia/forms/collection_edit_form.rb
+++ b/app/forms/sufia/forms/collection_edit_form.rb
@@ -4,7 +4,12 @@ module Sufia
       include HydraEditor::Form
       self.model_class = ::Collection
       self.terms = [:resource_type, :title, :creator, :contributor, :description, :tag, :rights,
-                    :publisher, :date_created, :subject, :language, :identifier, :based_near, :related_url]
+                    :publisher, :date_created, :subject, :language, :identifier, :based_near, :related_url, :visibility]
+
+      # Remove visibility from the set of rendered terms
+      def rendered_terms
+        terms - [:visibility]
+      end
 
       # Test to see if the given field is required
       # @param [Symbol] key a field

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+module CollectionHelper
+  def render_collection_visibility_badge
+    if can? :edit, @collection
+      render_collection_visibility_link(@collection)
+    else
+      render_visibility_label(@collection)
+    end
+  end
+
+  def render_collection_visibility_link(collection)
+    link_to render_visibility_label(collection), collections.edit_collection_path(collection, anchor: "permissions_display"),
+            id: "permission_" + collection.id, class: "visibility-link"
+  end
+end

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -2,7 +2,7 @@
   <div id="descriptions_display">
     <h2 class="non lower">Descriptions <small class="pull-right"><span class="error">*</span> indicates required fields</small> </h2>
     <div class="well">
-      <% f.object.terms.each do |term| %>
+      <% f.object.rendered_terms.each do |term| %>
         <%= render_edit_field_partial term, f: f %>
       <% end %>
     </div><!-- /well -->
@@ -13,6 +13,10 @@
       <input type="hidden" name="batch_document_ids[]" value="<%= batch_item %>"/>
     <% end %>
   <% end %>
+
+  <div class="collection_form_visibility">
+    <%= render 'permission_form', f: f.object %>
+  </div>
 
   <div class="primary-actions">
     <% if params[:action] == "new" %>

--- a/app/views/collections/_permission_form.html.erb
+++ b/app/views/collections/_permission_form.html.erb
@@ -1,0 +1,29 @@
+<% depositor = f.model.depositor || current_user %>
+
+<div class="alert alert-info hidden" id="save_perm_note">Permissions are <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
+<div class="alert alert-warning hidden" id="permissions_error">
+  <a class="close" data-dismiss="alert" href="#">
+    <span class="sr-only">Close this alert</span>
+    <span aria-hidden="true">×</span>
+  </a>
+<span id="permissions_error_text"></span></div>
+
+<div class="well">
+
+  <h3>Visibility - <small>who should have the ability to read and download</small>
+    <span id="visibility_tooltip" class="h5"><%= visibility_help %></span>
+  </h3>
+  <div class="radio">
+    <label>
+      <input type="radio" id="visibility_open" name="visibility" value="<%=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if f.model.public? %> checked="true"<% end %>/> <span class="label label-success">Open Access</span> Visible to the world.
+    </label>
+    <label>
+      <input type="radio" id="visibility_psu" name="visibility" value="<%=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if f.model.registered? %> checked="true"<% end %> /><span class="label label-info"><%=t('sufia.institution_name') %></span> Visible to all <%=t('sufia.institution_name') %> users.
+    </label>
+    <label>
+      <input type="radio" id="visibility_restricted" name="visibility" value="<%=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>"<% if f.model.private? %> checked="true"<% end %> /> <span class="label label-danger">Private</span> Visible to users/groups specified below, if any.
+    </label>
+  </div>
+
+</div><!-- /.well -->
+

--- a/app/views/collections/_show_document_list_row.html.erb
+++ b/app/views/collections/_show_document_list_row.html.erb
@@ -25,7 +25,7 @@
   </td>
   <td class="text-center"><%= document.date_uploaded %> </td>
   <td class="text-center">
-    <%= render_visibility_link(document) %>
+    <%= render_collection_visibility_link(document) %>
   </td>
   <td class="text-center">
     <%= render partial: 'show_document_list_menu', locals: { id: id, gf: gf } %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -5,7 +5,7 @@
   <div itemscope itemtype="http://schema.org/CollectionPage" class="row">
     <div class="col-sm-10 pull-right">
       <header>
-        <h1><%= @presenter.title %></h1>
+        <h1 class="visibility"><%= @presenter.title %> <%= render_collection_visibility_badge %></h1>
         <p class="collection_description"><%= @presenter.description %></p>
       </header>
       <% unless has_collection_search_parameters? %>

--- a/spec/factories/collection_factory.rb
+++ b/spec/factories/collection_factory.rb
@@ -1,0 +1,28 @@
+FactoryGirl.define do
+  factory :collection do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+    sequence(:title) { |n| ["Title #{n}"] }
+    before(:create) { |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    }
+
+    factory :public_collection do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :private_collection do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+
+    factory :institution_collection do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    end
+
+    factory :named_collection do
+      title ['collection title']
+      description ['collection description']
+    end
+  end
+end

--- a/spec/forms/collection_edit_form_spec.rb
+++ b/spec/forms/collection_edit_form_spec.rb
@@ -8,7 +8,7 @@ describe Sufia::Forms::CollectionEditForm do
     subject { form.terms }
     it { is_expected.to eq [:resource_type, :title, :creator, :contributor, :description,
                             :tag, :rights, :publisher, :date_created, :subject, :language,
-                            :identifier, :based_near, :related_url] }
+                            :identifier, :based_near, :related_url, :visibility] }
   end
 
   describe "multiple?" do

--- a/spec/lib/sufia/export/collection_converter_spec.rb
+++ b/spec/lib/sufia/export/collection_converter_spec.rb
@@ -1,22 +1,20 @@
 require 'spec_helper'
 
 describe Sufia::Export::CollectionConverter do
-  let(:collection) do
-    Collection.create(title: "title1", creator: ["creator1"], description: "description1") do |col|
-      col.apply_depositor_metadata("jilluser")
-    end
-  end
+  let(:user1) { FactoryGirl.build(:jill) }
+  let(:collection) { create(:public_collection, title: "title1", creator: ["creator1"], description: "description1", user: user1) }
   let(:permission) { collection.permissions.first }
   let(:permission2) { collection.permissions.last }
-  let(:json) { "{\"id\":\"#{collection.id}\",\"title\":\"title1\",\"description\":\"description1\",\"creator\":[\"creator1\"],\"members\":[],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#jilluser\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{collection.id}\"},{\"id\":\"#{permission2.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#public\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{collection.id}\"}]}" }
+  let(:json) { "{\"id\":\"#{collection.id}\",\"title\":\"title1\",\"description\":\"description1\",\"creator\":[\"creator1\"],\"members\":[],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#public\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{collection.id}\"},{\"id\":\"#{permission2.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#jilluser@example.com\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{collection.id}\"}]}" }
+
   describe "to_json" do
     subject { described_class.new(collection).to_json }
-    it { is_expected.to eq json }
+    it { is_expected.to eq(json) }
 
     context "pretty to_json" do
       subject { described_class.new(collection).to_json(pretty: true) }
-      let(:json) { "{\n  \"id\": \"#{collection.id}\",\n  \"title\": \"title1\",\n  \"description\": \"description1\",\n  \"creator\": [\n    \"creator1\"\n  ],\n  \"members\": [\n\n  ],\n  \"permissions\": [\n    {\n      \"id\": \"#{permission.id}\",\n      \"agent\": \"http://projecthydra.org/ns/auth/person#jilluser\",\n      \"mode\": \"http://www.w3.org/ns/auth/acl#Write\",\n      \"access_to\": \"#{collection.id}\"\n    },\n    {\n      \"id\": \"#{permission2.id}\",\n      \"agent\": \"http://projecthydra.org/ns/auth/group#public\",\n      \"mode\": \"http://www.w3.org/ns/auth/acl#Read\",\n      \"access_to\": \"#{collection.id}\"\n    }\n  ]\n}" }
-      it { is_expected.to eq json }
+      let(:json) { "{\n  \"id\": \"#{collection.id}\",\n  \"title\": \"title1\",\n  \"description\": \"description1\",\n  \"creator\": [\n    \"creator1\"\n  ],\n  \"members\": [\n\n  ],\n  \"permissions\": [\n    {\n      \"id\": \"#{permission.id}\",\n      \"agent\": \"http://projecthydra.org/ns/auth/group#public\",\n      \"mode\": \"http://www.w3.org/ns/auth/acl#Read\",\n      \"access_to\": \"#{collection.id}\"\n    },\n    {\n      \"id\": \"#{permission2.id}\",\n      \"agent\": \"http://projecthydra.org/ns/auth/person#jilluser@example.com\",\n      \"mode\": \"http://www.w3.org/ns/auth/acl#Write\",\n      \"access_to\": \"#{collection.id}\"\n    }\n  ]\n}" }
+      it { is_expected.to eq(json) }
     end
 
     context "with members" do
@@ -25,8 +23,8 @@ describe Sufia::Export::CollectionConverter do
       before do
         collection.members = [file1, file2]
       end
-      let(:json) { "{\"id\":\"#{collection.id}\",\"title\":\"title1\",\"description\":\"description1\",\"creator\":[\"creator1\"],\"members\":[\"#{file1.id}\",\"#{file2.id}\"],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#jilluser\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{collection.id}\"},{\"id\":\"#{permission2.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#public\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{collection.id}\"}]}" }
-      it { is_expected.to eq json }
+      let(:json) { "{\"id\":\"#{collection.id}\",\"title\":\"title1\",\"description\":\"description1\",\"creator\":[\"creator1\"],\"members\":[\"#{file1.id}\",\"#{file2.id}\"],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#public\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{collection.id}\"},{\"id\":\"#{permission2.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#jilluser@example.com\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{collection.id}\"}]}" }
+      it { is_expected.to eq(json) }
     end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,25 +1,28 @@
 require 'spec_helper'
 
 describe Collection, type: :model do
-  before do
-    @user = FactoryGirl.create(:user)
-    @collection = described_class.new(id: 'mock-collection-with-members', title: "test collection") do |c|
-      c.apply_depositor_metadata(@user.user_key)
-    end
+  let(:user1) { FactoryGirl.create(:user) }
+  let(:public_collection) { create(:public_collection, title: "public collection", creator: ["creator1"], user: user1) }
+  let(:private_collection) { create(:private_collection, title: "private collection", creator: ["creator1"], user: user1) }
+
+  it "has open visibility for public collection" do
+    public_collection.save
+    expect(public_collection.read_groups).to eq ['public']
   end
 
-  it "has open visibility" do
-    @collection.save
-    expect(@collection.read_groups).to eq ['public']
+  it "has no read visibility for private collection" do
+    private_collection.save
+    expect(private_collection.read_groups).to eq []
   end
 
   it "does not allow a collection to be saved without a title" do
-    @collection.title = nil
-    expect { @collection.save! }.to raise_error(ActiveFedora::RecordInvalid)
+    public_collection.title = nil
+    expect { public_collection.save! }.to raise_error(ActiveFedora::RecordInvalid)
   end
 
   describe "::bytes" do
-    subject { @collection.bytes }
+    let(:unsaved_collection) { create(:public_collection, title: "unsaved collection", creator: ["creator1"], user: user1) }
+    subject { unsaved_collection.bytes }
     context "with no items" do
       it "gets zero without querying solr" do
         expect(ActiveFedora::SolrService).not_to receive(:query)
@@ -37,24 +40,27 @@ describe Collection, type: :model do
       end
       let(:query) { ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::GenericFile.to_class_uri) }
       let(:args) do
-        { fq: "{!join from=hasCollectionMember_ssim to=id}id:#{@collection.id}",
+        { fq: "{!join from=hasCollectionMember_ssim to=id}id:#{unsaved_collection.id}",
           fl: "id, file_size_is",
           rows: 3 }
       end
 
       before do
-        allow(@collection).to receive(:members).and_return([file, file, file])
+        allow(unsaved_collection).to receive(:members).and_return([file, file, file])
         allow(ActiveFedora::SolrService).to receive(:query).with(query, args).and_return(documents)
       end
 
       context "when saved" do
         before do
-          allow(@collection).to receive(:new_record?).and_return(false)
+          allow(unsaved_collection).to receive(:new_record?).and_return(false)
         end
         it { is_expected.to eq 99 }
       end
 
       context "when not saved" do
+        before do
+          allow(unsaved_collection).to receive(:new_record?).and_return(true)
+        end
         it "raises an error" do
           expect { subject }.to raise_error "Collection must be saved to query for bytes"
         end

--- a/spec/views/collections/_form.html.erb_spec.rb
+++ b/spec/views/collections/_form.html.erb_spec.rb
@@ -1,14 +1,12 @@
 require 'spec_helper'
 
 describe 'collections/_form.html.erb' do
-  let(:collection) do
-    Collection.new(title: 'the title', description: 'the description',
-                   creator: ['the creator'])
-  end
-
+  let(:user1) { FactoryGirl.create(:user) }
+  let(:collection) { create(:public_collection, title: "the title", creator: ["the creator"], description: "the description", user: user1) }
   let(:collection_form) { Sufia::Forms::CollectionEditForm.new(collection) }
 
   before do
+    allow(controller).to receive(:current_user).and_return(user1)
     controller.request.path_parameters[:id] = 'j12345'
     assign(:form, collection_form)
   end
@@ -30,5 +28,8 @@ describe 'collections/_form.html.erb' do
     expect(rendered).to have_selector("input#collection_related_url")
     expect(rendered).to have_selector("select#collection_rights")
     expect(rendered).to have_selector("select#collection_resource_type")
+    expect(rendered).to have_selector("input#visibility_open")
+    expect(rendered).to have_selector("input#visibility_psu")
+    expect(rendered).to have_selector("input#visibility_restricted")
   end
 end

--- a/sufia-models/app/models/concerns/sufia/collection_behavior.rb
+++ b/sufia-models/app/models/concerns/sufia/collection_behavior.rb
@@ -7,12 +7,7 @@ module Sufia
     include Sufia::GenericFile::Permissions
 
     included do
-      before_save :update_permissions
       validates :title, presence: true
-    end
-
-    def update_permissions
-      self.visibility = "open"
     end
 
     # Compute the sum of each file in the collection using Solr to


### PR DESCRIPTION
Fixes #2605 ; refs #1974, PR #1975

Backport collection visibility from Sufia 7 to Sufia 6.x. Allows users to set visibility to Open, Institutional, or Private. Open collections are discoverable and viewable by all users.

Changes proposed in this pull request:

    Collection - new view - includes a partial form at the bottom that allows user to set visibility
    Collection - edit view - includes a partial form at the bottom that allows user to set visibility
    Collection - show view - user not signed in - allows public collections to be viewed by all users
    Search - user not signed in - public collections show up in search results

@projecthydra/sufia-code-reviewers
