### PR TITLE
Updating view to allow description to be required

### DIFF
--- a/app/views/records/edit_fields/_description.html.erb
+++ b/app/views/records/edit_fields/_description.html.erb
@@ -1,5 +1,5 @@
 <% if f.object.class.multiple? key %>
-  <%= f.input :description, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: false %>
+  <%= f.input :description, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
 <% else %>
-  <%= f.input :description, as: :text, input_html: { rows: '14' } %>
+  <%= f.input :description, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
 <% end %>

--- a/spec/views/records/edit_fields/_description.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_description.html.erb_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe 'records/edit_fields/_description.html.erb', type: :view do
+  let(:work) { GenericWork.new }
+  let(:form) { Sufia::Forms::WorkForm.new(work, nil) }
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "records/edit_fields/description", f: f, key: 'description' %>
+      <% end %>
+    )
+  end
+  before do
+    assign(:form, form)
+  end
+
+  context "when single valued" do
+    before do
+      expect(Sufia::Forms::WorkForm).to receive(:multiple?).and_return(false)
+    end
+
+    context "when not required" do
+      before do
+        expect(form).to receive(:required?).and_return(false)
+      end
+      it 'has text area' do
+        render inline: form_template
+        expect(rendered).to have_selector('textarea[class="form-control text optional"]')
+      end
+    end
+
+    context "when required" do
+      before do
+        expect(form).to receive(:required?).and_return(true)
+      end
+      it 'has text area' do
+        render inline: form_template
+        expect(rendered).to have_selector('textarea[class="form-control text required"]')
+      end
+    end
+  end
+
+  context "when multi valued" do
+    before do
+      expect(Sufia::Forms::WorkForm).to receive(:multiple?).and_return(true)
+    end
+
+    context "when not required" do
+      before do
+        expect(form).to receive(:required?).and_return(false)
+      end
+      it 'has text area' do
+        render inline: form_template
+        expect(rendered).to have_selector('textarea[class="string multi_value optional generic_work_description form-control multi-text-field"]')
+      end
+    end
+
+    context "when required" do
+      before do
+        expect(form).to receive(:required?).and_return(true)
+      end
+      it 'has text area' do
+        render inline: form_template
+        puts rendered
+        expect(rendered).to have_selector('textarea[class="string multi_value required generic_work_description form-control multi-text-field"]')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2643 

Adds the ability for description to be required or not.  Also adds tests to verify that this will stay the case.

@projecthydra/sufia-code-reviewers

