### PR TITLE
making sure we do not use the incompatible google-client-api version

### DIFF
--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_follower', '>= 0.1.1', '< 0.3'
   spec.add_dependency 'carrierwave', '~> 0.9'
   spec.add_dependency 'oauth2', '~> 0.9'
-  spec.add_dependency 'google-api-client', '~> 0.7', '< 0.9'
+  spec.add_dependency 'google-api-client', '~> 0.7.1'
   spec.add_dependency 'legato', '~> 0.3'
   spec.add_dependency 'activerecord-import', '~> 0.5'
   if RUBY_VERSION < '2.1.0'


### PR DESCRIPTION
Fixes the build for sufia 6.x-stable on Ruby 2.1

@projecthydra/sufia-code-reviewers

