### PR TITLE
handeling either has_model_ssim or active_fedora_model_ssi

### DIFF
--- a/lib/sufia/migration/survey/fedora_id_service.rb
+++ b/lib/sufia/migration/survey/fedora_id_service.rb
@@ -49,7 +49,12 @@ module Sufia
             query = 'id:"' + id + '"'
             matches = ActiveFedora::SolrService.query(query)
             return nil if matches.count == 0
-            model_str = matches.first["active_fedora_model_ssi"]
+            model_str = matches.first["has_model_ssim"]
+            model_str = model_str.first if model_str.is_a?(Array)
+            if model_str.blank? || !Object.const_defined?(model_str)
+              Rails.logger.error("Invalid model #{id} #{model_str}")
+              return nil
+            end
             Object.const_get(model_str)
           end
 

--- a/spec/lib/sufia/migration/survey_fedora_id_service_spec.rb
+++ b/spec/lib/sufia/migration/survey_fedora_id_service_spec.rb
@@ -52,7 +52,7 @@ describe Sufia::Migration::Survey::FedoraIdService do
 
     it "finds the model ids" do
       is_expected.to include(file.id, collection.id)
-      subject.count eq 2
+      expect(subject.count).to eq 2
     end
 
     context "we only want a limited set" do
@@ -60,7 +60,21 @@ describe Sufia::Migration::Survey::FedoraIdService do
 
       it "finds the model ids" do
         is_expected.to include(file.id)
-        subject.count eq 1
+        expect(subject.count).to eq 1
+      end
+    end
+
+    context "we get a blank model back" do
+      before do
+        original_to_solr = file.to_solr
+        original_to_solr["has_model_ssim"] = nil
+        allow(file).to receive(:to_solr).and_return(original_to_solr)
+        file.update_index
+      end
+
+      it "finds the collection id" do
+        is_expected.to include(collection.id)
+        expect(subject.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
Since there is a chance that user will have a newer version of ActiveFedora that includes the has_model_ssim, or something might be a bit funky with thier repository lets handle records with no model and both of the possible keys.

@projecthydra/sufia-code-reviewers

