### PR TITLE
Don't give the depositor edit access if mediated deposit is configured.

### DIFF
--- a/app/actors/sufia/grant_edit_to_depositor_actor.rb
+++ b/app/actors/sufia/grant_edit_to_depositor_actor.rb
@@ -1,0 +1,15 @@
+module Sufia
+  class GrantEditToDepositorActor < CurationConcerns::Actors::GrantEditToDepositorActor
+    private
+
+      # Overriding the parent class so it doesn't grant access
+      # if mediated deposit is enabled
+      def grant_edit_access
+        super unless mediated_deposit?
+      end
+
+      def mediated_deposit?
+        Flipflop.enable_mediated_deposit?
+      end
+  end
+end

--- a/app/services/sufia/actor_factory.rb
+++ b/app/services/sufia/actor_factory.rb
@@ -9,6 +9,7 @@ module Sufia
        CurationConcerns::Actors::AttachFilesActor,
        CurationConcerns::Actors::ApplyOrderActor,
        CurationConcerns::Actors::InterpretVisibilityActor,
+       GrantEditToDepositorActor,
        CurationConcerns::Actors::InitializeWorkflowActor,
        model_actor(curation_concern)]
     end

--- a/spec/actors/sufia/grant_edit_to_depositor_actor_spec.rb
+++ b/spec/actors/sufia/grant_edit_to_depositor_actor_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+describe Sufia::GrantEditToDepositorActor, :workflow do
+  let(:user) { create(:user) }
+  let(:curation_concern) { GenericWork.new }
+  let(:attributes) { { title: ['test'] } }
+
+  subject do
+    CurationConcerns::Actors::ActorStack.new(curation_concern,
+                                             user,
+                                             [described_class,
+                                              CurationConcerns::Actors::GenericWorkActor])
+  end
+
+  describe 'create' do
+    context "with mediated deposit disabled" do
+      before do
+        allow(Flipflop).to receive(:enable_mediated_deposit?).and_return(false)
+      end
+      it 'gives the creator depositor access' do
+        expect(subject.create(attributes)).to be true
+        expect(curation_concern.edit_users).to eq [user.user_key]
+      end
+    end
+
+    context "with mediated deposit enabled" do
+      before do
+        allow(Flipflop).to receive(:enable_mediated_deposit?).and_return(true)
+      end
+
+      it 'does not give the creator depositor access' do
+        expect(subject.create(attributes)).to be true
+        expect(curation_concern.edit_users).to eq []
+      end
+    end
+  end
+end

--- a/spec/services/sufia/actor_factory_spec.rb
+++ b/spec/services/sufia/actor_factory_spec.rb
@@ -13,6 +13,7 @@ describe Sufia::ActorFactory, :no_clean do
                          CurationConcerns::Actors::AttachFilesActor,
                          CurationConcerns::Actors::ApplyOrderActor,
                          CurationConcerns::Actors::InterpretVisibilityActor,
+                         Sufia::GrantEditToDepositorActor,
                          CurationConcerns::Actors::InitializeWorkflowActor,
                          CurationConcerns::Actors::GenericWorkActor]
     end
@@ -29,6 +30,7 @@ describe Sufia::ActorFactory, :no_clean do
         CurationConcerns::Actors::AttachFilesActor,
         CurationConcerns::Actors::ApplyOrderActor,
         CurationConcerns::Actors::InterpretVisibilityActor,
+        Sufia::GrantEditToDepositorActor,
         CurationConcerns::Actors::InitializeWorkflowActor,
         CurationConcerns::Actors::GenericWorkActor
       ]


### PR DESCRIPTION
Extend the new actor in the curation_concerns branch.