### PR TITLE
checking for null or empty to work for selects and text areas

### DIFF
--- a/app/assets/javascripts/sufia/save_work/required_fields.es6
+++ b/app/assets/javascripts/sufia/save_work/required_fields.es6
@@ -7,7 +7,11 @@ export class RequiredFields {
   }
 
   get areComplete() {
-    return this.requiredFields.filter((n, elem) => { return $(elem).val().length < 1 } ).length == 0
+    return this.requiredFields.filter((n, elem) => { return this.isValuePresent(elem) } ).length == 0
+  }
+
+  isValuePresent(elem) {
+    return ($(elem).val() === null) || ($(elem).val().length < 1)
   }
 
   // Reassign requiredFields because fields may have been added or removed.

--- a/spec/javascripts/required_field_spec.js
+++ b/spec/javascripts/required_field_spec.js
@@ -1,0 +1,41 @@
+describe('RequiredFields', function() {
+  var control = require('sufia/save_work/required_fields');
+  var target = null;
+
+  describe('areComplete', function() {
+    describe('when required metadata is not present' ,  function() {
+      beforeEach(function() {
+        var fixture = setFixtures(form('',''));
+        target = new control.RequiredFields(fixture.find('#new_generic_work'),function () {});
+      });
+      it('is not complete', function() {
+        expect(target.areComplete).toEqual(false);
+      });
+    });
+
+    describe('when required metadata is not present', function() {
+      beforeEach(function() {
+        var fixture = setFixtures(form('title','selected="selected"'));
+        target = new control.RequiredFields(fixture.find('#new_generic_work'),function () {});
+      });
+      it('is complete', function() {
+        expect(target.areComplete).toEqual(true);
+      });
+    });
+
+  });
+});
+
+function form(title, resourceTypeSelected) {
+    return '<form id="new_generic_work">' +
+        '  <div>' +
+        '    <input class="string multi_value required form-control generic_work_title form-control multi-text-field" required="required" aria-required="true" name="generic_work[title][]" value="' + title + '" id="generic_work_title" type="text">' +
+        '  </div>' +
+        '  <div>' +
+        '    <select class="form-control select required form-control" multiple="multiple" required="required" aria-required="true" name="generic_work[resource_type][]" id="generic_work_resource_type">' +
+        '      <option value="Article"' + resourceTypeSelected + '>Article</option>' +
+        '      <option value="Other">Other</option>' +
+        '    </select>' +
+        '  </div>' +
+        '</form>';
+}


### PR DESCRIPTION
Fixes #2648 

Checks for null or length of zero to allow for other input types including multi select for resource_type.


@projecthydra/sufia-code-reviewers

