### PR TITLE
Adding access copy from work to files on ingest

### DIFF
--- a/app/controllers/curation_concerns/permissions_controller.rb
+++ b/app/controllers/curation_concerns/permissions_controller.rb
@@ -1,0 +1,17 @@
+class CurationConcerns::PermissionsController < ApplicationController
+  include CurationConcerns::PermissionsControllerBehavior
+
+  def confirm_access
+    # intentional noop to display default rails view
+  end
+
+  def copy_access
+    authorize! :edit, curation_concern
+    # copy visibility
+    VisibilityCopyJob.perform_later(curation_concern)
+
+    # copy permissions
+    InheritPermissionsJob.perform_later(curation_concern)
+    redirect_to [main_app, curation_concern], notice: I18n.t("sufia.upload.change_access_flash_message")
+  end
+end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -9,7 +9,9 @@ class AttachFilesToWorkJob < ActiveJob::Base
       file_set = FileSet.new
       user = User.find_by_user_key(work.depositor)
       actor = CurationConcerns::Actors::FileSetActor.new(file_set, user)
-      actor.create_metadata(work, visibility: work.visibility)
+      actor.create_metadata(work, visibility: work.visibility) do |file|
+        file.permissions_attributes = work.permissions.map(&:to_hash)
+      end
 
       attach_content(actor, uploaded_file.file)
       uploaded_file.update(file_set_uri: file_set.uri)

--- a/app/jobs/inherit_permissions_job.rb
+++ b/app/jobs/inherit_permissions_job.rb
@@ -1,0 +1,24 @@
+# A job to apply work permissions to all contained files set
+#
+class InheritPermissionsJob < ActiveJob::Base
+  # Perform the copy from the work to the contained filesets
+  #
+  # @param work containing access level and filesets
+  def perform(work)
+    work.file_sets.each do |file|
+      attribute_map = work.permissions.map(&:to_hash)
+
+      # copy and removed access to the new access with the delete flag
+      file.permissions.map(&:to_hash).each do |perm|
+        unless attribute_map.include?(perm)
+          perm[:_destroy] = true
+          attribute_map << perm
+        end
+      end
+
+      # apply the new and deleted attributes
+      file.permissions_attributes = attribute_map
+      file.save!
+    end
+  end
+end

--- a/app/views/curation_concerns/permissions/confirm_access.html.erb
+++ b/app/views/curation_concerns/permissions/confirm_access.html.erb
@@ -1,0 +1,12 @@
+<div class="panel panel-default permissions-confirm">
+  <div class="panel-heading">
+    <h4>Apply changes to contents?<h4>
+  </div>
+  <div class="panel-body">
+      <%= I18n.t("sufia.upload.change_access_message_html", curation_concern: curation_concern).html_safe %>
+  </div>
+  <div class="form-actions panel-footer">
+    <%= button_to I18n.t("sufia.upload.change_access_yes_message"), sufia.copy_access_curation_concerns_permission_path(curation_concern), class: 'btn btn-primary' %>
+    <%= link_to I18n.t("sufia.upload.change_access_no_message"), [main_app, curation_concern], class: 'btn' %>
+  </div>
+</div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -63,6 +63,10 @@ en:
       processing: "File is being processed; you may edit when processing has completed"
       permissions_message: "Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions."
       change_permissions_message_html: "<p>You have changed the permissions on this %{curation_concern_human_readable_type}, <i>%{curation_concern}</i>, making it visible to <b>%{visibility_badge}</b>.</p><p>Would you like change all of the files within the %{curation_concern_human_readable_type} to <b>%{visibility_badge}</b> as well?</p>"
+      change_access_message_html: "<p>You have changed the access level on work <i>%{curation_concern}</i>, making it accessible to other users or groups to view or edit.</p><p>Would you like change all of the files within the work to have the same access users, groups and visibility as well?</p>"
+      change_access_yes_message: "Yes please."
+      change_access_no_message: "No. I'll update it manually."
+      change_access_flash_message: "Updating file access levels. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file acess levels."
       alert:
         fail_html: "There was a problem during upload, none of your files uploaded correctly. Please %{reload_href}.  Use the %{contact_href} to report the error if it persists."
         fail_restart_href_text: "start over"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,8 @@ Sufia::Engine.routes.draw do
       member do
         get :confirm
         post :copy
+        get :confirm_access
+        post :copy_access
       end
     end
   end

--- a/spec/controllers/curation_concerns/permissions_controller_spec.rb
+++ b/spec/controllers/curation_concerns/permissions_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe CurationConcerns::PermissionsController do
+  let(:user) { create(:user) }
+  let(:work) { create(:work_with_one_file, user: user) }
+  before { sign_in user }
+
+  describe '#confirm_access' do
+    it 'draws the page' do
+      get :confirm_access, params: { id: work }
+      expect(response).to be_success
+    end
+  end
+
+  describe '#copy_access' do
+    it 'adds a worker to the queue' do
+      expect(VisibilityCopyJob).to receive(:perform_later).with(work)
+      expect(InheritPermissionsJob).to receive(:perform_later).with(work)
+      post :copy_access, params: { id: work }
+      expect(response).to redirect_to main_app.curation_concerns_generic_work_path(work)
+      expect(flash[:notice]).to eq 'Updating file access levels. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file acess levels.'
+    end
+  end
+end

--- a/spec/jobs/inherit_permissions_job_spec.rb
+++ b/spec/jobs/inherit_permissions_job_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe InheritPermissionsJob do
+  let(:user) { create(:user) }
+  let(:work) { create(:work_with_one_file, user: user) }
+
+  before do
+    work.permissions.build(name: name, type: type, access: access)
+    work.save
+  end
+
+  context "when edit people change" do
+    let(:name) { 'abc@123.com' }
+    let(:type) { 'person' }
+    let(:access) { 'edit' }
+
+    it 'copies permissions to its contained files' do
+      # files have the depositor as the edit user to begin with
+      expect(work.file_sets.first.edit_users).to eq [user.to_s]
+
+      described_class.perform_now(work)
+      work.reload.file_sets.each do |file|
+        expect(file.edit_users).to match_array [user.to_s, "abc@123.com"]
+      end
+    end
+
+    context "when people should be removed" do
+      before do
+        file_set = work.file_sets.first
+        file_set.permissions.build(name: "remove_me", type: type, access: access)
+        file_set.save
+      end
+
+      it 'copies permissions to its contained files' do
+        # files have the depositor as the edit user to begin with
+        expect(work.file_sets.first.edit_users).to eq [user.to_s, "remove_me"]
+
+        described_class.perform_now(work)
+        work.reload.file_sets.each do |file|
+          expect(file.edit_users).to match_array [user.to_s, "abc@123.com"]
+        end
+      end
+    end
+  end
+
+  context "when read people change" do
+    let(:name) { 'abc@123.com' }
+    let(:type) { 'person' }
+    let(:access) { 'read' }
+
+    it 'copies permissions to its contained files' do
+      # files have the depositor as the edit user to begin with
+      expect(work.file_sets.first.read_users).to eq []
+
+      described_class.perform_now(work)
+      work.reload.file_sets.each do |file|
+        expect(file.read_users).to match_array ["abc@123.com"]
+        expect(file.edit_users).to match_array [user.to_s]
+      end
+    end
+  end
+
+  context "when read groups change" do
+    let(:name) { 'my_read_group' }
+    let(:type) { 'group' }
+    let(:access) { 'read' }
+
+    it 'copies permissions to its contained files' do
+      # files have the depositor as the edit user to begin with
+      expect(work.file_sets.first.read_groups).to eq []
+
+      described_class.perform_now(work)
+      work.reload.file_sets.each do |file|
+        expect(file.read_groups).to match_array ["my_read_group"]
+        expect(file.edit_users).to match_array [user.to_s]
+      end
+    end
+  end
+
+  context "when edit groups change" do
+    let(:name) { 'my_edit_group' }
+    let(:type) { 'group' }
+    let(:access) { 'edit' }
+
+    it 'copies permissions to its contained files' do
+      # files have the depositor as the edit user to begin with
+      expect(work.file_sets.first.read_groups).to eq []
+
+      described_class.perform_now(work)
+      work.reload.file_sets.each do |file|
+        expect(file.edit_groups).to match_array ["my_edit_group"]
+        expect(file.edit_users).to match_array [user.to_s]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2448 

Updates the fileset automatically on create to have the same access levels as the containing work.
Prompts the user on update of the work to see if they would like to apply access level to the containing filesets.


<img width="1307" alt="screen shot 2016-09-16 at 9 28 11 am" src="https://cloud.githubusercontent.com/assets/1599081/18587429/01fedff8-7bf0-11e6-8a72-958cf2a5b206.png">


Changes proposed in this pull request:
*  Apply Work permissions to Files on Upload
* Prompt user to apply work permissions to Files on work edit

@projecthydra/sufia-code-reviewers

