### PR TITLE
Allow users and groups to share collections in v6.x-stable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,7 @@ Metrics/ModuleLength:
   Exclude:
     - 'app/controllers/concerns/sufia/users_controller_behavior.rb'
     - 'app/controllers/concerns/sufia/files_controller_behavior.rb'
+    - 'app/controllers/concerns/sufia/collections_controller_behavior.rb'
     - 'app/helpers/sufia/sufia_helper_behavior.rb'
 
 Style/BlockDelimiters:

--- a/app/assets/javascripts/sufia/permissions.js
+++ b/app/assets/javascripts/sufia/permissions.js
@@ -77,15 +77,27 @@ Blacklight.onLoad(function() {
   // when user clicks on visibility, update potential access levels
   $("input[name='visibility']").on("change", set_access_levels);
 
-	$('#generic_file_permissions_new_group_name').change(function (){
-      var edit_option = $("#generic_file_permissions_new_group_permission option[value='edit']")[0];
-	    if (this.value.toUpperCase() == 'PUBLIC') {
-	       edit_option.disabled =true;
-	    } else {
-           edit_option.disabled =false;
-	    }
+    if (($("[id=new_collection]").length) || ($("[id^=edit_collection]")).length) {
+        $('#collection_permissions_new_group_name').change(function (){
+            var edit_option = $("#collection_permissions_new_group_permission option[value='edit']")[0];
+            if (this.value.toUpperCase() == 'PUBLIC') {
+                edit_option.disabled =true;
+            } else {
+                edit_option.disabled =false;
+            }
+        });
+    }
+    else {
+        $('#generic_file_permissions_new_group_name').change(function () {
+            var edit_option = $("#generic_file_permissions_new_group_permission option[value='edit']")[0];
+            if (this.value.toUpperCase() == 'PUBLIC') {
+                edit_option.disabled = true;
+            } else {
+                edit_option.disabled = false;
+            }
 
-	});
+        });
+    }
 
   function addPerm(agent_name, access, access_label, agent_type)
   {
@@ -114,7 +126,11 @@ Blacklight.onLoad(function() {
   }
 
   function addHiddenPermField(element, type, name, access) {
-      var prefix = 'generic_file[permissions_attributes][' + nextIndex() + ']';
+      var prefix = 'generic_file';
+      if (($("[id=new_collection]").length) || ($("[id^=edit_collection]").length)) {
+          prefix = 'collection';
+      }
+      prefix += '[permissions_attributes][' + nextIndex() + ']';
       $('<input>').attr({
           type: 'hidden',
           name: prefix + '[type]',
@@ -145,13 +161,17 @@ Blacklight.onLoad(function() {
   });
 
   function showPermissionNote() {
-     $('#save_perm_note').removeClass('hidden');
+      $('#save_perm_note').removeClass('hidden');
   }
 
   function addDestroyField(element, index) {
+      var prefix = 'generic_file';
+      if (($("[id=new_collection]").length) || ($("[id^=edit_collection]").length)) {
+          prefix = 'collection';
+      }
       $('<input>').attr({
           type: 'hidden',
-          name: 'generic_file[permissions_attributes][' + index + '][_destroy]',
+          name: prefix + '[permissions_attributes][' + index + '][_destroy]',
           value: 'true'
       }).appendTo(element);
   }
@@ -169,6 +189,10 @@ function get_visibility() {
  * visibility of Open or Institution) so disable the Read option
  */
 function set_access_levels() {
+  var permissions_fld = 'generic_file[permissions]';
+  if (($("[id=new_collection]").length) || ($("[id^=edit_collection]").length)) {
+    permissions_fld = 'collection[permissions]';
+  }
   var vis = get_visibility();
   var enabled_disabled = false;
   if (vis == "open" || vis == "psu") {
@@ -176,7 +200,7 @@ function set_access_levels() {
   }
   $('#new_group_permission_skel option[value=read]').attr("disabled", enabled_disabled);
   $('#new_user_permission_skel option[value=read]').attr("disabled", enabled_disabled);
-  var perms_sel = $("select[name^='generic_file[permissions]']");
+  var perms_sel = $("select[name^=permissions_fld]");
   $.each(perms_sel, function(index, sel_obj) {
     $.each(sel_obj, function(j, opt) {
       if( opt.value == "read") {
@@ -192,10 +216,14 @@ function set_access_levels() {
  */
 function is_permission_duplicate(user_or_group_name)
 {
+  var permissions_fld = 'generic_file[permissions]';
+  if (($("[id=new_collection]").length) || ($("[id^=edit_collection]").length)) {
+    permissions_fld = 'collection[permissions]';
+  }
   s = "[" + user_or_group_name + "]";
   var patt = new RegExp(preg_quote(s), 'gi');
-  var perms_input = $("input[name^='generic_file[permissions]']");
-  var perms_sel = $("select[name^='generic_file[permissions]']");
+  var perms_input = $("input[name^=permissions_fld]");
+  var perms_sel = $("select[name^=permissions_fld]");
   var flag = 1;
   perms_input.each(function(index, form_input) {
       // if the name is already being used - return false (not valid)

--- a/app/controllers/my/shared_collections_controller.rb
+++ b/app/controllers/my/shared_collections_controller.rb
@@ -1,0 +1,19 @@
+module My
+  class SharedCollectionsController < MyController
+    self.search_params_logic += [
+      :show_only_shared_collections,
+      :show_only_collections
+    ]
+
+    def index
+      super
+      @selected_tab = :shared_collections
+    end
+
+    protected
+
+      def search_action_url(*args)
+        sufia.dashboard_shared_collections_url(*args)
+      end
+  end
+end

--- a/app/forms/sufia/forms/collection_edit_form.rb
+++ b/app/forms/sufia/forms/collection_edit_form.rb
@@ -2,6 +2,8 @@ module Sufia
   module Forms
     class CollectionEditForm
       include HydraEditor::Form
+      include HydraEditor::Form::Permissions
+
       self.model_class = ::Collection
       self.terms = [:resource_type, :title, :creator, :contributor, :description, :tag, :rights,
                     :publisher, :date_created, :subject, :language, :identifier, :based_near, :related_url, :visibility]

--- a/app/helpers/batch_edits_helper.rb
+++ b/app/helpers/batch_edits_helper.rb
@@ -6,6 +6,6 @@ module BatchEditsHelper
   end
 
   def render_check_all
-    render partial: 'batch_edits/check_all' unless params[:controller] =~ /my\/collections/
+    render partial: 'batch_edits/check_all' unless params[:controller] =~ /my\/.*collections/
   end
 end

--- a/app/helpers/sufia/dashboard_helper_behavior.rb
+++ b/app/helpers/sufia/dashboard_helper_behavior.rb
@@ -40,6 +40,10 @@ module Sufia
       params[:controller].match(/^my\/files/)
     end
 
+    def on_my_shared_files?
+      params[:controller].match(/^my\/shares/)
+    end
+
     def number_of_files(user = current_user)
       ::GenericFile.where(Solrizer.solr_name('depositor', :symbol) => user.user_key).count
     end

--- a/app/helpers/sufia/permissions_helper.rb
+++ b/app/helpers/sufia/permissions_helper.rb
@@ -1,11 +1,11 @@
 module Sufia
   module PermissionsHelper
     def visibility_help
-      help_link('generic_files/visibility', 'Visibility', 'Useage information for visibility')
+      help_link('generic_files/visibility', 'Visibility', 'Usage information for visibility')
     end
 
     def share_with_help
-      help_link('generic_files/share_with', 'Share With', 'Useage information for sharing')
+      help_link('generic_files/share_with', 'Share With', 'Usage information for sharing')
     end
 
     private

--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -209,6 +209,8 @@ module Sufia
           sufia.dashboard_shares_path
         when "my/highlights"
           sufia.dashboard_highlights_path
+        when "my/shared_collections"
+          sufia.dashboard_shared_collections_path
         else
           sufia.dashboard_files_path
         end

--- a/app/presenters/sufia/collection_presenter.rb
+++ b/app/presenters/sufia/collection_presenter.rb
@@ -11,7 +11,7 @@ module Sufia
 
     # Depositor and permissions are not displayed in app/views/collections/_show_descriptions.html.erb
     # so don't include them in `terms'.
-    # delegate :depositor, :permissions, to: :model
+    delegate :depositor, :permissions, to: :model
 
     def terms_with_values
       terms.select { |t| self[t].present? }

--- a/app/search_builders/sufia/search_builder.rb
+++ b/app/search_builders/sufia/search_builder.rb
@@ -9,6 +9,13 @@ module Sufia::SearchBuilder
     ]
   end
 
+  def show_only_shared_collections(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: scope.current_user.user_key)
+    ]
+  end
+
   def show_only_resources_deposited_by_current_user(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += [

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -40,6 +40,10 @@
                   <%= link_to t("sufia.search.form.option.my_shares.label_long"), "#",
                       data: { "search-option" => sufia.dashboard_shares_path, "search-label" => t("sufia.search.form.option.my_shares.label_short") } %>
                 </li>
+                <li>
+                  <%= link_to t("sufia.search.form.option.my_shared_collections.label_long"), "#",
+                              data: { "search-option" => sufia.dashboard_shared_collections_path, "search-label" => t("sufia.search.form.option.my_shared_collections.label_short") } %>
+                </li>
               <% end %>
 
             </ul>

--- a/app/views/collections/_permission_form.html.erb
+++ b/app/views/collections/_permission_form.html.erb
@@ -25,5 +25,87 @@
     </label>
   </div>
 
+  <!-- Share With -->
+  <div class="row">
+    <h3 class="col-sm-12">Share With <small>(optional)</small>
+      <span id="share_with_tooltip" class="h5"><%= share_with_help %></span>
+    </h3>
+  </div>
+
+  <div class="form-group row">
+    <div id="new-user">
+      <p class="col-sm-12">Enter <%=t('sufia.account_label') %> (one at a time)</p>
+      <p class="sr-only">Use the add button to give access to one <%=t('sufia.account_label') %> at a time (it will be added to the list below).  Select the user, by name or <%=t('sufia.account_label') %>. Then select the access level you wish to grant and click on Add this <%= t('sufia.account_label') %> to complete adding the permission.</p>
+      <div class="col-sm-5">
+        <label for="new_user_name_skel" class="sr-only"><%= t('sufia.account_label') %> (without the <%= t('sufia.directory.suffix') %> part)</label>
+        <%= text_field_tag 'new_user_name_skel', nil %>
+      </div>
+      <div class="col-sm-4">
+        <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
+        <%= select_tag 'new_user_permission_skel', options_for_select(Sufia.config.permission_levels), class: 'form-control' %>
+      </div>
+      <div class="col-sm-3">
+        <button class="btn btn-mini btn-inverse" id="add_new_user_skel">
+          <span class="sr-only">Add this <%= t('sufia.account_label') %></span>
+          <span aria-hidden="true"><i class="glyphicon glyphicon-plus"></i></span>
+        </button>
+        <br /> <span id="directory_user_result"></span>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <div id="new-group" >
+      <p class="sr-only">Use the add button to give access to one group at a time (it will be added to the list below).</p>
+      <div class="col-sm-5">
+        <label for="new_group_name_skel" class="sr-only">Group</label>
+        <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
+      </div>
+      <div class="col-sm-4">
+        <label for="new_group_permission_skel" class="sr-only">Access type to grant</label>
+        <%= select_tag 'new_group_permission_skel', options_for_select(Sufia.config.permission_levels), class: 'form-control' %>
+      </div>
+      <div class="col-sm-3">
+        <span class="sr-only">Add this group</span>
+        <button class="btn btn-mini btn-inverse" id="add_new_group_skel"><i class="glyphicon glyphicon-plus"></i></button>
+        <br /><span id="directory_group_result"></span>
+      </div>
+    </div>
+  </div>
+
 </div><!-- /.well -->
 
+<table class="table table-bordered">
+  <tr>
+    <th width="60%">Person/Group</th>
+    <th width="40%">Access Level</th>
+  </tr>
+  <tr id="file_permissions">
+    <td>
+      <%= label_tag :owner_access, class: "control-label" do %>
+        Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
+      <% end %>
+    </td>
+    <td>
+      <%= Sufia.config.owner_permission_levels.keys[0] %>
+    </td>
+  </tr>
+  <% x=1 %>
+  <% f.model.permissions.each do |permission_fields| %>
+    <%# skip the public, penn state (aka registered), and depositor perms as they are displayed first at the top %>
+    <% next if ['public', 'registered', depositor].include? permission_fields.agent_name.downcase %>
+    <tr>
+      <td><%= label_tag :owner_access, class: "control-label" do %>
+        <%= user_display_name_and_key(permission_fields.agent_name) %>
+      <% end %></td>
+      <td>
+        <div class="col-sm-8">
+          <%= select_tag "collection[permissions_attributes][#{x}][access]", options_for_select(Sufia.config.permission_levels, permission_fields.access), class: 'form-control select_perm', id: "collection_permission_attributes_#{x}_access" %>
+        </div>
+        <button class="btn close remove_perm" data-index="<%= x %>">X</button>
+      </td>
+    </tr>
+    <%= hidden_field_tag "collection[permissions_attributes][#{x}][id]", permission_fields.id, id: "collection_permission_attributes_#{x}_id" %>
+    <% x+=1 %>
+  <% end %>
+</table>

--- a/app/views/my/_sort_and_per_page.html.erb
+++ b/app/views/my/_sort_and_per_page.html.erb
@@ -3,7 +3,7 @@
     <%= render partial: 'collections/form_for_select_collection', locals: {user_collections: @user_collections}  %>
   </div>
 
-  <% if on_my_files? %>
+  <% if on_my_files? || on_my_shared_files? %>
     <div class="batch-toggle">
       <% session[:batch_edit_state] = "on" %>
       <div class="button_to-inline">

--- a/app/views/my/index.html.erb
+++ b/app/views/my/index.html.erb
@@ -25,6 +25,9 @@
   <li class="<%= "active" if @selected_tab == :shared %>">
     <%= link_to t('sufia.dashboard.my.shares'), sufia.dashboard_shares_path %>
   </li>
+  <li class="<%= "active" if @selected_tab == :shared_collections %>">
+    <%= link_to t('sufia.dashboard.my.shared_collections'), sufia.dashboard_shared_collections_path %>
+  </li>
 </ul>
 
 <%= render 'search_header' %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -29,8 +29,11 @@ en:
             label_short:  "My Highlights"
             label_long:   "My Highlights"
           my_shares:
-            label_short:  "My Shares"
-            label_long:   "My Shares"
+            label_short:  "My Shared Files"
+            label_long:   "My Shared Files"
+          my_shared_collections:
+            label_short:  "My Shared Collections"
+            label_long:   "My Shared Collections"
       button:
         html: '<span class="glyphicon glyphicon-search"></span> Go'
         text: "Search"
@@ -92,15 +95,17 @@ en:
         following:          "People you follow"
         followers:          "People who are following you"
       my:
-        files:        "My Files"
-        collections:  "My Collections"
-        highlights:   "My Highlights"
-        shares:       "Files Shared with Me"
+        files:              "My Files"
+        collections:        "My Collections"
+        highlights:         "My Highlights"
+        shares:             "Files Shared with Me"
+        shared_collections: "Collections Shared with Me"
         facet_label:
-          files:        "Filter your files"
-          collections:  "Filter your collections"
-          highlighted: "Filter your highlights"
-          shared:      "Filter your shares"
+          files:              "Filter your files"
+          collections:        "Filter your collections"
+          highlighted:        "Filter your highlights"
+          shared:             "Filter your shared files"
+          shared_collections: "Filter your shared collections"
         sr:
           show_label:     "Display all details of"
           detail_label:   "Display summary details of"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Sufia::Engine.routes.draw do
     end
   end
 
-  # Routes for user's files, collections, highlights and shares
+  # Routes for user's files, collections, highlights, shares (files and collections)
   # Preserves existing behavior by maintaining paths to /dashboard
   # Routes actions to the various My controllers
   scope :dashboard do
@@ -83,6 +83,10 @@ Sufia::Engine.routes.draw do
     get '/shares',            controller: 'my/shares', action: :index, as: 'dashboard_shares'
     get '/shares/page/:page', controller: 'my/shares', action: :index
     get '/shares/facet/:id',  controller: 'my/shares', action: :facet, as: 'dashboard_shares_facet'
+
+    get '/shares/collections',            controller: 'my/shared_collections', action: :index, as: 'dashboard_shared_collections'
+    get '/shares/collections/page/:page', controller: 'my/shared_collections', action: :index
+    get '/shares/collections/facet/:id',  controller: 'my/shared_collections', action: :facet, as: 'dashboard_shared_collections_facet'
   end
 
   # advanced routes for advanced search

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -34,6 +34,8 @@ describe DashboardHelper, type: :helper do
       expect(helper).to be_on_the_dashboard
       allow(helper).to receive(:params).and_return(controller: "my/shares")
       expect(helper).to be_on_the_dashboard
+      allow(helper).to receive(:params).and_return(controller: "my/shared_collections")
+      expect(helper).to be_on_the_dashboard
     end
   end
 

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -98,7 +98,7 @@ describe SufiaHelper, type: :helper do
         expect(helper.current_search_parameters).to be_nil
       end
 
-      it "is ignored on dashboard files, collections, highlights and shares" do
+      it "is ignored on dashboard files, collections, highlights and shares (files and collections)" do
         allow(helper).to receive(:params).and_return(controller: "my/files", q: "foo")
         expect(helper.current_search_parameters).to be_nil
         allow(helper).to receive(:params).and_return(controller: "my/collections", q: "foo")
@@ -106,6 +106,8 @@ describe SufiaHelper, type: :helper do
         allow(helper).to receive(:params).and_return(controller: "my/highlights", q: "foo")
         expect(helper.current_search_parameters).to be_nil
         allow(helper).to receive(:params).and_return(controller: "my/shares", q: "foo")
+        expect(helper.current_search_parameters).to be_nil
+        allow(helper).to receive(:params).and_return(controller: "my/shared_collections", q: "foo")
         expect(helper.current_search_parameters).to be_nil
       end
     end
@@ -151,6 +153,13 @@ describe SufiaHelper, type: :helper do
       it "returns the my dashboard shares path" do
         allow(helper).to receive(:params).and_return(controller: "my/shares")
         expect(helper.search_form_action).to eq(sufia.dashboard_shares_path)
+      end
+    end
+
+    context "when the user is on the my shared collections page" do
+      it "returns the my dashboard shared_collections path" do
+        allow(helper).to receive(:params).and_return(controller: "my/shared_collections")
+        expect(helper.search_form_action).to eq(sufia.dashboard_shared_collections_path)
       end
     end
   end

--- a/spec/lib/sufia/export/collection_converter_spec.rb
+++ b/spec/lib/sufia/export/collection_converter_spec.rb
@@ -26,5 +26,15 @@ describe Sufia::Export::CollectionConverter do
       let(:json) { "{\"id\":\"#{collection.id}\",\"title\":\"title1\",\"description\":\"description1\",\"creator\":[\"creator1\"],\"members\":[\"#{file1.id}\",\"#{file2.id}\"],\"permissions\":[{\"id\":\"#{permission.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#public\",\"mode\":\"http://www.w3.org/ns/auth/acl#Read\",\"access_to\":\"#{collection.id}\"},{\"id\":\"#{permission2.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#jilluser@example.com\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{collection.id}\"}]}" }
       it { is_expected.to eq(json) }
     end
+
+    context "with write groups" do
+      subject { described_class.new(private_collection).to_json }
+      let(:private_collection) { create(:private_collection, title: "title2", creator: ["creator2"], description: "description2", user: user1, edit_groups: ["group1", "group2"]) }
+      let(:permission1) { private_collection.permissions.first }
+      let(:permission2) { private_collection.permissions.second }
+      let(:permission3) { private_collection.permissions.last }
+      let(:json) { "{\"id\":\"#{private_collection.id}\",\"title\":\"title2\",\"description\":\"description2\",\"creator\":[\"creator2\"],\"members\":[],\"permissions\":[{\"id\":\"#{permission1.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#group1\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{private_collection.id}\"},{\"id\":\"#{permission2.id}\",\"agent\":\"http://projecthydra.org/ns/auth/group#group2\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{private_collection.id}\"},{\"id\":\"#{permission3.id}\",\"agent\":\"http://projecthydra.org/ns/auth/person#jilluser@example.com\",\"mode\":\"http://www.w3.org/ns/auth/acl#Write\",\"access_to\":\"#{private_collection.id}\"}]}" }
+      it { is_expected.to eq json }
+    end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -67,4 +67,123 @@ describe Collection, type: :model do
       end
     end
   end
+
+  describe "attributes" do
+    it "has a set of permissions" do
+      private_collection.read_groups = ['group1', 'group2']
+      private_collection.edit_users = ['user1']
+      private_collection.read_users = ['user2', 'user3']
+      expect(private_collection.permissions.map(&:to_hash)).to match_array [
+        { type: "group", access: "read", name: "group1" },
+        { type: "group", access: "read", name: "group2" },
+        { type: "person", access: "read", name: "user2" },
+        { type: "person", access: "read", name: "user3" },
+        { type: "person", access: "edit", name: "user1" }]
+    end
+  end
+
+  context "with access control metadata" do
+    subject do
+      described_class.new do |m|
+        m.apply_depositor_metadata('jcoyne')
+        m.permissions_attributes = [{ type: 'person', access: 'read', name: "person1" },
+                                    { type: 'person', access: 'read', name: "person2" },
+                                    { type: 'group', access: 'read', name: "group-6" },
+                                    { type: 'group', access: 'read', name: "group-7" },
+                                    { type: 'group', access: 'edit', name: "group-8" }]
+      end
+    end
+
+    it "has read groups accessor" do
+      expect(subject.read_groups).to eq ['group-6', 'group-7']
+    end
+
+    it "has read groups string accessor" do
+      expect(subject.read_groups_string).to eq 'group-6, group-7'
+    end
+
+    it "has read groups writer" do
+      subject.read_groups = ['group-2', 'group-3']
+      expect(subject.read_groups).to eq ['group-2', 'group-3']
+    end
+
+    it "has read groups string writer" do
+      subject.read_groups_string = 'umg/up.dlt.staff, group-3'
+      expect(subject.read_groups).to eq ['umg/up.dlt.staff', 'group-3']
+      expect(subject.edit_groups).to eq ['group-8']
+      expect(subject.read_users).to eq ['person1', 'person2']
+      expect(subject.edit_users).to eq ['jcoyne']
+    end
+
+    it "only revokes eligible groups" do
+      subject.set_read_groups(['group-2', 'group-3'], ['group-6'])
+      # 'group-7' is not eligible to be revoked
+      expect(subject.read_groups).to match_array ['group-2', 'group-3', 'group-7']
+      expect(subject.edit_groups).to eq ['group-8']
+      expect(subject.read_users).to match_array ['person1', 'person2']
+      expect(subject.edit_users).to eq ['jcoyne']
+    end
+  end
+
+  describe "permissions validation" do
+    before do
+      subject.apply_depositor_metadata('mjg36')
+      subject.title = 'Test Title'
+    end
+
+    describe "overriding" do
+      let(:asset) { SampleKlass.new }
+      before do
+        class SampleKlass < GenericFile
+          def paranoid_edit_permissions
+            []
+          end
+        end
+        asset.apply_depositor_metadata('mjg36')
+      end
+      after do
+        Object.send(:remove_const, :SampleKlass)
+      end
+      context "when public has edit access" do
+        before { asset.edit_groups = ['public'] }
+        it "is valid" do
+          expect(asset).to be_valid
+        end
+      end
+    end
+
+    context "when the depositor does not have edit access" do
+      before do
+        subject.permissions = [Hydra::AccessControls::Permission.new(type: 'person', name: 'mjg36', access: 'read')]
+      end
+      it "is invalid" do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:edit_users]).to include('Depositor must have edit access')
+      end
+    end
+
+    context "when the public has edit access" do
+      before { subject.edit_groups = ['public'] }
+
+      it "is invalid" do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:edit_groups]).to include('Public cannot have edit access')
+      end
+    end
+
+    context "when registered has edit access" do
+      before { subject.edit_groups = ['registered'] }
+
+      it "is invalid" do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:edit_groups]).to include('Registered cannot have edit access')
+      end
+    end
+
+    context "everything is copacetic" do
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+  end
 end

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -91,6 +91,10 @@ describe 'Routes', type: :routing do
     it "routes to my shared tab" do
       expect(get: '/dashboard/shares').to route_to(controller: 'my/shares', action: 'index')
     end
+
+    it "routes to my shared_collections tab" do
+      expect(get: '/dashboard/shares/collections').to route_to(controller: 'my/shared_collections', action: 'index')
+    end
   end
 
   describe 'Advanced Search' do

--- a/spec/views/collections/_permission_form.html.erb_spec.rb
+++ b/spec/views/collections/_permission_form.html.erb_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'collections/_permission_form.html.erb', type: :view do
+  let(:collection) do
+    stub_model(Collection, id: '123',
+                           depositor: 'bob',
+                           resource_type: ['Dataset'])
+  end
+
+  let(:form) do
+    form_for(collection, url: '/update') do |col_form|
+      return col_form
+    end
+  end
+
+  before do
+    allow(form).to receive(:model).and_return(collection)
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    allow(collection).to receive(:permissions).and_return(permissions)
+    allow(view).to receive(:f).and_return(form)
+    render
+  end
+
+  context "without additional users" do
+    let(:permissions) { [] }
+
+    it "draws the permissions form without error" do
+      expect(rendered).to have_css("input#new_user_name_skel")
+      expect(rendered).not_to have_css("button.remove_perm")
+    end
+  end
+
+  context "with additional users" do
+    let(:depositor_permission) { Hydra::AccessControls::Permission.new(id: '123', name: 'bob', type: 'person', access: 'edit') }
+    let(:public_permission) { Hydra::AccessControls::Permission.new(id: '124', name: 'public', type: 'group', access: 'read') }
+    let(:other_permission) { Hydra::AccessControls::Permission.new(id: '125', name: 'joe@example.com', type: 'person', access: 'edit') }
+    let(:permissions) { [depositor_permission, public_permission, other_permission] }
+
+    it "draws the permissions form without error" do
+      expect(rendered).to have_css("input#new_user_name_skel")
+      expect(rendered).to have_css("button.remove_perm", count: 1) # depositor and public should be filtered out
+      # expect(rendered).to have_css("button.remove_perm[data-index='2']")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2709
Version: v6.x-stable

Add ability for users to share collections with users/groups giving edit/read access to collections they created.

UI Changes:
* On **New/Edit Collection** screen, add permissions form for selecting user/group to add edit/read permissions.
* On **Dashboard**, add tab **Collections Shared With Me** and list all collections shared with the current user where access is edit.  (NOTE: Limiting to those with edit access is consistent **Files Shared With Me** tab.)
* On **Dashboard** -> **My Files** tab, when users selects multiple files and chooses **Add to Collection**, allow user to select collections shared with edit access for the current user
* On **Dashboard** -> **Files Shared With Me** tab, when users selects multiple files and chooses Add to Collection, allow user to select collections shared with edit access for the current user

User with edit/read access can:
* View show page for shared collections
* Discover shared collections in search

User with edit access can:
  * add generic files to collection
  * remove generic files from collection
  * modify collection metadata

@projecthydra/sufia-code-reviewers

Screen shots to be added soon.