### PR TITLE
Move homepage banner_image into a helper so it can be easily overridden

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -16,6 +16,10 @@ module Sufia
       t('sufia.institution_name_full', default: institution_name)
     end
 
+    def banner_image
+      Sufia.config.banner_image
+    end
+
     def orcid_label(style_class = '')
       "#{image_tag 'orcid.png', alt: t('sufia.user_profile.orcid.alt'), class: style_class} #{t('sufia.user_profile.orcid.label')}".html_safe
     end

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:navbar) do %>
   <div class="image-masthead">
-    <div class="background-container" style="background-image: url('<%= Sufia.config.banner_image %>')"></div>
+    <div class="background-container" style="background-image: url('<%= banner_image %>')"></div>
     <span class="background-container-gradient"></span>
 
     <div class="container site-title-container">

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -256,4 +256,10 @@ describe SufiaHelper, type: :helper do
       expect(helper.human_readable_date(value: ["2016-08-15T00:00:00Z"])).to eq("08/15/2016")
     end
   end
+
+  describe "#banner_image" do
+    it "returns the configured Sufia banner image" do
+      expect(helper.banner_image).to eq(Sufia.config.banner_image)
+    end
+  end
 end


### PR DESCRIPTION
Moves the Sufia homepage banner_image into a helper method, so that it can be easily overridden.  

One example of doing so would be in Lerna/HyBox, where the banner_image is editable from the admin menu. See related Lerna PR: https://github.com/projecthydra-labs/lerna/pull/402

@projecthydra/sufia-code-reviewers

