### PR TITLE
Statistic.ga_statistics should check for a nil profile

### DIFF
--- a/app/models/sufia/statistic.rb
+++ b/app/models/sufia/statistic.rb
@@ -32,7 +32,12 @@ module Sufia
       # see Legato::ProfileMethods.method_name_from_klass
       def ga_statistics(start_date, object)
         path = polymorphic_path(object)
-        Sufia::Analytics.profile.sufia__pageview(sort: 'date', start_date: start_date).for_path(path)
+        profile = Sufia::Analytics.profile
+        unless profile
+          Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
+          return []
+        end
+        profile.sufia__pageview(sort: 'date', start_date: start_date).for_path(path)
       end
 
       private

--- a/spec/models/work_view_stat_spec.rb
+++ b/spec/models/work_view_stat_spec.rb
@@ -17,15 +17,24 @@ RSpec.describe WorkViewStat, type: :model do
 
   describe ".ga_statistic" do
     let(:start_date) { 2.days.ago }
-    let(:views) { double }
-    let(:profile) { double(sufia__pageview: views) }
     let(:expected_path) { Rails.application.routes.url_helpers.curation_concerns_generic_work_path(work) }
     before do
       allow(Sufia::Analytics).to receive(:profile).and_return(profile)
     end
-    it "calls the Legato method with the correct path" do
-      expect(views).to receive(:for_path).with(expected_path)
-      described_class.ga_statistics(start_date, work)
+    context "when a profile is available" do
+      let(:views) { double }
+      let(:profile) { double(sufia__pageview: views) }
+      it "calls the Legato method with the correct path" do
+        expect(views).to receive(:for_path).with(expected_path)
+        described_class.ga_statistics(start_date, work)
+      end
+    end
+
+    context "when a profile not available" do
+      let(:profile) { nil }
+      it "calls the Legato method with the correct path" do
+        expect(described_class.ga_statistics(start_date, work)).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
This avoids a: `NoMethodError: undefined method 'sufia__pageview' for nil:NilClass` if google analytics isn't set up.