### PR TITLE
The 'New Work' link in the toolbar opens the modal

### DIFF
--- a/app/controllers/concerns/sufia/controller.rb
+++ b/app/controllers/concerns/sufia/controller.rb
@@ -2,8 +2,11 @@ module Sufia::Controller
   extend ActiveSupport::Concern
 
   included do
+    class_attribute :create_work_presenter_class
+    self.create_work_presenter_class = Sufia::SelectTypeListPresenter
     # Adds Hydra behaviors into the application controller
     include Hydra::Controller::ControllerBehavior
+    helper_method :create_work_presenter
   end
 
   def current_ability
@@ -13,5 +16,10 @@ module Sufia::Controller
   # Override Devise method to redirect to dashboard after signing in
   def after_sign_in_path_for(_resource)
     sufia.dashboard_index_path
+  end
+
+  # A presenter for selecting a work type to create
+  def create_work_presenter
+    @create_work_presenter ||= create_work_presenter_class.new(current_user)
   end
 end

--- a/app/presenters/sufia/select_type_list_presenter.rb
+++ b/app/presenters/sufia/select_type_list_presenter.rb
@@ -1,15 +1,37 @@
 module Sufia
+  # Presents the list of work type options that a user may choose from when deciding to
+  # create a new work
   class SelectTypeListPresenter
-    # @param classification [CurationConcerns::QuickClassificationQuery]
-    def initialize(classification)
-      @classification = classification
+    # @param current_user [User]
+    def initialize(current_user)
+      @current_user = current_user
     end
 
     class_attribute :row_presenter
     self.row_presenter = SelectTypePresenter
 
+    # @return [Boolean] are there many differnt types to choose?
+    def many?
+      authorized_models.size > 1
+    end
+
+    def authorized_models
+      return [] unless @current_user
+      @authorized_models ||= CurationConcerns::QuickClassificationQuery.new(@current_user).authorized_models
+    end
+
+    # Return or yield the first model in the list. This is used when the list
+    # only has a single element.
+    # @yieldparam [Class] model a class that decends from ActiveFedora::Base
+    # @return [Class] a class that decends from ActiveFedora::Base
+    def first_model
+      yield(authorized_models.first) if block_given?
+      authorized_models.first
+    end
+
+    # @yieldparam [SelectTypePresenter] presenter a presenter for the item
     def each
-      @classification.each { |i| yield row_presenter.new(i) }
+      authorized_models.each { |model| yield row_presenter.new(model) }
     end
   end
 end

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,3 +1,4 @@
+<%= render '/shared/select_work_type_modal' if create_work_presenter.many? %>
 <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation">
   <div class="container-fluid">
     <!-- Brand and toggle get grouped for better mobile display -->
@@ -8,14 +9,13 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <%= render partial: '/logo' %>
+      <%= render '/logo' %>
     </div>
 
     <div class="collapse navbar-collapse" id="top-navbar-collapse">
-      <%= render partial: '/toolbar' %>
+      <%= render '/toolbar' %>
 
-      <%= render partial: '/user_util_links' %>
+      <%= render '/user_util_links' %>
     </div>
   </div>
 </nav>
-

--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -22,17 +22,24 @@
         <% end %>
         <ul class="dropdown-menu">
           <li><%= link_to t("sufia.toolbar.works.my"), sufia.dashboard_works_path %></li>
-
-          <% classification = CurationConcerns::QuickClassificationQuery.new(current_user) %>
-          <% classification.each do |concern| %>
-            <li><%= link_to(
-                  t("sufia.toolbar.works.new", type: concern.human_readable_type),
-                  new_polymorphic_path([main_app, concern]),
-                  class: "item-option contextual-quick-classify #{dom_class(concern, 'new').gsub('_', '-')}",
+          <li>
+          <% if create_work_presenter.many? %>
+            <%= link_to(
+                  t("sufia.toolbar.works.new"),
+                  '#',
+                  data: { toggle: "modal", target: "#worktypes-to-create" },
+                  class: "item-option contextual-quick-classify",
                   role: 'menuitem'
                 ) %>
-            </li>
+          <% else %>
+            <%= link_to(
+                  t("sufia.toolbar.works.new"),
+                  new_polymorphic_path([main_app, create_work_presenter.first_model]),
+                  class: "item-option contextual-quick-classify",
+                  role: 'menuitem'
+                ) %>
           <% end %>
+          </li>
           <li><%= link_to t("sufia.toolbar.works.batch"), sufia.new_batch_upload_path %></li>
         </ul>
       </li>

--- a/app/views/dashboard/_create_work_action.html.erb
+++ b/app/views/dashboard/_create_work_action.html.erb
@@ -1,9 +1,13 @@
-<% classification = CurationConcerns::QuickClassificationQuery.new(current_user) %>
-<% if classification.authorized_models.size > 1 %>
-  <%= render 'select_work_type', presenter: Sufia::SelectTypeListPresenter.new(classification) %>
+<% if create_work_presenter.many? %>
+  <div class="col-xs-6 col-sm-3 heading-tile">
+    <%= link_to('#', data: { toggle: "modal", target: "#worktypes-to-create" }) do %>
+      <span class="glyphicon glyphicon-upload"></span>
+      <%= t("sufia.dashboard.create_work") %>
+    <% end %>
+  </div>
 <% else %>
   <div class="col-xs-6 col-sm-3 heading-tile">
-    <% classification.each do |concern| %>
+    <% create_work_presenter.first_model do |concern| %>
       <%= link_to(new_polymorphic_path([main_app, concern]),
                             class: "item-option contextual-quick-classify #{dom_class(concern, 'new').gsub('_', '-')}",
                             role: 'menuitem'

--- a/app/views/dashboard/_index_partials/_heading_actions.html.erb
+++ b/app/views/dashboard/_index_partials/_heading_actions.html.erb
@@ -1,8 +1,6 @@
 <div class="col-xs-12 heading-row">
   <div class="row">
-    <% if can_ever_create_works? %>
-      <%= render 'create_work_action' %>
-    <% end %>
+    <%= render 'create_work_action' if can_ever_create_works? %>
     <% if can?(:create, Collection) %>
         <div class="col-xs-6 col-sm-3 heading-tile">
           <%= link_to new_collection_path, id: "hydra-collection-add" do %>

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div class="modal-body">
         <table class="table">
-          <% presenter.each do |row_presenter| %>
+          <% create_work_presenter.each do |row_presenter| %>
             <tr>
               <td class="select-work-icon">
                 <%= link_to(new_polymorphic_path([main_app, row_presenter.concern]),
@@ -36,11 +36,4 @@
       </div>
     </div>
   </div>
-</div>
-
-<div class="col-xs-6 col-sm-3 heading-tile">
-  <%= link_to('#', data: { toggle: "modal", target: "#worktypes-to-create" }) do %>
-    <span class="glyphicon glyphicon-upload"></span>
-    <%= t("sufia.dashboard.create_work") %>
-  <% end %>
 </div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -108,7 +108,7 @@ en:
         shares: "Shares"
       works:
         menu: "Works"
-        new: "New %{type}"
+        new: "New Work"
         my: "My Works"
         batch: "Batch Create"
       collections:

--- a/spec/presenters/sufia/select_type_list_presenter_spec.rb
+++ b/spec/presenters/sufia/select_type_list_presenter_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Sufia::SelectTypeListPresenter do
+  let(:instance) { described_class.new(user) }
+  let(:user) { create(:user) }
+
+  describe "#many?" do
+    subject { instance.many? }
+    it { is_expected.to be false }
+
+    context "if user is nil" do
+      it { is_expected.to be false }
+    end
+
+    context "if authorized_models returns more than one" do
+      before do
+        allow(instance).to receive(:authorized_models).and_return([double, double])
+      end
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/views/dashboard/create_work_action.html.erb_spec.rb
+++ b/spec/views/dashboard/create_work_action.html.erb_spec.rb
@@ -1,30 +1,24 @@
 require 'spec_helper'
 
-RSpec.describe 'dashboard/create_work_action.html.erb', type: :view do
-  let(:classification) { double }
+RSpec.describe 'dashboard/_create_work_action.html.erb', type: :view do
   before do
-    allow(CurationConcerns::QuickClassificationQuery).to receive(:new).and_return(classification)
-    allow(view).to receive(:current_user).and_return(double)
-    allow(classification).to receive(:authorized_models).and_return(results)
+    allow(view).to receive(:create_work_presenter).and_return(presenter)
+    allow(presenter).to receive(:first_model).and_yield(GenericWork)
+    render
   end
 
   context "when we have more than one model" do
-    let(:results) { [GenericWork, double] }
-    before do
-      stub_template 'dashboard/_select_work_type.html.erb' => 'SelectType'
-      render 'dashboard/create_work_action', classification: classification
-    end
+    let(:presenter) { instance_double(Sufia::SelectTypeListPresenter, many?: true) }
+
     it "renders the select template" do
-      expect(rendered).to have_content 'SelectType'
+      expect(rendered).to have_selector 'a[data-toggle="modal"][data-target="#worktypes-to-create"]'
+      expect(rendered).to have_link('Create Work', href: '#')
     end
   end
 
   context "when we have one model" do
-    let(:results) { [GenericWork] }
-    before do
-      allow(classification).to receive(:each).and_yield(GenericWork)
-      render 'dashboard/create_work_action', classification: classification
-    end
+    let(:presenter) { instance_double(Sufia::SelectTypeListPresenter, many?: false) }
+
     it "doesn't draw the modal" do
       expect(rendered).not_to include "modal"
       expect(rendered).to have_link "Create Work", href: '/concern/generic_works/new'

--- a/spec/views/dashboard/index_spec.rb
+++ b/spec/views/dashboard/index_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe "dashboard/index.html.erb", type: :view do
   let(:user) { create(:user, display_name: "Charles Francis Xavier") }
   let(:ability) { instance_double("Ability") }
   before do
+    stub_template('dashboard/_create_work_action.html.erb' => "Create Work Stub")
     allow(user).to receive(:title).and_return("Professor, Head")
     allow(user).to receive(:department).and_return("Xavier’s School for Gifted Youngsters")
     allow(user).to receive(:telephone).and_return("814.865.8399")
@@ -11,13 +12,17 @@ RSpec.describe "dashboard/index.html.erb", type: :view do
     allow(user).to receive(:total_file_views).and_return(1)
     allow(user).to receive(:total_file_downloads).and_return(3)
     allow(user).to receive(:avatar).and_return(nil)
+
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:current_ability).and_return(ability)
-    allow(ability).to receive(:can?).with(:create, GenericWork).and_return(can_create_work)
+
     allow(ability).to receive(:can?).with(:create, Collection).and_return(can_create_collection)
     allow(ability).to receive(:can?).with(:edit, user).and_return(can_edit_user)
+
+    allow(view).to receive(:can_ever_create_works?).and_return(true)
     allow(view).to receive(:number_of_works).and_return("15")
     allow(view).to receive(:number_of_collections).and_return("3")
+
     assign(:activity, [])
     assign(:notifications, [])
   end
@@ -31,7 +36,7 @@ RSpec.describe "dashboard/index.html.erb", type: :view do
     let(:heading) { view.content_for(:page_header) }
 
     it "displays welcome message and links" do
-      expect(heading).to have_link("Create Work", href: new_curation_concerns_generic_work_path)
+      expect(heading).to have_content "Create Work Stub"
       expect(heading).to have_link("Create Collection", href: new_collection_path)
       expect(heading).to have_link("View Works", href: sufia.dashboard_works_path)
       expect(heading).to include "My Dashboard"

--- a/spec/views/shared/select_work_type_modal.html.erb_spec.rb
+++ b/spec/views/shared/select_work_type_modal.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'dashboard/select_work_type.html.erb', type: :view do
+RSpec.describe 'shared/_select_work_type_modal.html.erb', type: :view do
   let(:presenter) { instance_double Sufia::SelectTypeListPresenter }
   let(:row1) do
     instance_double(Sufia::SelectTypePresenter,
@@ -23,13 +23,13 @@ RSpec.describe 'dashboard/select_work_type.html.erb', type: :view do
   before do
     allow(presenter).to receive(:each).and_yield(row1).and_yield(row2)
     allow(view).to receive(:new_polymorphic_path).and_return('/foos/new')
-    render 'dashboard/select_work_type', presenter: presenter
+    allow(view).to receive(:create_work_presenter).and_return(presenter)
+    render
   end
   let(:results) { [GenericWork, other_model] }
 
   it "draws the modal" do
     expect(rendered).to have_selector "#worktypes-to-create.modal"
-    expect(rendered).to have_selector 'a[data-toggle="modal"][data-target="#worktypes-to-create"]'
     expect(rendered).to have_link "Book", href: '/foos/new'
     expect(rendered).to have_link "Generic Work"
   end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

If the current user can create more than one work type, and they select
"New Work" from the toolbar, the modal will pop-up and ask the user
which type of work to create.

If there is only one work type, the modal is not opened.
Fixes #2433