### PR TITLE
adding 5px to tds in trophyrows

### DIFF
--- a/app/assets/stylesheets/sufia/_form.scss
+++ b/app/assets/stylesheets/sufia/_form.scss
@@ -2,7 +2,7 @@
   margin: 15px 10px;
 }
 
-/* For the admin page */
+// For the admin page //
 td.status {
   width: 2rem;
   font-size: 1.1rem;
@@ -22,4 +22,9 @@ td.toggle {
     &.active { @extend .btn-primary; }
     &:not(.active) { @extend .btn-default; }
   }
+}
+
+// for profile page highlighted works //
+tr.highlighted-works td {
+  padding: 5px;
 }

--- a/app/views/users/_contributions.html.erb
+++ b/app/views/users/_contributions.html.erb
@@ -2,7 +2,7 @@
   <% if presenter.trophies.count > 0 %>
     <table>
       <% presenter.trophies.each do |t| %>
-        <tr id="trophyrow_<%= t.id %>">
+        <tr id="trophyrow_<%= t.id %>" class='highlighted-works'>
           <td>
             <%= link_to t do %>
               <%= image_tag t.thumbnail_path, width: 90 %>


### PR DESCRIPTION
Fixes #2415 

adds 5px to td elements in tr elements with ids matching '#trophyrow_'.

<img width="392" alt="breathing_room" src="https://cloud.githubusercontent.com/assets/186452/18397129/6e096920-768c-11e6-8a91-addfa6f4e331.png">

Edit in /app/assets/stylesheets/sufia/_form.scss

@projecthydra/sufia-code-reviewers

