### PR TITLE
Remove unnecessary call to find_collections

### DIFF
--- a/app/controllers/concerns/sufia/my_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/my_controller_behavior.rb
@@ -13,7 +13,6 @@ module Sufia
       before_action :authenticate_user!
       before_action :enforce_show_permissions, only: :show
       before_action :enforce_viewing_context_for_show_requests, only: :show
-      before_action :find_collections, only: :index
       before_action :find_collections_with_edit_access, only: :index
 
       layout 'sufia-dashboard'


### PR DESCRIPTION
The call to `find_collections_with_edit_access` overwrites the
`@user_collections` variable set by `find_collections`