### PR TITLE
Add about_page methods to ContentBlock

### DIFF
--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -2,6 +2,7 @@ class ContentBlock < ActiveRecord::Base
   MARKETING  = 'marketing_text'.freeze
   RESEARCHER = 'featured_researcher'.freeze
   ANNOUNCEMENT = 'announcement_text'.freeze
+  ABOUT = 'about_page'.freeze
 
   def self.marketing_text
     find_or_create_by(name: MARKETING)
@@ -29,6 +30,14 @@ class ContentBlock < ActiveRecord::Base
 
   def self.featured_researcher=(value)
     create(name: RESEARCHER, value: value)
+  end
+
+  def self.about_page
+    find_or_create_by(name: ABOUT)
+  end
+
+  def self.about_page=(value)
+    about_page.update(value: value)
   end
 
   def self.external_keys

--- a/spec/models/content_block_spec.rb
+++ b/spec/models/content_block_spec.rb
@@ -25,6 +25,12 @@ describe ContentBlock, type: :model do
            value: '<h1>Announcement Text</h1>')
   end
 
+  let!(:about) do
+    create(:content_block,
+           name: ContentBlock::ABOUT,
+           value: '<h1>About Page</h1>')
+  end
+
   describe '.announcement_text' do
     subject { described_class.announcement_text.value }
     it { is_expected.to eq '<h1>Announcement Text</h1>' }
@@ -35,6 +41,19 @@ describe ContentBlock, type: :model do
     it 'sets a new announcement_text' do
       described_class.announcement_text = new_announcement
       expect(described_class.announcement_text.value).to eq new_announcement
+    end
+  end
+
+  describe '.about_page' do
+    subject { described_class.about_page.value }
+    it { is_expected.to eq '<h1>About Page</h1>' }
+  end
+
+  describe '.about_page=' do
+    let(:new_about) { '<h2>Foobarfoo</h2>' }
+    it 'sets a new announcement_text' do
+      described_class.about_page = new_about
+      expect(described_class.about_page.value).to eq new_about
     end
   end
 


### PR DESCRIPTION
Adds about_page methods to ContentBlock model.

This is to support editing the /about page from the content block editors screen in lerna. 


@projecthydra/sufia-code-reviewers

