### PR TITLE
shared works should not be available if in mediated deposit and inact…

### DIFF
--- a/app/search_builders/sufia/my_shares_search_builder.rb
+++ b/app/search_builders/sufia/my_shares_search_builder.rb
@@ -9,5 +9,7 @@ class Sufia::MySharesSearchBuilder < Sufia::SearchBuilder
     solr_parameters[:fq] += [
       "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: scope.current_user.user_key)
     ]
+
+    solr_parameters[:fq] += ['-suppressed_bsi:true'] if Flipflop.enable_mediated_deposit?
   end
 end

--- a/spec/search_builder/sufia/my_shares_search_builder_spec.rb
+++ b/spec/search_builder/sufia/my_shares_search_builder_spec.rb
@@ -8,18 +8,42 @@ describe Sufia::MySharesSearchBuilder do
                        current_user: me) }
   let(:builder) { described_class.new(scope) }
 
+  let(:solr_params) { { q: user_query } }
+
   before do
     allow(builder).to receive(:gated_discovery_filters).and_return(["access_filter1", "access_filter2"])
     allow(ActiveFedora::SolrQueryBuilder).to receive(:construct_query_for_rel)
       .with(depositor: me.user_key)
       .and_return("depositor")
+    allow(Flipflop).to receive(:enable_mediated_deposit?).and_return(mediation_enabled)
   end
 
+  let(:mediation_enabled) { false }
   subject { builder.to_hash['fq'] }
 
   it "filters things we have access to in which we are not the depositor" do
     expect(subject).to eq ["access_filter1 OR access_filter2",
                            "{!terms f=has_model_ssim}GenericWork,Collection",
                            "-depositor"]
+  end
+
+  describe "mediated deposit" do
+    let(:user_query) { nil }
+
+    context "with mediated deposit enabled" do
+      let(:mediation_enabled) { true }
+      it "does includes suppressed switch" do
+        builder.show_only_shared_files(solr_params)
+        expect(solr_params[:fq]).to eq ["-depositor", "-suppressed_bsi:true"]
+      end
+    end
+
+    context "with mediated deposit disabled" do
+      let(:mediation_enabled) { false }
+      it "does not include suppressed switch" do
+        builder.show_only_shared_files(solr_params)
+        expect(solr_params[:fq]).to eq ["-depositor"]
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request is to address issue #2728 .  With this change when a work is shared, and the work is inactive and mediated deposit is enabled, the work is not available from the Dashboard/Shares page until the work is no longer inactive.  

Issue #2728 also talks about not having notifications sent out, but I did not see any notifications sent out when not in mediated deposit, and the work is shared and published, so I think for now there is no change needed regarding this.