### PR TITLE
Use UTF8 encoding for Endnote files

### DIFF
--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -63,7 +63,7 @@ module Sufia
       def additional_response_formats(format)
         format.endnote do
           send_data(presenter.solr_document.export_as_endnote,
-                    type: "application/x-endnote-refer",
+                    type: "application/x-endnote-refer; charset=utf-8",
                     filename: presenter.solr_document.endnote_filename)
         end
       end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -72,7 +72,7 @@ describe CurationConcerns::GenericWorksController do
         get :show, params: { id: work, format: 'endnote' }
         expect(response).to be_successful
         expect(disposition).to include("attachment")
-        expect(content_type).to eq("application/x-endnote-refer")
+        expect(content_type).to eq("application/x-endnote-refer; charset=utf-8")
         expect(response.body).to include("%T test title")
       end
     end


### PR DESCRIPTION
Sorry, forgot to add this earlier.

@projecthydra/sufia-code-reviewers

