### PR TITLE
Remove casting a SolrDocument to SolrDocument

### DIFF
--- a/app/views/my/_document_list.html.erb
+++ b/app/views/my/_document_list.html.erb
@@ -1,4 +1,4 @@
 <% # container for all documents in index view -%>
 <div class="table-responsive" id="documents">
-  <%= render partial: 'my/_index_partials/default_group', locals: {docs: @response.docs.map { |x| SolrDocument.new(x) }, facet_value: nil} %>
+  <%= render 'my/_index_partials/default_group', docs: @response.docs %>
 </div>

--- a/app/views/my/_index_partials/_default_group.html.erb
+++ b/app/views/my/_index_partials/_default_group.html.erb
@@ -1,15 +1,15 @@
 <table class="table table-striped">
   <caption class="sr-only"><%= t("sufia.dashboard.my.sr.listing") %> <%= application_name %></caption>
-<% unless params[:display_type] == 'list' %>
-  <thead>
-  <tr>
-    <th><label for="check_all" class="sr-only"><%= t("sufia.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
-    <th><%= t("sufia.dashboard.my.heading.title") %></th>
-    <th class="sorts-dash"><i id="<%= CatalogController.uploaded_field %>" class="<%=params[:sort]== "#{CatalogController.uploaded_field} desc" ? 'caret' : params[:sort]== "#{CatalogController.uploaded_field} asc" ? 'caret up' : ''%>"></i><%= t("sufia.dashboard.my.heading.date_uploaded") %></th>
-    <th><%= t("sufia.dashboard.my.heading.visibility") %></th>
-    <th><%= t("sufia.dashboard.my.heading.action") %></th>
-  </tr>
-  </thead>
+  <% unless params[:display_type] == 'list' %>
+    <thead>
+    <tr>
+      <th><label for="check_all" class="sr-only"><%= t("sufia.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
+      <th><%= t("sufia.dashboard.my.heading.title") %></th>
+      <th class="sorts-dash"><i id="<%= CatalogController.uploaded_field %>" class="<%= params[:sort] == "#{CatalogController.uploaded_field} desc" ? 'caret' : params[:sort] == "#{CatalogController.uploaded_field} asc" ? 'caret up' : ''%>"></i><%= t("sufia.dashboard.my.heading.date_uploaded") %></th>
+      <th><%= t("sufia.dashboard.my.heading.visibility") %></th>
+      <th><%= t("sufia.dashboard.my.heading.action") %></th>
+    </tr>
+    </thead>
   <% end %>
   <tbody>
   <% docs.each_with_index do |document, counter| %>


### PR DESCRIPTION

Removes this deprecation warning
```
DEPRECATION WARNING: Blacklight::Document#initialize expects a hash-like
object, received SolrDocument. (called from new at
/home/travis/build/projecthydra/sufia/app/views/my/_document_list.html.erb:3)
```