### PR TITLE
[WIP] Test that file set builds distinct objects on repeated use

### DIFF
--- a/lib/sufia/import/file_set_builder.rb
+++ b/lib/sufia/import/file_set_builder.rb
@@ -2,15 +2,12 @@
 #
 module Sufia::Import
   class FileSetBuilder
-    attr_reader :file_set, :permission_builder, :version_builder
+    attr_reader :import_binary
 
     # @param import_binary boolean indicating whether to import the binary from sufia6 fedora instance
     #     If true, fedora_sufia6_user and fedora_sufia6_password must be set in config/application.rb
     def initialize(import_binary)
       @import_binary = import_binary
-      @file_set = FileSet.new
-      @permission_builder = PermissionBuilder.new(file_set)
-      @version_builder = VersionBuilder.new(file_set)
     end
 
     # Build a FileSet from GenericFile metadata
@@ -28,6 +25,9 @@ module Sufia::Import
     #                          created: "2016-09-28T20:00:14.658Z", label: "version1" }, ...],
     #                permissions: [ { id: "b5911dfd-07b1-43ab-b11d-1bc0534d874c", agent: "http://projecthydra.org/ns/auth/person#cam156@psu.edu", mode: "http://www.w3.org/ns/auth/acl#Write", access_to: "44558d49x" }, ...] }
     def build(gf_metadata)
+      file_set = FileSet.new
+      permission_builder = PermissionBuilder.new(file_set)
+      version_builder = VersionBuilder.new(file_set)
       data = gf_metadata.deep_symbolize_keys
       # TODO: Where did the filename property go?
       # file_set.filename = data.filename

--- a/spec/lib/sufia/import/file_set_builder_spec.rb
+++ b/spec/lib/sufia/import/file_set_builder_spec.rb
@@ -8,12 +8,16 @@ describe Sufia::Import::FileSetBuilder do
   let(:builder) { described_class.new(true) }
 
   let(:gf_metadata) { JSON.parse(json, symbolize_names: true) }
+  let(:gf_metadata2) { JSON.parse(json2, symbolize_names: true) }
 
   let(:json) do
     generic_file_json(title: ["My Great File"],
                       date_uploaded: "2015-09-28T20:00:14.243+00:00",
                       date_modified: "2015-10-28T20:00:14.243+00:00",
                       label: "my label")
+  end
+  let(:json2) do
+    generic_file_json(title: ["My Greater File"])
   end
 
   let(:permission_builder) { instance_double(Sufia::Import::PermissionBuilder) }
@@ -31,5 +35,18 @@ describe Sufia::Import::FileSetBuilder do
     expect(file_set.date_uploaded).to eq "2015-09-28T20:00:14.243+00:00"
     expect(file_set.date_modified).to eq "2015-10-28T20:00:14.243+00:00"
     expect(file_set.label).to eq "my label"
+  end
+
+  context "when used more than once" do
+    before do
+      allow(permission_builder).to receive(:build)
+      allow(version_builder).to receive(:build)
+    end
+    it "creates a distinct FileSets" do
+      file_set1 = builder.build(gf_metadata)
+      file_set2 = builder.build(gf_metadata2)
+      expect(file_set1.title).to eq ['My Great File']
+      expect(file_set2.title).to eq ['My Greater File']
+    end
   end
 end


### PR DESCRIPTION
@cam156 follow-up for discussion on #2855 

This demonstrates that the problem is with the file_set_builder (as well as work and collection builders, though I haven't demonstrated that here yet) and not so much the version and permission builders. However, I lean toward changing those also (as shown in the other PR) for consistency. What do you think?

This means I should write failing tests for work and collection builders, but tests should be fine as-is for version and permissions builders.