### PR TITLE
Hides inactive work from search results and adds functionality to ask if work is suppressed.

### DIFF
--- a/app/indexers/sufia/work_indexer.rb
+++ b/app/indexers/sufia/work_indexer.rb
@@ -12,6 +12,7 @@ module Sufia
         admin_set_label = object.admin_set.to_s
         solr_doc[Solrizer.solr_name('admin_set', :facetable)] = admin_set_label
         solr_doc[Solrizer.solr_name('admin_set', :stored_searchable)] = admin_set_label
+        solr_doc[Solrizer.solr_name('suppressed', STORED_BOOL)] = object.suppressed?
       end
     end
   end

--- a/app/models/concerns/sufia/publishable.rb
+++ b/app/models/concerns/sufia/publishable.rb
@@ -1,0 +1,15 @@
+module Sufia
+  module Publishable
+    extend CurationConcerns::Publishable
+
+    def suppressed?
+      state == inactive_uri
+    end
+
+    private
+
+      def inactive_uri
+        ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive')
+      end
+  end
+end

--- a/app/models/concerns/sufia/work_behavior.rb
+++ b/app/models/concerns/sufia/work_behavior.rb
@@ -6,6 +6,7 @@ module Sufia
     include Sufia::Works::Metadata
     include Sufia::Works::Featured
     include Sufia::WithEvents
+    include Sufia::Publishable
 
     included do
       self.indexer = Sufia::WorkIndexer

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -13,6 +13,26 @@ describe GenericWork do
     end
   end
 
+  describe "suppressed?" do
+    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
+    before do
+      allow(work).to receive(:state).and_return(::RDF::URI(activity_uri))
+    end
+    context "When a work's state is inactive" do
+      let(:activity_uri) { 'http://fedora.info/definitions/1/0/access/ObjState#inactive' }
+      it "is suppressed" do
+        expect(work).to be_suppressed
+      end
+    end
+
+    context "When a work's state is active" do
+      let(:activity_uri) { 'http://fedora.info/definitions/1/0/access/ObjState#active' }
+      it "is not suppressed" do
+        expect(work).not_to be_suppressed
+      end
+    end
+  end
+
   describe "created for someone (proxy)" do
     let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
     let(:transfer_to) { create(:user) }


### PR DESCRIPTION
Fixes #2828 Relates #2640 

This introduces a new module called `Sufa::Publishable`, which extends a module in curation concerns called `CurationConcerns::Publishable`. This is added on as a behavior on a "GenericWork" which allows for the asking of whether or not the work is suppressed or not. Suppression depends on the state of the Work. If the work is inactive, then the work is "suppressed". Otherwise, it is not suppressed and can be accessed by users other than its creator.

This also adds the functionality of hiding an inactive work from the search results.