### PR TITLE
All the work type icon generation in one place

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -147,7 +147,7 @@ module Sufia
       end
     end
 
-    # *Sometimes* a Blacklight helper_method
+    # *Sometimes* a Blacklight index field helper_method
     # @param [String,User,Hash{Symbol=>Array}] args if a hash, the user_key must be under :value
     # @return [ActiveSupport::SafeBuffer] the html_safe link
     def link_to_profile(args)
@@ -171,7 +171,7 @@ module Sufia
     end
     deprecation_deprecate rights_statement_links: "use licence_links instead"
 
-    # A Blacklight helper_method
+    # A Blacklight index field helper_method
     # @param [Hash] options from blacklight helper_method invocation. Maps rights URIs to links with labels.
     # @return [ActiveSupport::SafeBuffer] rights statement links, html_safe
     def license_links(options)
@@ -214,8 +214,9 @@ module Sufia
       user.respond_to?(:name) ? "#{user.name} (#{user_key})" : user_key
     end
 
+    # Used by the gallery view
     def collection_thumbnail(_document, _image_options = {}, _url_options = {})
-      content_tag(:span, "", class: ["fa", "fa-cubes", "collection-icon-search"])
+      content_tag(:span, "", class: [Sufia::ModelIcon.css_class_for(Collection), "collection-icon-search"])
     end
 
     private

--- a/app/presenters/sufia/model_icon.rb
+++ b/app/presenters/sufia/model_icon.rb
@@ -1,0 +1,7 @@
+module Sufia
+  class ModelIcon
+    def self.css_class_for(model)
+      I18n.t(:"sufia.icons.#{model.model_name.i18n_key}", default: :"sufia.icons.default")
+    end
+  end
+end

--- a/app/presenters/sufia/select_type_presenter.rb
+++ b/app/presenters/sufia/select_type_presenter.rb
@@ -7,7 +7,7 @@ module Sufia
     attr_reader :concern
 
     def icon_class
-      translate('icon_class')
+      ModelIcon.css_class_for(concern)
     end
 
     def description

--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -41,7 +41,7 @@
     <% if can?(:create, Collection) %>
       <li class="dropdown">
         <%= link_to sufia.dashboard_collections_path, role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
-          <span class="fa fa-cubes"></span> <%= t("sufia.toolbar.collections.menu") %> <span class="caret"></span>
+          <span class="<%= Sufia::ModelIcon.css_class_for(Collection) %>"></span> <%= t("sufia.toolbar.collections.menu") %> <span class="caret"></span>
         <% end %>
         <ul class="dropdown-menu">
           <li><%= link_to t("sufia.toolbar.collections.my"), sufia.dashboard_collections_path %></li>

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,4 +1,4 @@
     <div class="col-sm-3">
-      <span class="fa fa-cubes collection-icon-search"></span>
+      <span class="<%= Sufia::ModelIcon.css_class_for(Collection) %> collection-icon-search"></span>
     </div>
 

--- a/app/views/collections/_media_display.html.erb
+++ b/app/views/collections/_media_display.html.erb
@@ -1,1 +1,1 @@
-<span class="fa fa-cubes collection-icon-search"></span>
+<span class="<%= Sufia::ModelIcon.css_class_for(Collection) %> collection-icon-search"></span>

--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -3,7 +3,7 @@
   <td></td>
   <td>
     <div class="media">
-      <span class="fa fa-cubes collection-icon-small pull-left"></span>
+      <span class="<%= Sufia::ModelIcon.css_class_for(Collection) %> collection-icon-small pull-left"></span>
       <div class="media-body">
         <div class="media-heading">
           <%= link_to document, id: "src_copy_link#{id}" do %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -10,6 +10,9 @@ en:
       contact:          "Contact"
     product_name:       "Sufia"
     product_twitter_handle: "@HydraSphere"
+    icons:
+      collection:       'fa fa-cubes'
+      default:          'fa fa-cube'
     institution_name:   "Institution Name"
     institution_name_full: "The Institution Name"
     sort_label: "Sort the listing of items"

--- a/lib/generators/sufia/work/templates/locale.en.yml.erb
+++ b/lib/generators/sufia/work/templates/locale.en.yml.erb
@@ -1,10 +1,11 @@
 en:
   sufia:
+    icons:
+      <%= file_name %>:     'fa fa-file-text-o'
     select_type:
       <%= file_name %>:
         name:               "<%= human_name.titleize %>"
         description:        "<%= human_name %> works"
-        icon_class:         'fa fa-file-text-o'
   simple_form:
     labels:
       <%= file_name %>:


### PR DESCRIPTION
All the icons for work types now come consistently from the locales. Ref #2867

@projecthydra/sufia-code-reviewers

