### PR TITLE
Remove the page-header class

### DIFF
--- a/app/views/dashboard/_index_partials/_heading_greetings.html.erb
+++ b/app/views/dashboard/_index_partials/_heading_greetings.html.erb
@@ -1,3 +1,3 @@
 <div class="col-md-12">
-  <h1 class="page-header"><%= t("sufia.dashboard.title") %></h1>
+  <h1><%= t("sufia.dashboard.title") %></h1>
 </div>


### PR DESCRIPTION
This is a class provided by bootstrap
(http://getbootstrap.com/components/#page-header) and it provides too
much margin-top when combined with out `main-header` class