### PR TITLE
Add a style for representative media

### DIFF
--- a/app/assets/stylesheets/sufia/_representative-media.scss
+++ b/app/assets/stylesheets/sufia/_representative-media.scss
@@ -1,0 +1,4 @@
+.representative-media {
+  display: block;
+  padding: 0.5em 0;
+}

--- a/app/assets/stylesheets/sufia/_sufia.scss
+++ b/app/assets/stylesheets/sufia/_sufia.scss
@@ -1,14 +1,13 @@
 @import 'hydra-editor/multi_value_fields';
 @import 'curation_concerns/modules/forms';
 @import 'curation_concerns/modules/file_manager';
-@import "curation_concerns/positioning";
 @import 'sufia/variables', 'sufia/file_sets', 'sufia/settings', 'sufia/header',
         'sufia/styles', 'sufia/file-listing', 'sufia/browse_everything_overrides',
         'sufia/nestable', 'sufia/collections', 'sufia/batch-edit', 'sufia/dashboard',
         'sufia/home-page', 'sufia/featured', 'sufia/usage-stats', 'sufia/catalog',
         'sufia/buttons', 'sufia/tinymce', 'sufia/proxy-rights', 'sufia/file-show',
         'sufia/work-show', 'sufia/modal', 'sufia/form', 'sufia/form-progress',
-        'sufia/fixedsticky', 'sufia/file_upload';
+        'sufia/fixedsticky', 'sufia/file_upload', 'sufia/representative-media';
 @import 'sharing_buttons';
 
 /* This class is to workaround an issue in which Bootstrap requires a div to display a tooltip


### PR DESCRIPTION
The fix from #2542 was too broad and brought too many styles that were
adversely affecting the Sufia layout.

See the initial issue: #2532