### PR TITLE
Notify admins when mediated works are created

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -113,4 +113,5 @@ RSpec/AnyInstance:
     - 'spec/presenters/sufia/work_usage_spec.rb'
     - 'spec/presenters/sufia/file_usage_spec.rb'
     - 'spec/services/sufia/repository_audit_service_spec.rb'
+    - 'spec/actors/sufia/create_with_files_actor_spec.rb'
 


### PR DESCRIPTION
Fixes #2627 ; refs #2627 

I need some advice on the one failing test in this branch at https://github.com/projecthydra/sufia/compare/mediated_deposit_epic...2627-mediated-user-notification#diff-9b011f9abccd87bc7d1df0443a0e26d8R68

When someone creates a mediated work, all users with the *admin* role should receive a notification that the work has been created.  The code works, but I'm having trouble testing that a user is an admin since we don't include roles by default in sufia.  I stubbed `.admin?` but that doesn't work because my code in `receiving_users` cycles through User.find_each instead of using the stubbed instance.  **So how do I have an admin user to test with in the database when we don't include hydra-role-management by default?**  Is there a way to stub .admin? in ActiveRecord so that it persists in the test db?  Thanks

@projecthydra/sufia-code-reviewers

