### PR TITLE
Change builders to instantiate objects in #build instead of initialize

### DIFF
--- a/lib/sufia/import/collection_builder.rb
+++ b/lib/sufia/import/collection_builder.rb
@@ -2,13 +2,6 @@
 #
 module Sufia::Import
   class CollectionBuilder
-    attr_reader :collection, :permission_builder
-
-    def initialize
-      @collection = Collection.new
-      @permission_builder = PermissionBuilder.new(collection)
-    end
-
     # Build a Collection from json data
     #
     # @param hash json metadata from the collection, e.g.:
@@ -18,6 +11,8 @@ module Sufia::Import
     #                "agent": "http://projecthydra.org/ns/auth/person#depositor@example.com", "mode": "http://www.w3.org/ns/auth/acl#Write",
     #                "access_to": "2v23vt57t" } ] }
     def build(json)
+      collection = Collection.new
+      permission_builder = PermissionBuilder.new
       data = json.deep_symbolize_keys
       members = get_members(data.delete(:members))
       # TODO: a couple fields exported as single-valued but are expected to be multi
@@ -25,7 +20,7 @@ module Sufia::Import
       data[:title] = Array(data[:title])
       data[:description] = Array(data[:description])
       collection.apply_depositor_metadata(data.delete(:depositor))
-      permission_builder.build(data.delete(:permissions))
+      permission_builder.build(collection, data.delete(:permissions))
       collection.update_attributes(data)
       members.each { |w| collection.ordered_members << w }
 

--- a/lib/sufia/import/file_set_builder.rb
+++ b/lib/sufia/import/file_set_builder.rb
@@ -2,15 +2,12 @@
 #
 module Sufia::Import
   class FileSetBuilder
-    attr_reader :file_set, :permission_builder, :version_builder
+    attr_reader :import_binary
 
     # @param import_binary boolean indicating whether to import the binary from sufia6 fedora instance
     #     If true, fedora_sufia6_user and fedora_sufia6_password must be set in config/application.rb
     def initialize(import_binary)
       @import_binary = import_binary
-      @file_set = FileSet.new
-      @permission_builder = PermissionBuilder.new(file_set)
-      @version_builder = VersionBuilder.new(file_set)
     end
 
     # Build a FileSet from GenericFile metadata
@@ -28,6 +25,9 @@ module Sufia::Import
     #                          created: "2016-09-28T20:00:14.658Z", label: "version1" }, ...],
     #                permissions: [ { id: "b5911dfd-07b1-43ab-b11d-1bc0534d874c", agent: "http://projecthydra.org/ns/auth/person#cam156@psu.edu", mode: "http://www.w3.org/ns/auth/acl#Write", access_to: "44558d49x" }, ...] }
     def build(gf_metadata)
+      file_set = FileSet.new
+      permission_builder = PermissionBuilder.new
+      version_builder = VersionBuilder.new
       data = gf_metadata.deep_symbolize_keys
       # TODO: Where did the filename property go?
       # file_set.filename = data.filename
@@ -36,9 +36,9 @@ module Sufia::Import
       file_set.date_uploaded = data[:date_uploaded]
       file_set.date_modified = data[:date_modified]
       file_set.apply_depositor_metadata(data[:depositor])
-      permission_builder.build(data[:permissions])
+      permission_builder.build(file_set, data[:permissions])
       # bring over the File
-      version_builder.build(data[:versions]) if @import_binary
+      version_builder.build(file_set, data[:versions]) if @import_binary
 
       file_set
     end

--- a/lib/sufia/import/permission_builder.rb
+++ b/lib/sufia/import/permission_builder.rb
@@ -1,31 +1,24 @@
 # Create permissions on a Work or FileSet
 module Sufia::Import
   class PermissionBuilder
-    attr_reader :object
-
-    # @param PCDMObject object   Object for the permissions to be applied to
-    #
-    def initialize(object)
-      @object = object
-    end
-
     # Build permissions on a FileSet or a work based on the metadata from GenericFile
     #
-    #  @param Array[hash] generic_file_perms An array of hashes with the below keys
-    #  @option :agent    - Agent that has permisisons; example: "http://projecthydra.org/ns/auth/person#user1@example.com"
-    #  @option :mode     - access acl; example: "http://www.w3.org/ns/auth/acl#Write"
-    #  @option :acces_to - not used - Permissions are added to the object passed in the initializer
-    #  @option :id       - not used - Id for the permissions is generated
-    def build(generic_file_perms)
+    # @param PCDMObject object   Object for the permissions to be applied to
+    # @param Array[hash] generic_file_perms An array of hashes with the below keys
+    #   @option :agent    - Agent that has permisisons; example: "http://projecthydra.org/ns/auth/person#user1@example.com"
+    #   @option :mode     - access acl; example: "http://www.w3.org/ns/auth/acl#Write"
+    #   @option :acces_to - not used - Permissions are added to the object passed in the initializer
+    #   @option :id       - not used - Id for the permissions is generated
+    def build(object, generic_file_perms)
       generic_file_perms.each do |gf_perm|
-        create(gf_perm)
+        create(object, gf_perm)
       end
     end
 
     private
 
-      def create(gf_perm)
-        return if permission_exists(gf_perm)
+      def create(object, gf_perm)
+        return if permission_exists(object, gf_perm)
         # agent = http://projecthydra.org/ns/auth/person#cam156@psu.edu"
         agent_parts = gf_perm[:agent].split("/").last.split("#") # e.g. "http://projecthydra.org/ns/auth/person#hjc14"
         type = agent_parts.first
@@ -37,7 +30,7 @@ module Sufia::Import
         object.permissions.build(name: name, type: type, access: access)
       end
 
-      def permission_exists(gf_perm)
+      def permission_exists(object, gf_perm)
         !object.permissions.to_a.find { |p| p.agent[0] == gf_perm[:agent] && p.mode[0] == gf_perm[:mode] }.nil?
       end
   end

--- a/lib/sufia/import/work_builder.rb
+++ b/lib/sufia/import/work_builder.rb
@@ -2,13 +2,6 @@
 #
 module Sufia::Import
   class WorkBuilder
-    attr_reader :work, :permission_builder
-
-    def initialize
-      @work = Sufia.primary_work_type.new
-      @permission_builder = PermissionBuilder.new(work)
-    end
-
     # Build a Work from GenericFile metadata
     #
     # @param hash gf_metadata metadata from the generic_file, e.g.:
@@ -23,6 +16,8 @@ module Sufia::Import
     #                versions: [],
     #                permissions: [ { id: "b5911dfd-07b1-43ab-b11d-1bc0534d874c", agent: "http://projecthydra.org/ns/auth/person#cam156@psu.edu", mode: "http://www.w3.org/ns/auth/acl#Write", access_to: "44558d49x" } ] }
     def build(gf_metadata)
+      work = Sufia.primary_work_type.new
+      permission_builder = PermissionBuilder.new
       data = gf_metadata.deep_symbolize_keys
       data.delete(:batch_id) # This attribute was removed in sufia 7
       data.delete(:versions) # works don't have versions; these are used in file set builder
@@ -32,7 +27,7 @@ module Sufia::Import
         data[:rights] << "http://www.europeana.eu/portal/rights/rr-r.html"
       end
       work.apply_depositor_metadata(data.delete(:depositor))
-      permission_builder.build(data.delete(:permissions))
+      permission_builder.build(work, data.delete(:permissions))
       work.update_attributes(data)
 
       work

--- a/spec/lib/sufia/import/collection_builder_spec.rb
+++ b/spec/lib/sufia/import/collection_builder_spec.rb
@@ -7,7 +7,12 @@ describe Sufia::Import::CollectionBuilder do
   let(:builder) { described_class.new }
 
   let(:data) { JSON.parse(json, symbolize_names: true) }
+  let(:data2) { JSON.parse(json2, symbolize_names: true) }
   let(:json) { collection_json }
+  let(:json2) do
+    collection_json(id: "col123",
+                    title: "Mystery")
+  end
 
   let(:permission_builder) { instance_double(Sufia::Import::PermissionBuilder) }
   before do
@@ -15,7 +20,7 @@ describe Sufia::Import::CollectionBuilder do
   end
 
   it "creates a collection with metadata and permissions" do
-    expect(permission_builder).to receive(:build).with(data[:permissions])
+    expect(permission_builder).to receive(:build).with(an_instance_of(Collection), data[:permissions])
     coll = builder.build(data)
     expect(coll.id).to eq "2v23vt57t"
     expect(coll.members).to eq []
@@ -28,8 +33,21 @@ describe Sufia::Import::CollectionBuilder do
     let(:json) { collection_json(member_ids: ["some_id"]) }
 
     it "throws a RuntimeError" do
-      allow(permission_builder).to receive(:build).with(data[:permissions])
+      allow(permission_builder).to receive(:build).with(an_instance_of(Collection), data[:permissions])
       expect { builder.build(data) }.to raise_error RuntimeError
+    end
+  end
+  context "when used more than once" do
+    before do
+      allow(permission_builder).to receive(:build)
+    end
+    it "creates distinct Collections" do
+      coll1 = builder.build(data)
+      coll2 = builder.build(data2)
+      expect(coll1.title).to eq ['Fantasy']
+      expect(coll1.id).to eq "2v23vt57t"
+      expect(coll2.title).to eq ['Mystery']
+      expect(coll2.id).to eq "col123"
     end
   end
 end

--- a/spec/lib/sufia/import/file_set_builder_spec.rb
+++ b/spec/lib/sufia/import/file_set_builder_spec.rb
@@ -8,12 +8,16 @@ describe Sufia::Import::FileSetBuilder do
   let(:builder) { described_class.new(true) }
 
   let(:gf_metadata) { JSON.parse(json, symbolize_names: true) }
+  let(:gf_metadata2) { JSON.parse(json2, symbolize_names: true) }
 
   let(:json) do
     generic_file_json(title: ["My Great File"],
                       date_uploaded: "2015-09-28T20:00:14.243+00:00",
                       date_modified: "2015-10-28T20:00:14.243+00:00",
                       label: "my label")
+  end
+  let(:json2) do
+    generic_file_json(title: ["My Greater File"])
   end
 
   let(:permission_builder) { instance_double(Sufia::Import::PermissionBuilder) }
@@ -24,12 +28,25 @@ describe Sufia::Import::FileSetBuilder do
   end
 
   it "creates a FileSet with metadata versions and permissions" do
-    expect(permission_builder).to receive(:build).with(gf_metadata[:permissions])
-    expect(version_builder).to receive(:build).with(gf_metadata[:versions])
+    expect(permission_builder).to receive(:build).with(an_instance_of(FileSet), gf_metadata[:permissions])
+    expect(version_builder).to receive(:build).with(an_instance_of(FileSet), gf_metadata[:versions])
     file_set = builder.build(gf_metadata)
     expect(file_set.title).to eq(["My Great File"])
     expect(file_set.date_uploaded).to eq "2015-09-28T20:00:14.243+00:00"
     expect(file_set.date_modified).to eq "2015-10-28T20:00:14.243+00:00"
     expect(file_set.label).to eq "my label"
+  end
+
+  context "when used more than once" do
+    before do
+      allow(permission_builder).to receive(:build)
+      allow(version_builder).to receive(:build)
+    end
+    it "creates a distinct FileSets" do
+      file_set1 = builder.build(gf_metadata)
+      file_set2 = builder.build(gf_metadata2)
+      expect(file_set1.title).to eq ['My Great File']
+      expect(file_set2.title).to eq ['My Greater File']
+    end
   end
 end

--- a/spec/lib/sufia/import/permission_builder_spec.rb
+++ b/spec/lib/sufia/import/permission_builder_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Sufia::Import::PermissionBuilder do
   let(:user) { create(:user) }
-  let(:builder) { described_class.new(object) }
+  let(:builder) { described_class.new }
   subject { object.permissions.map(&:to_hash) }
 
   let(:permissions) do
@@ -23,7 +23,7 @@ describe Sufia::Import::PermissionBuilder do
   end
 
   before do
-    builder.build(permissions)
+    builder.build(object, permissions)
   end
   context "when adding permissions to the work" do
     let(:object) { create(:generic_work, user: user) }

--- a/spec/lib/sufia/import/version_builder_spec.rb
+++ b/spec/lib/sufia/import/version_builder_spec.rb
@@ -4,7 +4,7 @@ describe Sufia::Import::VersionBuilder do
   let(:user) { create(:user) }
   let(:sufia6_user) { "s6user" }
   let(:sufia6_password) { "s6password" }
-  let(:builder) { described_class.new(file_set) }
+  let(:builder) { described_class.new }
   let(:file_set) { create(:file_set, user: user) }
   subject { file_set }
 
@@ -35,7 +35,7 @@ describe Sufia::Import::VersionBuilder do
 
   context "when username / password have not been configured" do
     it "raises runtime error" do
-      expect { builder.build(versions) }.to raise_error RuntimeError
+      expect { builder.build(file_set, versions) }.to raise_error RuntimeError
     end
   end
   context "when username / password are provided" do
@@ -45,7 +45,7 @@ describe Sufia::Import::VersionBuilder do
       allow(builder).to receive(:open).with(version1_uri, http_basic_authentication: [sufia6_user, sufia6_password]).and_return(version1)
       allow(builder).to receive(:open).with(version2_uri, http_basic_authentication: [sufia6_user, sufia6_password]).and_return(version2)
       allow(CharacterizeJob).to receive(:perform_now).and_return(true)
-      builder.build(versions)
+      builder.build(file_set, versions)
     end
     after do
       version1.close

--- a/spec/lib/sufia/import/work_builder_spec.rb
+++ b/spec/lib/sufia/import/work_builder_spec.rb
@@ -8,12 +8,17 @@ describe Sufia::Import::WorkBuilder do
   let(:builder) { described_class.new }
 
   let(:gf_metadata) { JSON.parse(json, symbolize_names: true) }
+  let(:gf_metadata2) { JSON.parse(json2, symbolize_names: true) }
 
   let(:json) do
     generic_file_json(id: "th83kz34n",
                       date_uploaded: "2016-06-21T09:08:00.000+00:00",
                       date_modified: "2016-06-21T09:08:00.000+00:00",
                       rights: 'All rights reserved')
+  end
+  let(:json2) do
+    generic_file_json(id: "different_id",
+                      title: ["A different work"])
   end
 
   let(:permission_builder) { instance_double(Sufia::Import::PermissionBuilder) }
@@ -22,7 +27,7 @@ describe Sufia::Import::WorkBuilder do
   end
 
   it "creates a Work with metadata and permissions" do
-    expect(permission_builder).to receive(:build).with(gf_metadata[:permissions])
+    expect(permission_builder).to receive(:build).with(an_instance_of(Sufia.primary_work_type), gf_metadata[:permissions])
     work = builder.build(gf_metadata)
     expect(work.id).to eq "th83kz34n"
     expect(work.label).to eq "15040187724_9e2f2d7c21_z.jpg"
@@ -52,5 +57,19 @@ describe Sufia::Import::WorkBuilder do
     expect(work.bibliographic_citation).to eq ["cite me"]
     expect(work.source).to eq ["source of me"]
     expect(work.visibility).to eq "restricted"
+  end
+
+  context "when used more than once" do
+    before do
+      allow(permission_builder).to receive(:build)
+    end
+    it "creates a distinct Works" do
+      work1 = builder.build(gf_metadata)
+      work2 = builder.build(gf_metadata2)
+      expect(work1.title).to eq ['My Awesone File']
+      expect(work1.id).to eq "th83kz34n"
+      expect(work2.title).to eq ['A different work']
+      expect(work2.id).to eq "different_id"
+    end
   end
 end

--- a/spec/support/export_json_helper.rb
+++ b/spec/support/export_json_helper.rb
@@ -66,8 +66,8 @@ module ExportJsonHelper
 
   def collection_json(options = {})
     "{
-      \"id\": \"2v23vt57t\",
-      \"title\": \"Fantasy\",
+      \"id\": \"#{options.fetch(:id, '2v23vt57t')}\",
+      \"title\": \"#{options.fetch(:title, 'Fantasy')}\",
       \"depositor\": \"archivist@example.com\",
       \"description\": \"Magic and power\",
       \"creator\": [


### PR DESCRIPTION
@cam156 the builders were all instantiating objects on initialize which meant if they were used to build multiple objects they never actually created a new object to use.

I think this problem was hidden by the way mocking was done in the tests but it wasn't obvious to me how to modify the tests to reveal the bug. If you have an idea there I'd be glad to hear it.

The solution is to either instantiate a new builder every time you want to build something (which I think is contrary to the pattern implied by the name) or move this object creation out of the initializer and into #build, as I've done here.