### PR TITLE
Remove unnecessary include

### DIFF
--- a/app/controllers/concerns/sufia/homepage_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/homepage_controller_behavior.rb
@@ -3,9 +3,7 @@ module Sufia::HomepageControllerBehavior
 
   included do
     # Adds Hydra behaviors into the application controller
-    include Hydra::Controller::ControllerBehavior
     include Blacklight::SearchContext
-    include Sufia::Controller
     include Blacklight::SearchHelper
     include Blacklight::AccessControls::Catalog
 

--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -2,7 +2,6 @@ module Sufia
   module WorksControllerBehavior
     extend ActiveSupport::Concern
     include Sufia::Breadcrumbs
-    include Sufia::Controller
     include CurationConcerns::CurationConcernController
 
     included do

--- a/app/controllers/curation_concerns/file_sets_controller.rb
+++ b/app/controllers/curation_concerns/file_sets_controller.rb
@@ -1,7 +1,6 @@
 module CurationConcerns
   class FileSetsController < ApplicationController
     include CurationConcerns::FileSetsControllerBehavior
-    include Sufia::Controller
     include Sufia::FileSetsControllerBehavior
   end
 end


### PR DESCRIPTION
`include Sufia::Controller` is already added to ApplicationController, so there's no reason to re-include it on controllers that extend from ApplicationController