### PR TITLE
make inactive records undiscoverable.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ group :development, :test do
   gem 'coveralls', require: false
 end
 
+gem 'hydra-role-management'
+
 # BEGIN ENGINE_CART BLOCK
 # engine_cart: 0.10.0
 # engine_cart stanza: 0.10.0

--- a/app/indexers/sufia/work_indexer.rb
+++ b/app/indexers/sufia/work_indexer.rb
@@ -8,6 +8,7 @@ module Sufia
         # when a work in the collection matches the query.
         solr_doc[Solrizer.solr_name('file_set_ids', :symbol)] = solr_doc[Solrizer.solr_name('member_ids', :symbol)]
         solr_doc[Solrizer.solr_name('resource_type', :facetable)] = object.resource_type
+        solr_doc[Solrizer.solr_name('suppressed', STORED_BOOL)] = object.suppressed?
 
         admin_set_label = object.admin_set.to_s
         solr_doc[Solrizer.solr_name('admin_set', :facetable)] = admin_set_label

--- a/app/models/concerns/curation_concerns/publishable.rb
+++ b/app/models/concerns/curation_concerns/publishable.rb
@@ -1,0 +1,18 @@
+module CurationConcerns
+  module Publishable
+    extend ActiveSupport::Concern
+
+    included do
+      # This holds the workflow state
+      property :state, predicate: Vocab::FedoraResourceStatus.objState, multiple: false
+
+      class_attribute :state_workflow, instance_writer: false
+      self.state_workflow = StateWorkflow
+    end
+
+    # This method has been overriden to handle mediated deposit
+    def suppressed?
+      state_workflow.new(state).pending? || state_workflow.new(state).state == ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive')
+    end
+  end
+end

--- a/app/search_builders/sufia/catalog_search_builder.rb
+++ b/app/search_builders/sufia/catalog_search_builder.rb
@@ -2,7 +2,8 @@ class Sufia::CatalogSearchBuilder < Sufia::SearchBuilder
   self.default_processor_chain += [
     :add_access_controls_to_solr_params,
     :add_advanced_parse_q_to_solr,
-    :show_works_or_works_that_contain_files
+    :show_works_or_works_that_contain_files,
+    :show_only_active_records
   ]
 
   # show both works that match the query and works that contain files that match the query
@@ -10,6 +11,13 @@ class Sufia::CatalogSearchBuilder < Sufia::SearchBuilder
     return if solr_parameters[:q].blank?
     solr_parameters[:user_query] = solr_parameters[:q]
     solr_parameters[:q] = new_query
+  end
+
+  # show works that are in the active state.
+  def show_only_active_records(solr_parameters)
+    return unless Flipflop.enable_mediated_deposit?
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << '-suppressed_bsi:true'
   end
 
   private

--- a/spec/search_builder/sufia/catalog_search_builder_spec.rb
+++ b/spec/search_builder/sufia/catalog_search_builder_spec.rb
@@ -2,21 +2,47 @@ describe Sufia::CatalogSearchBuilder do
   let(:builder) { described_class.new([], self) }
   let(:solr_params) { { q: user_query } }
 
-  context "with a user query" do
-    let(:user_query) { "find me" }
-    it "creates a valid solr join for works and files" do
-      builder.show_works_or_works_that_contain_files(solr_params)
-      expect(solr_params[:user_query]).to eq user_query
-      expect(solr_params[:q]).to eq "{!lucene}_query_:\"{!dismax v=$user_query}\" _query_:\"{!join from=id to=file_set_ids_ssim}{!dismax v=$user_query}\""
+  describe "search query" do
+    context "with a user query" do
+      let(:user_query) { "find me" }
+      it "creates a valid solr join for works and files" do
+        builder.show_works_or_works_that_contain_files(solr_params)
+        expect(solr_params[:user_query]).to eq user_query
+        expect(solr_params[:q]).to eq "{!lucene}_query_:\"{!dismax v=$user_query}\" _query_:\"{!join from=id to=file_set_ids_ssim}{!dismax v=$user_query}\""
+      end
+    end
+
+    context "with out a user query" do
+      let(:user_query) { nil }
+      it "does not modify the query" do
+        builder.show_works_or_works_that_contain_files(solr_params)
+        expect(solr_params[:user_query]).to be_nil
+        expect(solr_params[:q]).to be_nil
+      end
     end
   end
 
-  context "with out a user query" do
-    let(:user_query) { nil }
-    it "does not modify the query" do
-      builder.show_works_or_works_that_contain_files(solr_params)
-      expect(solr_params[:user_query]).to be_nil
-      expect(solr_params[:q]).to be_nil
+  describe "mediated deposit" do
+    before do
+      allow(Flipflop).to receive(:enable_mediated_deposit?).and_return(mediation_enabled)
+    end
+
+    context "with mediated deposit enabled" do
+      let(:user_query) { nil }
+      let(:mediation_enabled) { true }
+      it "does includes suppressed switch" do
+        builder.show_only_active_records(solr_params)
+        expect(solr_params[:fq]).to eq ["-suppressed_bsi:true"]
+      end
+    end
+
+    context "with mediated deposit disabled" do
+      let(:user_query) { nil }
+      let(:mediation_enabled) { false }
+      it "does not include suppressed switch" do
+        builder.show_only_active_records(solr_params)
+        expect(solr_params[:fq]).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
I'm working on #2640 (if work is inactive then don't have it show up in facet or search).  I think what I have to do is change app/search_builders/sufia/catalog_search_builder.rb so that it will not include the works that are inactive in the results by adding a method to filter them out.  But since the state is not in solr ( I don't think ), I'm not sure how to check for this.  Am I headed in the right direction?  Any suggestions?  Thank you! Jose

BTW, the only file of interest is this one.  I changed the other files in my local repository based on issues that have not yet been merged.

app/search_builders/sufia/catalog_search_builder.rb