### PR TITLE
Give the language a default so it doesn't break html

### DIFF
--- a/app/views/layouts/curation_concerns/1_column.html.erb
+++ b/app/views/layouts/curation_concerns/1_column.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= t("sufia.document_language") %>" prefix="og:http://ogp.me/ns#">
+<html lang="<%= t("sufia.document_language", default: '') %>" prefix="og:http://ogp.me/ns#">
   <head>
     <%= render partial: 'layouts/head_tag_content' %>
   </head>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= t("sufia.document_language") %>">
+<html lang="<%= t("sufia.document_language", default: '') %>">
 <head>
   <%= render "layouts/head_tag_content"%>
 </head>

--- a/app/views/layouts/sufia-dashboard.html.erb
+++ b/app/views/layouts/sufia-dashboard.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= t("sufia.document_language") %>">
+<html lang="<%= t("sufia.document_language", default: '') %>">
 <head><%= render 'layouts/head_tag_content' %></head>
 <body>
 <a href="#skip_to_content" class="sr-only">Skip to Content</a>


### PR DESCRIPTION
Otherwise it puts a span tag in the lang attribute.

```html
<html lang="<span class="translation_missing" title="translation
missing: es.sufia.document_language">Document Language</span>">
```