### PR TITLE
Adding FileSet, Permission and Version builders

### DIFF
--- a/lib/sufia.rb
+++ b/lib/sufia.rb
@@ -19,6 +19,7 @@ require 'curation_concerns'
 require 'sufia/engine'
 require 'sufia/version'
 require 'sufia/inflections'
+require 'sufia/import'
 require 'kaminari_route_prefix'
 
 module Sufia

--- a/lib/sufia/import.rb
+++ b/lib/sufia/import.rb
@@ -1,0 +1,10 @@
+require 'sufia/import/builder'
+require 'sufia/import/permission_builder'
+require 'sufia/import/version_builder'
+require 'sufia/import/file_set_builder'
+
+module Sufia
+  module Permissions
+    VERSION = Sufia::VERSION
+  end
+end

--- a/lib/sufia/import/builder.rb
+++ b/lib/sufia/import/builder.rb
@@ -1,0 +1,25 @@
+module Sufia
+  module Import
+    # An abstract class to Build an object
+    #
+    class Builder
+      attr_reader :settings, :import_binary, :sufia6_user, :sufia6_password
+
+      # @param Hash settings
+      #        @attr sufia6_user      - User name for accessing the sufia 6 fedora
+      #        @attr sufia6_password  - Password for accessing the sufia 6 fedora
+      #        @attr import_binary    - (default true) Import the binaryt content from fedora
+      def initialize(settings)
+        @settings = settings
+        @import_binary = settings[:import_binary]
+        @import_binary ||= true
+        @sufia6_user = settings[:sufia6_user]
+        @sufia6_password = settings[:sufia6_password]
+      end
+
+      def build(_generic_file_metadata)
+        raise "need to override"
+      end
+    end
+  end
+end

--- a/lib/sufia/import/file_set_builder.rb
+++ b/lib/sufia/import/file_set_builder.rb
@@ -1,0 +1,45 @@
+# Builder for generating a File set incluing permissions and versions
+#
+module Sufia::Import
+  class FileSetBuilder < Builder
+    attr_reader :file_set, :permission_builder, :version_builder
+
+    # @param settings see Sufia::Import::Builder for settings
+    def initialize(settings)
+      super
+      @file_set = FileSet.new
+      @permission_builder = PermissionBuilder.new(settings, file_set)
+      @version_builder = VersionBuilder.new(settings, file_set)
+    end
+
+    # Build a FileSet from GenericFile metadata
+    #
+    # @param OpenStruct generic_file_metadata metadata from the generic_file in OpenStruct format
+    #    <OpenStruct id="44558d49x", label="my label", depositor="cam156@psu.edu", arkivo_checksum="arkivo checksum",
+    #                relative_path="relative path", import_url="import url", resource_type=["resource type"],
+    #                title=["My Great File"], creator=["cam156@psu.edu"], contributor=["contributor1", "contribnutor2"],
+    #                description=["description of the file"], tag=["tag1", "tag2"], rights=["Attribution 3.0"],
+    #                publisher=["publisher joe"], date_created=["a long time ago"], date_uploaded="2015-09-28T20:00:14.243+00:00",
+    #                date_modified="2015-10-28T20:00:14.243+00:00", subject=["subject 1", "subject 2"], language=["WA Language WA"],
+    #                identifier=["You ID ME"], based_near=["Kalamazoo"], related_url=["abc123.org"], bibliographic_citation=["cite me"],
+    #                source=["source of me"], batch_id="qn59q409q", visibility="restricted",
+    #                versions=[#<OpenStruct uri="http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version1",
+    #                          created="2016-09-28T20:00:14.658Z", label="version1">, ...],
+    #                permissions=[#<OpenStruct id="b5911dfd-07b1-43ab-b11d-1bc0534d874c", agent="http://projecthydra.org/ns/auth/person#cam156@psu.edu", mode="http://www.w3.org/ns/auth/acl#Write", access_to="44558d49x">...]>
+    def build(generic_file_metadata)
+      file_set.title << generic_file_metadata.title
+      # Where did the filename property go?
+      # file_set.filename = generic_file_metadata.filename
+      file_set.label = generic_file_metadata.label
+      file_set.date_uploaded = generic_file_metadata.date_uploaded
+      file_set.date_modified = generic_file_metadata.date_modified
+      file_set.apply_depositor_metadata(generic_file_metadata.depositor)
+      permission_builder.build(generic_file_metadata.permissions)
+
+      # File
+      version_builder.build(generic_file_metadata.versions) if import_binary
+
+      file_set
+    end
+  end
+end

--- a/lib/sufia/import/permission_builder.rb
+++ b/lib/sufia/import/permission_builder.rb
@@ -1,0 +1,46 @@
+# Create permissions on a Work or FileSet
+module Sufia::Import
+  class PermissionBuilder < Builder
+    attr_reader :object
+
+    # @param Hash       settings see Sufia::Import::Builder for settings
+    # @param PCDMObject object   Object for the permissions to be applied to
+    #
+    def initialize(settings, object)
+      super(settings)
+      @object = object
+    end
+
+    # Build permissions on a FileSet or a work based on the metadata from GenericFile
+    #
+    #  @param Array[OpenStruct] generic_file_perms An array of OpenStrucs with the below attributes
+    #     @attr agent    - Agent that has permisisons; example: "http://projecthydra.org/ns/auth/person#user1@example.com"
+    #     @attr mode     - access acl; example: "http://www.w3.org/ns/auth/acl#Write"
+    #     @attr acces_to - not used - Permissions are added to the object passed in the initializer
+    #     @attr id       - not used - Id for the permissions is generated
+    def build(generic_file_perms)
+      generic_file_perms.each do |gf_perm|
+        create(gf_perm)
+      end
+    end
+
+    private
+
+      def create(gf_perm)
+        return if permission_exists(gf_perm)
+        # agent = http://projecthydra.org/ns/auth/person#cam156@psu.edu"
+        agent_parts = gf_perm.agent.split("/").last.split("#") # e.g. "http://projecthydra.org/ns/auth/person#hjc14"
+        type = agent_parts.first
+        name = agent_parts.last
+
+        # acess = http://www.w3.org/ns/auth/acl#Write
+        access = gf_perm.mode.split("#").last.downcase # e.g. "http://www.w3.org/ns/auth/acl#Write"
+        access = "edit" if access == "write"
+        object.permissions.build(name: name, type: type, access: access)
+      end
+
+      def permission_exists(gf_perm)
+        !object.permissions.to_a.find { |p| p.agent[0] == gf_perm.agent && p.mode[0] == gf_perm.mode }.nil?
+      end
+  end
+end

--- a/lib/sufia/import/version_builder.rb
+++ b/lib/sufia/import/version_builder.rb
@@ -1,0 +1,60 @@
+module Sufia::Import
+  # Build all the versions of a file and add it to a file set
+  #
+  #
+  class VersionBuilder < Builder
+    attr_reader :file_set
+
+    # @param settings see Sufia::Import::Builder for settings
+    # @param file_set FileSet that will be modifed to include versions
+    def initialize(settings, file_set)
+      super(settings)
+      @file_set = file_set
+    end
+
+    # build versions based on the input
+    #
+    # @param Array[OpenStruct] generic_file_versions
+    #     Each item is expected to contain uri, label, and created
+    #       uri     - Link to content in Sufia 6 repository
+    #       label   - Version label
+    #       created - date the version was created
+    #
+    def build(generic_file_versions)
+      sorted_versions = generic_file_versions.sort_by(&:created)
+      sorted_versions.each_with_index do |gf_version, index|
+        filename_on_disk = create(gf_version)
+
+        # characterize the current version
+        characterize(filename_on_disk) if index == (sorted_versions.count - 1)
+
+        File.delete(filename_on_disk)
+      end
+    end
+
+    private
+
+      def create(version)
+        filename_on_disk = File.join Dir.tmpdir, "#{file_set.id}_#{version.label}"
+        Rails.logger.debug "[IMPORT] Downloading #{version} to #{filename_on_disk}"
+        File.open(filename_on_disk, 'wb') do |file_to_upload|
+          source_uri = sufia6_version_open_uri(version.uri)
+          file_to_upload.write source_uri.read
+        end
+
+        # ...upload it...
+        File.open(filename_on_disk, 'rb') do |file_to_upload|
+          Hydra::Works::UploadFileToFileSet.call(file_set, file_to_upload)
+        end
+        filename_on_disk
+      end
+
+      def sufia6_version_open_uri(content_uri)
+        open(content_uri, http_basic_authentication: [sufia6_user, sufia6_password])
+      end
+
+      def characterize(filename_on_disk)
+        CharacterizeJob.perform_now(file_set, file_set.original_file.id, filename_on_disk)
+      end
+  end
+end

--- a/spec/lib/sufia/import/file_set_builder_spec.rb
+++ b/spec/lib/sufia/import/file_set_builder_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'support/export_json_helper'
+
+describe Sufia::Import::FileSetBuilder do
+  let(:user) { create(:user) }
+  let(:sufia6_user) { "s6user" }
+  let(:sufia6_password) { "s6password" }
+  let(:builder) { described_class.new(sufia6_user: sufia6_user, sufia6_password: sufia6_password) }
+
+  let(:gf_metadata) { JSON.parse(json, object_class: OpenStruct) }
+
+  let(:json) do
+    generic_file_json(title: ["My Great File"],
+                      date_uploaded: "2015-09-28T20:00:14.243+00:00",
+                      date_modified: "2015-10-28T20:00:14.243+00:00",
+                      label: "my label")
+  end
+
+  let(:permission_builder) { instance_double(Sufia::Import::PermissionBuilder) }
+  let(:version_builder) { instance_double(Sufia::Import::PermissionBuilder) }
+  before do
+    allow(Sufia::Import::PermissionBuilder).to receive(:new).and_return(permission_builder)
+    allow(Sufia::Import::VersionBuilder).to receive(:new).and_return(version_builder)
+  end
+
+  it "creates a FileSet with metadata versions and permissions" do
+    expect(permission_builder).to receive(:build).with(gf_metadata.permissions)
+    expect(version_builder).to receive(:build).with(gf_metadata.versions)
+    file_set = builder.build(gf_metadata)
+    expect(file_set.title).to eq(["My Great File"])
+    expect(file_set.date_uploaded).to eq "2015-09-28T20:00:14.243+00:00"
+    expect(file_set.date_modified).to eq "2015-10-28T20:00:14.243+00:00"
+    expect(file_set.label).to eq "my label"
+  end
+end

--- a/spec/lib/sufia/import/permission_builder_spec.rb
+++ b/spec/lib/sufia/import/permission_builder_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Sufia::Import::PermissionBuilder do
+  let(:user) { create(:user) }
+  let(:builder) { described_class.new({}, object) }
+  subject { object.permissions.map(&:to_hash) }
+
+  let(:permissions) do
+    [
+      OpenStruct.new("id" => "abc12333-07b1-43ab-b11d-1bc0534d874c",
+                     "agent" => "http://projecthydra.org/ns/auth/person##{user.user_key}",
+                     "mode" => "http://www.w3.org/ns/auth/acl#Write",
+                     "access_to" => "44558d49x"),
+      OpenStruct.new("id" => "b5911dfd-07b1-43ab-b11d-1bc0534d874c",
+                     "agent" => "http://projecthydra.org/ns/auth/person#cam156@psu.edu",
+                     "mode" => "http://www.w3.org/ns/auth/acl#Write",
+                     "access_to" => "44558d49x"),
+      OpenStruct.new("id" => "db8e6b05-3fe1-4d3f-9905-5232ba49f8f5",
+                     "agent" => "http://projecthydra.org/ns/auth/person#other@psu.edu",
+                     "mode" => "http://www.w3.org/ns/auth/acl#Read",
+                     "access_to" => "44558d49x")
+    ]
+  end
+
+  before do
+    builder.build(permissions)
+  end
+  context "when adding permissions to the work" do
+    let(:object) { create(:generic_work, user: user) }
+
+    it do
+      is_expected.to contain_exactly({ name: "cam156@psu.edu", type: "person", access: "edit" },
+                                     { name: "other@psu.edu", type: "person", access: "read" },
+                                     name: user.user_key, type: "person", access: "edit")
+    end
+  end
+  context "when adding permissions to the file set" do
+    let(:object) { create(:file_set, user: user) }
+
+    it do
+      is_expected.to contain_exactly({ name: "cam156@psu.edu", type: "person", access: "edit" },
+                                     { name: "other@psu.edu", type: "person", access: "read" },
+                                     name: user.user_key, type: "person", access: "edit")
+    end
+  end
+end

--- a/spec/lib/sufia/import/version_builder_spec.rb
+++ b/spec/lib/sufia/import/version_builder_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Sufia::Import::VersionBuilder do
+  let(:user) { create(:user) }
+  let(:sufia6_user) { "s6user" }
+  let(:sufia6_password) { "s6password" }
+  let(:builder) { described_class.new({ sufia6_user: sufia6_user, sufia6_password: sufia6_password }, file_set) }
+  let(:file_set) { create(:file_set, user: user) }
+  subject { file_set }
+
+  let(:version1_uri) { "http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version1" }
+  let(:version2_uri) { "http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version2" }
+  let(:versions) do
+    [
+      OpenStruct.new(
+        "uri" => version1_uri,
+        "created" => "2016-09-28T20:00:14.658Z",
+        "label" => "version1"
+      ),
+      OpenStruct.new(
+        "uri" => version2_uri,
+        "created" => "2016-09-29T15:58:00.639Z",
+        "label" => "version2"
+      )
+    ]
+  end
+  let(:version1) do
+    file = Tempfile.new('version1')
+    file.write("hello world! version1")
+    file.rewind
+    file
+  end
+  let(:version2) do
+    file = Tempfile.new('version2')
+    file.write("hello world! version2")
+    file.rewind
+    file
+  end
+
+  before do
+    allow(builder).to receive(:open).with(version1_uri, http_basic_authentication: [sufia6_user, sufia6_password]).and_return(version1)
+    allow(builder).to receive(:open).with(version2_uri, http_basic_authentication: [sufia6_user, sufia6_password]).and_return(version2)
+    allow(CharacterizeJob).to receive(:perform_now).and_return(true)
+    builder.build(versions)
+  end
+  after do
+    version1.close
+    version1.unlink
+    version2.close
+    version2.unlink
+  end
+  context "when adding permissions to the file set" do
+    it "creates versions" do
+      expect(file_set.original_file.versions.all.count).to eq(2)
+      expect(file_set.original_file.versions.all.map(&:label)).to contain_exactly("version1", "version2")
+      expect(file_set.original_file.content).to eq("hello world! version2")
+      # TODO: how do we set the dates correctly...
+      # expect(file_set.original_file.versions.all.map(&:created)).to contain_exactly("2016-09-28T20:00:14.658Z", "2016-09-29T15:58:00.639Z")
+    end
+  end
+end

--- a/spec/support/export_json_helper.rb
+++ b/spec/support/export_json_helper.rb
@@ -1,0 +1,81 @@
+module ExportJsonHelper
+  def generic_file_json(options = {})
+    "{
+      \"id\": \"#{options.fetch(:id, '44558d49x')}\",
+      #{descriptive_metadata1_json(options)},
+      #{descriptive_metadata2_json(options)},
+      \"batch_id\": \"qn59q409q\",
+      \"visibility\": \"restricted\",
+      \"versions\": #{versions_json(options)},
+      \"permissions\": #{permissions_json(options)}
+    }"
+  end
+
+  def permissions_json(_options = {})
+    "[
+        {
+          \"id\": \"b5911dfd-07b1-43ab-b11d-1bc0534d874c\",
+          \"agent\": \"http://projecthydra.org/ns/auth/person#cam156@psu.edu\",
+          \"mode\": \"http://www.w3.org/ns/auth/acl#Write\",
+          \"access_to\": \"44558d49x\"
+        },
+        {
+          \"id\": \"db8e6b05-3fe1-4d3f-9905-5232ba49f8f5\",
+          \"agent\": \"http://projecthydra.org/ns/auth/person#other@psu.edu\",
+          \"mode\": \"http://www.w3.org/ns/auth/acl#Read\",
+          \"access_to\": \"44558d49x\"
+        }
+      ]"
+  end
+
+  def versions_json(_options = {})
+    "[
+        {
+          \"uri\": \"http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version1\",
+          \"created\": \"2016-09-28T20:00:14.658Z\",
+          \"label\": \"version1\"
+        },
+        {
+          \"uri\": \"http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version2\",
+          \"created\": \"2016-09-29T15:58:00.639Z\",
+          \"label\": \"version2\"
+        }
+      ]"
+  end
+
+  private
+
+    # breaking this out and apart so rubocop will be happy
+    def descriptive_metadata1_json(options = {})
+      "      \"label\": \"#{options.fetch(:label, '15040187724_9e2f2d7c21_z.jpg')}\",
+        \"depositor\": \"cam156@psu.edu\",
+        \"arkivo_checksum\": \"arkivo checksum\",
+        \"relative_path\": \"relative path\",
+        \"import_url\": \"import url\",
+        \"resource_type\": [\"resource type\"],
+        \"title\": #{options.fetch(:title, '["My Awesone File"]')},
+        \"creator\": [ \"cam156@psu.edu\" ],
+        \"contributor\": [\"contributor1\", \"contribnutor2\"],
+        \"description\": [\"description of the file\"],
+        \"tag\": [\"tag1\", \"tag2\"],
+        \"rights\": [\"Attribution 3.0\"]"
+    end
+
+    def descriptive_metadata2_json(options = {})
+      "      \"publisher\": [\"publisher joe\"],
+        \"date_created\": [\"a long time ago\"],
+        \"date_uploaded\": \"#{options.fetch(:date_uploaded, '2016-09-28T20:00:14.243+00:00')}\",
+        \"date_modified\": \"#{options.fetch(:date_modified, '2016-09-28T17:32:46.610-04:00')}\",
+        \"subject\": [\"subject 1\", \"subject 2\"],
+        \"language\": [\"WA Language WA\"],
+        \"identifier\": [\"You ID ME\"],
+        \"based_near\": [\"Kalamazoo\"],
+        \"related_url\": [\"abc123.org\"],
+        \"bibliographic_citation\": [\"cite me\"],
+        \"source\": [\"source of me\"]"
+    end
+
+    RSpec.configure do |config|
+      config.include ExportJsonHelper
+    end
+end


### PR DESCRIPTION
Fixes #2144 

Adds in FileSetImporter along with permission and version importers.

@hackmastera suggested maybe this should go into a separate gem so it does not need to be versioned along with sufia.  What do people think?  This code could really be anywhere with the exception that it depends on the Objects in CC & Sufia.

@projecthydra/sufia-code-reviewers

