### PR TITLE
Don't display the action column if there's no user, fixes #2587

### DIFF
--- a/app/views/collections/_show_document_list.html.erb
+++ b/app/views/collections/_show_document_list.html.erb
@@ -6,7 +6,9 @@
     <th>Title</th>
     <th>Date Uploaded</th>
     <th>Visibility</th>
-    <th>Action</th>
+    <% if current_user %>
+      <th>Action</th>
+    <% end %>
   </tr>
   </thead>
   <tbody>

--- a/app/views/collections/_show_document_list_menu.html.erb
+++ b/app/views/collections/_show_document_list_menu.html.erb
@@ -2,8 +2,7 @@
   <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">Select an action<span class="caret"></span>
   </button>
   <ul class="dropdown-menu dropdown-menu-right">
-    <% if current_user %>
-      <% if can? :edit, document %>
+    <% if can? :edit, document %>
       <li>
         <%= link_to [:edit, document],
                     class: "itemicon itemedit",
@@ -12,12 +11,11 @@
           <i class='glyphicon glyphicon-pencil'></i> <%= t('sufia.collection.document_list.edit') %>
         <% end %>
       </li>
-      <% end %>
-      <li>
-        <%= display_trophy_link(current_user, document.id) do |text| %>
-          <i class='glyphicon glyphicon-star'></i> <%= text %>
-        <% end %>
-      </li>
     <% end %>
+    <li>
+      <%= display_trophy_link(current_user, document.id) do |text| %>
+        <i class='glyphicon glyphicon-star'></i> <%= text %>
+      <% end %>
+    </li>
   </ul>
 </div>

--- a/app/views/collections/_show_document_list_row.html.erb
+++ b/app/views/collections/_show_document_list_row.html.erb
@@ -23,9 +23,11 @@
   <td class="text-center">
     <%= render_visibility_link(document) %>
   </td>
-  <td class="text-center">
-    <%= render'show_document_list_menu', document: document %>
-  </td>
+  <% if current_user %>
+    <td class="text-center">
+      <%= render 'show_document_list_menu', document: document %>
+    </td>
+  <% end %>
 </tr>
 <tr id="detail_<%= id %>"> <!--  document detail"> -->
   <td colspan="6">

--- a/spec/views/collections/_show_document_list.html.erb_spec.rb
+++ b/spec/views/collections/_show_document_list.html.erb_spec.rb
@@ -27,6 +27,7 @@ describe 'collections/_show_document_list.html.erb', type: :view do
     it "renders collection" do
       render(partial: 'collections/show_document_list.html.erb', locals: { documents: documents })
       expect(rendered).to have_content 'One Hundred Years of Solitude'
+      expect(rendered).not_to have_content 'Action'
     end
   end
 end

--- a/spec/views/collections/_show_document_list_menu.html.erb_spec.rb
+++ b/spec/views/collections/_show_document_list_menu.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe 'collections/_show_document_list_menu.html.erb', type: :view do
       allow(controller).to receive(:current_ability).and_return(ability)
     end
 
-    it "displays the action list in a drop down for an individual work user can edit" do
+    it "displays the action list in a drop down for an individual work the user can edit" do
       allow(ability).to receive(:can?).with(:edit, document).and_return(true)
       render('collections/show_document_list_menu.html.erb', document: document, current_user: user)
       expect(rendered).to have_content 'Select an action'
@@ -18,21 +18,13 @@ describe 'collections/_show_document_list_menu.html.erb', type: :view do
       expect(rendered).to have_content 'Highlight Work on Profile'
     end
 
-    it "displays the action list in a drop down for individual work user can not edit" do
+    it "displays the action list in a drop down for an individual work the user cannot edit" do
       allow(ability).to receive(:can?).with(:edit, document).and_return(false)
       render('collections/show_document_list_menu.html.erb', document: document, current_user: user)
       expect(rendered).to have_content 'Select an action'
       expect(rendered).not_to have_content 'Edit'
       expect(rendered).not_to have_content 'Download File'
       expect(rendered).to have_content 'Highlight Work on Profile'
-    end
-
-    it "displays the action list in a drop down for individual work without being logged in" do
-      render('collections/show_document_list_menu.html.erb', document: document, current_user: false)
-      expect(rendered).to have_content 'Select an action'
-      expect(rendered).not_to have_content 'Edit'
-      expect(rendered).not_to have_content 'Download File'
-      expect(rendered).not_to have_content 'Highlight Work on Profile'
     end
   end
 end


### PR DESCRIPTION
Fixes #2587 

Don't display the action menu or column if there user isn't logged in.

@projecthydra/sufia-code-reviewers

