### PR TITLE
Toggle chevron class when expanding details in dashboard

### DIFF
--- a/app/assets/javascripts/sufia/dashboard_actions.js
+++ b/app/assets/javascripts/sufia/dashboard_actions.js
@@ -10,13 +10,11 @@ Blacklight.onLoad(function() {
   });
 
   function show_details(item) {
-    var button = $(this);
-    //button.id format: "expand_NNNNNNNNNN"
     var array = item.id.split("expand_");
     if (array.length > 1) {
       var docId = array[1];
       $("#detail_" + docId + " .expanded-details").slideToggle();
-      button.toggleClass('glyphicon-chevron-right glyphicon-chevron-down');
+      $(item).toggleClass('glyphicon-chevron-right glyphicon-chevron-down');
     }
   }
 


### PR DESCRIPTION
The chevron wasn't toggling because it was set to `this` which wasn't a valid context. It needed to be `$(item)`.

![before](https://cloud.githubusercontent.com/assets/312085/20322798/5ab6563a-ab48-11e6-8331-f5574173347b.png)
![after](https://cloud.githubusercontent.com/assets/312085/20322806/5f381900-ab48-11e6-9f05-5bd929fcfd41.png)



@projecthydra/sufia-code-reviewers

