### PR TITLE
Undo #2814 now that it is no longer needed.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,6 @@ require 'equivalent-xml/rspec_matchers'
 require 'database_cleaner'
 require 'support/features'
 require 'support/backport_test_helpers'
-require 'support/minter'
 require 'support/rake'
 require 'byebug' unless ENV['TRAVIS']
 

--- a/spec/support/minter.rb
+++ b/spec/support/minter.rb
@@ -1,9 +1,0 @@
-RSpec.configure do |config|
-  # Switch to the File based minter, so we don't need to recreate the
-  # database rows for the default minter.
-  config.before(:suite) do
-    ActiveFedora::Noid.configure do |noid_config|
-      noid_config.minter_class = ActiveFedora::Noid::Minter::File
-    end
-  end
-end


### PR DESCRIPTION
The default minter in AF::Noid 2.0.0.beta4 was changed to the database-backed one, which required #2814 to get the test suite working again. This is no longer required with AF::Noid 2.0.0.beta5.