### PR TITLE
Add visibility template to Admin Set form

### DIFF
--- a/app/controllers/sufia/admin/permission_templates_controller.rb
+++ b/app/controllers/sufia/admin/permission_templates_controller.rb
@@ -6,7 +6,9 @@ module Sufia
       def update
         authorize! :update, @permission_template
         @permission_template.update(update_params)
-        redirect_to sufia.edit_admin_admin_set_path(params[:admin_set_id], anchor: 'participants'),
+        # Ensure we redirect to active tab
+        current_tab = params[:sufia_permission_template][:access_grants_attributes].present? ? 'participants' : 'visibility'
+        redirect_to sufia.edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
                     notice: 'Permissions updated'
       end
 
@@ -19,7 +21,7 @@ module Sufia
 
         def update_params
           params.require(:sufia_permission_template)
-                .permit(access_grants_attributes: [:access, :agent_id, :agent_type, :id])
+                .permit(:visibility, access_grants_attributes: [:access, :agent_id, :agent_type, :id])
         end
     end
   end

--- a/app/forms/sufia/forms/permission_template_form.rb
+++ b/app/forms/sufia/forms/permission_template_form.rb
@@ -4,7 +4,17 @@ module Sufia
       include HydraEditor::Form
       self.model_class = PermissionTemplate
       self.terms = []
-      delegate :access_grants, :access_grants_attributes=, to: :model
+      delegate :access_grants, :access_grants_attributes=, :visibility, to: :model
+
+      # Visibility options for permission templates
+      def visibility_options
+        i18n_prefix = "sufia.admin.admin_sets.form_visibility.visibility"
+        # Note: Visibility 'varies' = '' implies no constraints
+        [[Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, I18n.t('.everyone', scope: i18n_prefix)],
+         ['', I18n.t('.varies', scope: i18n_prefix)],
+         [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, I18n.t('.institution', scope: i18n_prefix)],
+         [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, I18n.t('.restricted', scope: i18n_prefix)]]
+      end
     end
   end
 end

--- a/app/views/sufia/admin/admin_sets/_form.html.erb
+++ b/app/views/sufia/admin/admin_sets/_form.html.erb
@@ -7,6 +7,9 @@
           <li>
             <a href="#participants"><%= t('.tabs.participants') %></a>
           </li>
+          <li>
+            <a href="#visibility"><%= t('.tabs.visibility') %></a>
+          </li>
         <% end %>
       </ul>
       <div class="tab-content">
@@ -31,6 +34,7 @@
         </div>
         <% if @form.persisted? %>
           <%= render 'form_participants' %>
+          <%= render 'form_visibility' %>
         <% end %>
       </div>
     </div>

--- a/app/views/sufia/admin/admin_sets/_form_visibility.html.erb
+++ b/app/views/sufia/admin/admin_sets/_form_visibility.html.erb
@@ -1,0 +1,18 @@
+          <div id="visibility" class="tab-pane">
+            <div class="panel panel-default labels">
+              <%= simple_form_for @form.permission_template,
+                                  url: [sufia, :admin, @form, :permission_template] do |f| %>
+                <div class="panel-body">
+                  <p><%= t('.page_description') %></p>
+                  <h3><%= t('.visibility.title') %></h3>
+                  <p><%= t('.visibility.description') %></p>
+                  <%# List each option in a <div class='radio'> tag %>
+                  <%= f.collection_radio_buttons :visibility, f.object.visibility_options, :first, :last, item_wrapper_tag: :div, item_wrapper_class: 'radio' %>
+                </div>
+                <div class="panel-footer">
+                  <%= link_to t('.cancel'), sufia.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+                  <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+                </div>
+              <% end %>
+            </div>
+          </div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -312,6 +312,7 @@ en:
           tabs:
             description:        "Description"
             participants:       "Participants"
+            visibility:         "Release and Visibility"
         form_participants:
           add_group:            "Add group:"
           add_user:             "Add user:"
@@ -339,6 +340,16 @@ en:
             type:               "Type"
             action:             "Action"
             remove:             "Remove"
+        form_visibility:
+          page_description:     "Release and visibility settings control when works added to this set are made available for discovery and download and who can discover and download them."
+          visibility:
+            title:              "Visibility"
+            description:        "After its release date, works in this set can be discovered and downloaded by:"
+            everyone:           "Everyone -- all works in this set will be public"
+            varies:             "Varies -- default is public, but depositors can restrict the visibility of individual works"
+            institution:        "Institution -- all works will be visible only to authenticated users of this institution"
+            restricted:         "Restricted -- all works will be visible only to repository managers and managers and reviewers of this administrative set"
+          cancel:               "Cancel"
         show:
           header:           "Administrative Set"
           item_list_header: "Works in This Set"

--- a/spec/controllers/sufia/admin/permission_templates_controller_spec.rb
+++ b/spec/controllers/sufia/admin/permission_templates_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Sufia::Admin::PermissionTemplatesController do
   end
 
   context "when signed in as an admin" do
-    describe "update" do
+    describe "update participants" do
       let(:admin_set) { create(:admin_set) }
       let!(:permission_template) { Sufia::PermissionTemplate.create!(admin_set_id: admin_set.id) }
       let(:input_params) do
@@ -37,6 +37,25 @@ RSpec.describe Sufia::Admin::PermissionTemplatesController do
           put :update, params: input_params
         end.to change { permission_template.access_grants.count }.by(1)
         expect(response).to redirect_to(sufia.edit_admin_admin_set_path(admin_set, anchor: 'participants'))
+        expect(flash[:notice]).to eq 'Permissions updated'
+      end
+    end
+    describe "update visibility" do
+      let(:admin_set) { create(:admin_set) }
+      let!(:permission_template) { Sufia::PermissionTemplate.create!(admin_set_id: admin_set.id) }
+      let(:input_params) do
+        { admin_set_id: admin_set.id,
+          sufia_permission_template: {
+            visibility: 'open'
+          } }
+      end
+
+      it "is successful" do
+        expect(controller).to receive(:authorize!).with(:update, permission_template)
+        expect do
+          put :update, params: input_params
+        end.to change { permission_template.reload.visibility }.from(nil).to('open')
+        expect(response).to redirect_to(sufia.edit_admin_admin_set_path(admin_set, anchor: 'visibility'))
         expect(flash[:notice]).to eq 'Permissions updated'
       end
     end

--- a/spec/features/admin_admin_set_spec.rb
+++ b/spec/features/admin_admin_set_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe "The admin sets, through the admin dashboard" do
     expect(page).to have_content "Works in This Set"
 
     click_link "Edit"
-
-    fill_in "Title", with: 'A better unique name'
-    click_button 'Save'
+    within('#description') do
+      fill_in "Title", with: 'A better unique name'
+      click_button 'Save'
+    end
     expect(page).to have_content "A better unique name"
   end
 end


### PR DESCRIPTION
Fixes  projecthydra-labs/lerna#419

Add ability to manage visibility on the Admin Set permissions template.  NOTE: The `visibility` column already exists on the `permission_templates` table, hence there's no DB migration in this PR.

![screenshot](https://cloud.githubusercontent.com/assets/483997/20013337/b803062e-a280-11e6-850b-f09329606ed9.png)

@projecthydra/sufia-code-reviewers 
