### PR TITLE
Adds external link icon to Related URL field

### DIFF
--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -8,6 +8,6 @@
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim') %>
 <%= presenter.attribute_to_html(:based_near, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:related_url) %>
+<%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:source) %>

--- a/spec/views/curation_concerns/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_attribute_rows.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'curation_concerns/base/_attribute_rows.html.erb', type: :view do
+  let(:url) { "http://example.com" }
+  let(:ability) { double }
+  let(:work) { stub_model(GenericWork, related_url: [url]) }
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:presenter) { Sufia::WorkShowPresenter.new(solr_document, ability) }
+
+  let(:page) do
+    render 'curation_concerns/base/attribute_rows', presenter: presenter
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  it 'shows external link with icon for related url field' do
+    expect(page).to have_selector '.glyphicon-new-window'
+    expect(page).to have_link(url)
+  end
+end


### PR DESCRIPTION
Fixes #2472 

Change in Curation Concerns removed external link icon from related url field.

This provides a new CC renderer using code similar to an existing Sufia helper (iconify_auto_link). A future issue may pull out the helper code and replace it with a renderer. 

@projecthydra/sufia-code-reviewers

