### PR TITLE
Add install template for quicker installation

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -1,0 +1,13 @@
+gem 'sufia', '7.2.0'
+gem 'flipflop', github: 'jcoyne/flipflop', branch: 'hydra'
+
+run 'bundle install'
+
+generate 'sufia:install', '-f'
+
+# Support Rails 4.2 and 5.0
+begin
+  rails_command 'db:migrate'
+rescue NoMethodError
+  rake 'db:migrate'
+end


### PR DESCRIPTION
Using a template, and updating it within every release, allows us to simplify the instructions for developers who wish to get Sufia up and running in development mode very quickly. Also helps automate manual steps such as the inclusion of the `flipflop` gem from GitHub.

README and release management process have already been updated to reflect the new template.