### PR TITLE
added dropdown style for submenu items on the admin sidebar

### DIFF
--- a/app/assets/stylesheets/sufia/_dashboard.scss
+++ b/app/assets/stylesheets/sufia/_dashboard.scss
@@ -120,3 +120,28 @@ div.heading-tile:hover .glyphicon {
     margin-top: $padding-small-vertical;
   }
 }
+
+// submenu items
+ul.collapse > li > a,
+ul.collapsing > li > a {
+  padding-left: 40px;
+}
+
+.collapse-toggle {
+  margin-bottom: 0;
+
+  &::after {
+    content: "❯";
+    float: right;
+    transform: rotate(90deg);
+  }
+
+  &.collapsed {
+    border-bottom: 0;
+
+    &::after {
+      transform: rotate(0deg);
+      transition: transform 0.1s ease;
+    }
+  }
+}

--- a/app/views/sufia/admin/_sidebar.html.erb
+++ b/app/views/sufia/admin/_sidebar.html.erb
@@ -14,14 +14,22 @@
       <span class="fa fa-sitemap"></span> <%= t('sufia.admin.sidebar.admin_sets') %>
     <% end %>
   </li>
-  <li class="<%= 'active' if current_page? curation_concerns.admin_workflow_path %>">
-      <%= link_to curation_concerns.admin_workflow_path do %>
-      <span class="fa fa-code-fork"></span> <%= t('sufia.admin.sidebar.workflow') %>
-  <% end %>
-  </li>
-  <li class="<%= 'active' if current_page? curation_concerns.admin_workflow_roles_path %>">
-      <%= link_to curation_concerns.admin_workflow_roles_path do %>
-      <span class="fa fa-users"></span> <%= t('sufia.admin.sidebar.workflow_roles') %>
-  <% end %>
+  <li>
+    <a role="button" class="collapsed collapse-toggle" data-toggle="collapse" href="#collapseWorkflows" aria-expanded="false" aria-controls="collapseWorkflows">
+      <span class="fa fa-code-fork"></span>
+      <span><%= t('sufia.admin.sidebar.workflow') %></span>
+    </a>
+    <ul class="collapse nav nav-pills nav-stacked" id="collapseWorkflows">
+      <li class="<%= 'active' if current_page? curation_concerns.admin_workflow_path %>">
+        <%= link_to curation_concerns.admin_workflow_path do %>
+          <span class="fa fa-flag"></span> <%= t('sufia.admin.sidebar.workflow_review') %>
+      <% end %>
+      </li>
+      <li class="<%= 'active' if current_page? curation_concerns.admin_workflow_roles_path %>">
+        <%= link_to curation_concerns.admin_workflow_roles_path do %>
+          <span class="fa fa-users"></span> <%= t('sufia.admin.sidebar.workflow_roles') %>
+      <% end %>
+      </li>
+    </ul>
   </li>
 </ul>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -316,7 +316,8 @@ en:
         settings:   "Settings"
         statistics: "Statistics"
         workflow: "Workflows"
-        workflow_roles: "Workflow Roles"
+        workflow_review: "Review"
+        workflow_roles: "Roles"
       stats:
         registered: "Registered"
         deposited_form:


### PR DESCRIPTION
Fixes #2806 
This PR adds the style and javascript to the dashboard that can be used to add the submenu and dropdown effect to workflow sub-categories such as Review and Roles.

The sidebar menu/submenu is similar to the [Roles and permissions menu on the List Admin Set Roles mockup](https://wiki.duraspace.org/display/hydra/List+Admin+Set+Roles+-+Manage+Users%2C+Groups%2C+Roles+Mockups).

Screenshot: 
![image](https://cloud.githubusercontent.com/assets/3486120/19777295/63707d76-9c2c-11e6-91dd-8e1fe15aac8d.png)
