### PR TITLE
Adding enable_mediated_deposit as a flippable feature

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -7,4 +7,8 @@ Flipflop.configure do
   feature :assign_admin_set,
           default: true,
           description: "Ability to assign uploaded items to an admin set"
+
+  feature :enable_mediated_deposit,
+          default: false,
+          description: "Turn on mediation for all deposits"
 end

--- a/spec/models/flipflop_spec.rb
+++ b/spec/models/flipflop_spec.rb
@@ -5,4 +5,8 @@ RSpec.describe Flipflop do
     subject { described_class.assign_admin_set? }
     it { is_expected.to be true }
   end
+  describe "enable_mediated_deposit?" do
+    subject { described_class.enable_mediated_deposit? }
+    it { is_expected.to be false }
+  end
 end


### PR DESCRIPTION
Fixes #2628 ; refs #2628

Replaces #2645 to change from a forked personal branch to a proper sufia branch so other contributors can push changes.

This simply adds the configurable option in the administrative dashboard that will be used to enable a mediated deposit workflow.

Changes proposed in this pull request:

add feature "enable_mediated_deposit"

@projecthydra/sufia-code-reviewers
