### PR TITLE
set date_created on each version as it is imported

### DIFF
--- a/lib/sufia/import.rb
+++ b/lib/sufia/import.rb
@@ -2,6 +2,7 @@ require 'sufia/import/builder'
 require 'sufia/import/permission_builder'
 require 'sufia/import/version_builder'
 require 'sufia/import/file_set_builder'
+require 'sufia/import/add_version_to_file_set'
 require 'sufia/import/work_builder'
 
 module Sufia

--- a/lib/sufia/import/add_version_to_file_set.rb
+++ b/lib/sufia/import/add_version_to_file_set.rb
@@ -1,0 +1,36 @@
+module Sufia
+  module Import
+    # Follow the Hydra::Works:AddFileToFileSet to add a new version and
+    # set the date_created attribute before the version is minted
+    class AddVersionToFileSet
+      # Adds a version to the file_set with the date_created
+      # @param [Hydra::PCDM::FileSet] file_set the file will be added to
+      # @param [IO,File,Rack::Multipart::UploadedFile, #read] object that will be the contents. If file responds to :mime_type, :content_type, :original_name, or :original_filename, those will be called to provide metadata.
+      # @param [RDF::URI or String] type URI for the RDF.type that identifies the file's role within the file_set
+      # @param [DateTime string] date_created date the version was previously created
+      def self.call(file_set, file, type, date_created)
+        raise ArgumentError, 'supplied object must be a file set' unless file_set.file_set?
+        raise ArgumentError, 'supplied file must respond to read' unless file.respond_to? :read
+
+        # TODO: required as a workaround for https://github.com/projecthydra/active_fedora/pull/858
+        file_set.save unless file_set.persisted?
+
+        status = Sufia::Import::VersioningUpdater.new(file_set, type, true, date_created).update(file)
+        status ? file_set : false
+      end
+    end
+
+    class VersioningUpdater < Hydra::Works::AddFileToFileSet::VersioningUpdater
+      attr_reader :date_created
+      def initialize(file_set, type, update_existing, date_created)
+        super(file_set, type, update_existing)
+        @date_created = date_created
+      end
+
+      def attach_attributes(file)
+        super(file)
+        current_file.date_created = date_created
+      end
+    end
+  end
+end

--- a/lib/sufia/import/version_builder.rb
+++ b/lib/sufia/import/version_builder.rb
@@ -43,8 +43,9 @@ module Sufia::Import
 
         # ...upload it...
         File.open(filename_on_disk, 'rb') do |file_to_upload|
-          Hydra::Works::UploadFileToFileSet.call(file_set, file_to_upload)
+          Sufia::Import::AddVersionToFileSet.call(file_set, file_to_upload, :original_file, version[:created])
         end
+
         filename_on_disk
       end
 

--- a/spec/lib/sufia/import/version_builder_spec.rb
+++ b/spec/lib/sufia/import/version_builder_spec.rb
@@ -50,8 +50,8 @@ describe Sufia::Import::VersionBuilder do
       expect(file_set.original_file.versions.all.count).to eq(2)
       expect(file_set.original_file.versions.all.map(&:label)).to contain_exactly("version1", "version2")
       expect(file_set.original_file.content).to eq("hello world! version2")
-      # TODO: how do we set the dates correctly...
-      # expect(file_set.original_file.versions.all.map(&:created)).to contain_exactly("2016-09-28T20:00:14.658Z", "2016-09-29T15:58:00.639Z")
+      expect(file_set.original_file.date_created).to eq(["2016-09-29T15:58:00.639Z"])
+      expect(file_set.original_file.versions.all.map { |v| Hydra::PCDM::File.new(v.uri).date_created.first }).to contain_exactly("2016-09-28T20:00:14.658Z", "2016-09-29T15:58:00.639Z")
     end
   end
 end


### PR DESCRIPTION
Fixes #2144.  This PR sets the date so the work should now be complete.

Added new VersionUpdater to update the attribute before the version is created, which sets the metadata in stone

@projecthydra/sufia-code-reviewers

