### PR TITLE
Prevent turbolinks from carying admin styles to the main site

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -10,7 +10,7 @@
         <!-- END META SECTION -->
 
         <!-- CSS INCLUDE -->
-        <%= stylesheet_link_tag 'sufia/admin' %>
+        <%= stylesheet_link_tag 'sufia/admin', data: { turbolinks_track: 'reload' } %>
         <!-- EOF CSS INCLUDE -->
     </head>
     <body>


### PR DESCRIPTION

Fixes #2740
See
https://github.com/turbolinks/turbolinks#reloading-when-assets-change