### PR TITLE
New works are inactive when mediation is on

### DIFF
--- a/app/actors/sufia/create_with_files_actor.rb
+++ b/app/actors/sufia/create_with_files_actor.rb
@@ -3,7 +3,7 @@ module Sufia
   class CreateWithFilesActor < CurationConcerns::Actors::AbstractActor
     def create(attributes)
       self.uploaded_file_ids = attributes.delete(:uploaded_files)
-      validate_files && next_actor.create(attributes) && attach_files
+      validate_files && mark_inactive && next_actor.create(attributes) && attach_files
     end
 
     def update(attributes)
@@ -41,6 +41,15 @@ module Sufia
       def uploaded_files
         return [] if uploaded_file_ids.empty?
         @uploaded_files ||= UploadedFile.find(uploaded_file_ids)
+      end
+
+      def mark_inactive
+        return true unless Flipflop.enable_mediated_deposit?
+        curation_concern.state = inactive_uri
+      end
+
+      def inactive_uri
+        ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive')
       end
   end
 end

--- a/spec/actors/sufia/create_with_files_actor_spec.rb
+++ b/spec/actors/sufia/create_with_files_actor_spec.rb
@@ -44,4 +44,22 @@ describe Sufia::CreateWithFilesActor do
       end
     end
   end
+
+  describe "mediated deposit" do
+    subject { actor.curation_concern.state }
+    let(:inactive_uri) { RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive') }
+    before do
+      allow(Flipflop).to receive(:enable_mediated_deposit?).and_return(mediation_enabled)
+      allow(AttachFilesToWorkJob).to receive(:perform_later).with(GenericWork, [uploaded_file1, uploaded_file2])
+      actor.create(attributes)
+    end
+    context "when enabled" do
+      let(:mediation_enabled) { true }
+      it { is_expected.to eq inactive_uri }
+    end
+    context "when disabled" do
+      let(:mediation_enabled) { false }
+      it { is_expected.to be nil }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2616 ; refs #2616

If mediated deposit is flipped on, new works are marked inactive.