### PR TITLE
Download endnote file as attachment, fixes #2694

### DIFF
--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -61,7 +61,11 @@ module Sufia
 
       # Called by CurationConcerns::CurationConcernController#show
       def additional_response_formats(format)
-        format.endnote { render plain: presenter.solr_document.export_as_endnote }
+        format.endnote do
+          send_data(presenter.solr_document.export_as_endnote,
+                    type: "application/x-endnote-refer",
+                    filename: presenter.solr_document.endnote_filename)
+        end
       end
 
       def add_breadcrumb_for_controller

--- a/app/models/concerns/sufia/solr_document/export.rb
+++ b/app/models/concerns/sufia/solr_document/export.rb
@@ -20,6 +20,12 @@ module Sufia
         text.join("\n")
       end
 
+      # Name of the downloaded endnote file
+      # Override this if you want to use a different name
+      def endnote_filename
+        "#{id}.endnote"
+      end
+
       def persistent_url
         "#{Sufia.config.persistent_hostpath}#{id}"
       end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -62,9 +62,19 @@ describe CurationConcerns::GenericWorksController do
       expect(assigns(:presenter)).to be_kind_of Sufia::WorkShowPresenter
     end
 
-    it 'renders an endnote file' do
-      get :show, params: { id: work, format: 'endnote' }
-      expect(response).to be_successful
+    context "with an endnote file" do
+      let(:disposition)  { response.header.fetch("Content-Disposition") }
+      let(:content_type) { response.header.fetch("Content-Type") }
+
+      render_views
+
+      it 'downloads the file' do
+        get :show, params: { id: work, format: 'endnote' }
+        expect(response).to be_successful
+        expect(disposition).to include("attachment")
+        expect(content_type).to eq("application/x-endnote-refer")
+        expect(response.body).to include("%T test title")
+      end
     end
 
     context "without a referer" do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -122,4 +122,10 @@ describe ::SolrDocument, type: :model do
     subject { document.width }
     it { is_expected.to eq '555' }
   end
+
+  context "when exporting in endnote format" do
+    let(:attributes) { { id: "1234" } }
+    subject { document.endnote_filename }
+    it { is_expected.to eq("1234.endnote") }
+  end
 end


### PR DESCRIPTION
Fixes #2694 

Downloads endnote export format as a file and provides a configurable filename via SolrDocument.

@projecthydra/sufia-code-reviewers

