### PR TITLE
Move nested builder creation into initialize

### DIFF
--- a/lib/sufia/import/collection_builder.rb
+++ b/lib/sufia/import/collection_builder.rb
@@ -2,6 +2,12 @@
 #
 module Sufia::Import
   class CollectionBuilder
+    attr_reader :permission_builder
+
+    def initialize
+      @permission_builder = PermissionBuilder.new
+    end
+
     # Build a Collection from json data
     #
     # @param hash json metadata from the collection, e.g.:
@@ -12,7 +18,6 @@ module Sufia::Import
     #                "access_to": "2v23vt57t" } ] }
     def build(json)
       collection = Collection.new
-      permission_builder = PermissionBuilder.new
       data = json.deep_symbolize_keys
       members = get_members(data.delete(:members))
       # TODO: a couple fields exported as single-valued but are expected to be multi

--- a/lib/sufia/import/file_set_builder.rb
+++ b/lib/sufia/import/file_set_builder.rb
@@ -2,12 +2,14 @@
 #
 module Sufia::Import
   class FileSetBuilder
-    attr_reader :import_binary
+    attr_reader :import_binary, :permission_builder, :version_builder
 
     # @param import_binary boolean indicating whether to import the binary from sufia6 fedora instance
     #     If true, fedora_sufia6_user and fedora_sufia6_password must be set in config/application.rb
     def initialize(import_binary)
       @import_binary = import_binary
+      @permission_builder = PermissionBuilder.new
+      @version_builder = VersionBuilder.new
     end
 
     # Build a FileSet from GenericFile metadata
@@ -26,8 +28,6 @@ module Sufia::Import
     #                permissions: [ { id: "b5911dfd-07b1-43ab-b11d-1bc0534d874c", agent: "http://projecthydra.org/ns/auth/person#cam156@psu.edu", mode: "http://www.w3.org/ns/auth/acl#Write", access_to: "44558d49x" }, ...] }
     def build(gf_metadata)
       file_set = FileSet.new
-      permission_builder = PermissionBuilder.new
-      version_builder = VersionBuilder.new
       data = gf_metadata.deep_symbolize_keys
       # TODO: Where did the filename property go?
       # file_set.filename = data.filename

--- a/lib/sufia/import/work_builder.rb
+++ b/lib/sufia/import/work_builder.rb
@@ -2,6 +2,12 @@
 #
 module Sufia::Import
   class WorkBuilder
+    attr_reader :permission_builder
+
+    def initialize
+      @permission_builder = PermissionBuilder.new
+    end
+
     # Build a Work from GenericFile metadata
     #
     # @param hash gf_metadata metadata from the generic_file, e.g.:
@@ -17,7 +23,6 @@ module Sufia::Import
     #                permissions: [ { id: "b5911dfd-07b1-43ab-b11d-1bc0534d874c", agent: "http://projecthydra.org/ns/auth/person#cam156@psu.edu", mode: "http://www.w3.org/ns/auth/acl#Write", access_to: "44558d49x" } ] }
     def build(gf_metadata)
       work = Sufia.primary_work_type.new
-      permission_builder = PermissionBuilder.new
       data = gf_metadata.deep_symbolize_keys
       data.delete(:batch_id) # This attribute was removed in sufia 7
       data.delete(:versions) # works don't have versions; these are used in file set builder


### PR DESCRIPTION
@cam156 I forgot this bit! version / permission builders only need to be created once now that they don't initialize anything.