### PR TITLE
Create work, selecting admin set restricts visibility

### DIFF
--- a/app/assets/javascripts/sufia/save_work/visibility_component.es6
+++ b/app/assets/javascripts/sufia/save_work/visibility_component.es6
@@ -1,9 +1,11 @@
 export class VisibilityComponent {
   constructor(element) {
     this.element = element
+    this.form = element.closest('form')
     $('.collapse').collapse({ toggle: false })
     element.find("[type='radio']").on('change', () => { this.showForm() })
     this.showForm()
+    this.limitByAdminSet()
   }
 
   showForm() {
@@ -24,4 +26,39 @@ export class VisibilityComponent {
     }
     $(target).collapse('show');
   }
+
+  // Limit visibility options based on selected AdminSet (if enabled)
+  limitByAdminSet() {
+    let adminSetInput = this.form.find('select[id$="_admin_set_id"]')
+    if(adminSetInput) {
+      $(adminSetInput).on('change', () => { this.selectVisibility(adminSetInput.find(":selected")) })
+      this.selectVisibility(adminSetInput.find(":selected"))
+    }
+  }
+
+  // Select visibility to match the AdminSet requirements (if any)
+  selectVisibility(selected) {
+    // Requirement is in HTML5 'data-visibility' attr
+    let visibility = selected.data('visibility')
+    if(visibility) {
+      this.restrictToVisibility(visibility)
+    }
+    else {
+      this.enableAllOptions()
+    }
+  }
+
+  // Require given visibility option. All others disabled.
+  restrictToVisibility(value) {
+    this.element.find("[type='radio'][value='" + value + "']").prop("checked", true).prop("disabled", false)
+    this.element.find("[type='radio'][value!='" + value + "']").prop("disabled", true)
+    // Ensure required option is opened in form
+    this.showForm()
+  }
+
+  // Ensure all visibility options are enabled
+  enableAllOptions() {
+    this.element.find("[type='radio']").prop("disabled", false)
+  }
+
 }

--- a/app/forms/sufia/forms/permission_template_form.rb
+++ b/app/forms/sufia/forms/permission_template_form.rb
@@ -26,7 +26,8 @@ module Sufia
 
         # This allows the attributes
         def grants_as_collection(attributes)
-          attributes_collection = Array.wrap(attributes[:access_grants_attributes])
+          return [] unless attributes[:access_grants_attributes]
+          attributes_collection = attributes[:access_grants_attributes]
 
           if attributes_collection.respond_to?(:permitted?)
             attributes_collection = attributes_collection.to_h

--- a/app/forms/sufia/forms/permission_template_form.rb
+++ b/app/forms/sufia/forms/permission_template_form.rb
@@ -26,7 +26,7 @@ module Sufia
 
         # This allows the attributes
         def grants_as_collection(attributes)
-          attributes_collection = attributes[:access_grants_attributes]
+          attributes_collection = Array.wrap(attributes[:access_grants_attributes])
 
           if attributes_collection.respond_to?(:permitted?)
             attributes_collection = attributes_collection.to_h

--- a/app/services/sufia/admin_set_service.rb
+++ b/app/services/sufia/admin_set_service.rb
@@ -20,5 +20,16 @@ module Sufia
         [doc, counts[doc.id]]
       end
     end
+
+    # @param [Symbol] access :read or :edit
+    def select_options(access = :read)
+      search_results(access).map do |element|
+        permission_template = PermissionTemplate.find_by(admin_set_id: element.id)
+        visibility = permission_template.visibility if permission_template
+        # Add HTML5 'data' attributes corresponding to permission template fields
+        # Used to limit visibility options of new works (via JS) when an AdminSet is selected
+        [element.to_s, element.id, { 'data-visibility' => visibility }]
+      end
+    end
   end
 end

--- a/spec/forms/sufia/forms/permission_template_form_spec.rb
+++ b/spec/forms/sufia/forms/permission_template_form_spec.rb
@@ -45,5 +45,14 @@ RSpec.describe Sufia::Forms::PermissionTemplateForm do
         expect(admin_set.reload.edit_users).to be_empty
       end
     end
+
+    context "with visibility only" do
+      let(:input_params) do
+        ActionController::Parameters.new(visibility: "open").permit!
+      end
+      it "updates the visibility" do
+        expect { subject }.to change { permission_template.reload.visibility }.from(nil).to('open')
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/projecthydra-labs/hyku/issues/422

When creating a new work, selecting an AdminSet will now automatically select the required visibility settings specified by that AdminSet (if any).  Any incompatible visibility settings are disabled.

Also fixes a small bug introduced in updating visibility of an AdminSet. See https://github.com/projecthydra/sufia/pull/2876/commits/b2201b8cc58483598c8e6f31ec9e28e5cd48898d for this bug fix and corresponding test.

![screenshot](https://cloud.githubusercontent.com/assets/483997/20197241/06f3f260-a764-11e6-8f63-346162a0d010.png)

@projecthydra/sufia-code-reviewers 