### PR TITLE
Prioritize sufia engine routes over curation concerns

### DIFF
--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -99,8 +99,8 @@ module Sufia
     def inject_routes
       gsub_file 'config/routes.rb', /root (:to =>|to:) "catalog#index"/, ''
       gsub_file 'config/routes.rb', /'welcome#index'/, "'sufia/homepage#index'" # Replace the root path injected by CurationConcerns
-      routing_code = "\n mount Sufia::Engine => '/'\n"
-      sentinel = /end\Z/
+      routing_code = "\n  mount Sufia::Engine, at: '/'\n"
+      sentinel = /\s+mount CurationConcerns::Engine/
       inject_into_file 'config/routes.rb', routing_code, before: sentinel, verbose: false
     end
 


### PR DESCRIPTION
The catch-all route that required sufia appear last in the route list was removed in #1906. This ensures the sufia routes take priority over curation_concerns.