### PR TITLE
Notifications should be sent for workflow steps

### DIFF
--- a/app/services/sufia/workflow/abstract_notification.rb
+++ b/app/services/sufia/workflow/abstract_notification.rb
@@ -1,0 +1,39 @@
+module Sufia
+  module Workflow
+    class AbstractNotification
+      def self.send_notification(entity:, comment:, user:, recipients:)
+        new(entity, comment, user, recipients).call
+      end
+
+      attr_reader :work_id, :title, :comment, :user, :recipients
+
+      def initialize(entity, comment, user, recipients)
+        @work_id = entity.proxy_for_global_id.sub(/.*\//, '')
+        @title = entity.proxy_for.title.first
+        @comment = comment.respond_to?(:comment) ? comment.comment.to_s : ''
+        @recipients = recipients
+        @user = user
+      end
+
+      def call
+        user.send_message(users_to_notify.uniq, message, subject)
+      end
+
+      protected
+
+        def subject
+          raise NotImplementedError, "Implement #subject in a child class"
+        end
+
+        def message
+          "#{title} (#{work_id}) was advanced in the workflow by #{user.user_key} and is awaiting approval #{comment}"
+        end
+
+      private
+
+        def users_to_notify
+          recipients[:to] + recipients[:cc]
+        end
+    end
+  end
+end

--- a/app/services/sufia/workflow/complete_notification.rb
+++ b/app/services/sufia/workflow/complete_notification.rb
@@ -1,0 +1,22 @@
+module Sufia
+  module Workflow
+    class CompleteNotification < AbstractNotification
+      protected
+
+        def subject
+          'Deposit has been approved'
+        end
+
+        def message
+          "#{title} (#{work_id}) was approved by #{user.user_key}. #{comment}"
+        end
+
+      private
+
+        def users_to_notify
+          user_key = ActiveFedora::Base.find(work_id).depositor
+          super << ::User.find_by(email: user_key)
+        end
+    end
+  end
+end

--- a/app/services/sufia/workflow/pending_review_notification.rb
+++ b/app/services/sufia/workflow/pending_review_notification.rb
@@ -1,0 +1,21 @@
+module Sufia
+  module Workflow
+    class PendingReviewNotification < AbstractNotification
+      protected
+
+        def subject
+          'Deposit needs review'
+        end
+
+        def message
+          "#{title} (#{work_id}) was deposited by #{user.user_key} and is awaiting approval #{comment}"
+        end
+
+      private
+
+        def users_to_notify
+          super << user
+        end
+    end
+  end
+end

--- a/lib/generators/sufia/templates/workflow.json.erb
+++ b/lib/generators/sufia/templates/workflow.json.erb
@@ -1,24 +1,40 @@
 {
-  "workflows": [
-    {
-      "name": "one_step_mediated_deposit",
-      "label": "One-step mediated deposit workflow",
-      "description": "A single-step workflow for mediated deposit",
-      "actions": [
-         {
-           "name": "deposit",
-           "from_states": [],
-           "transition_to": "pending_review"
-         },
-         {
-           "name": "approve",
-           "from_states": [{"names": ["pending_review"], "roles": ["approving"]}],
-           "transition_to": "complete",
-           "methods": [
-             "CurationConcerns::Workflow::ActivateObject"
-           ]
-         }
-      ]
-    }
-  ]
+    "workflows": [
+        {
+            "name": "one_step_mediated_deposit",
+            "label": "One-step mediated deposit workflow",
+            "description": "A single-step workflow for mediated deposit",
+            "actions": [
+                {
+                    "name": "deposit",
+                    "from_states": [],
+                    "transition_to": "pending_review",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Sufia::Workflow::PendingReviewNotification",
+                            "to": ["approving"],
+                            "cc": []
+                        }
+                    ]
+                },
+                {
+                    "name": "approve",
+                    "from_states": [{"names": ["pending_review"], "roles": ["approving"]}],
+                    "transition_to": "complete",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Sufia::Workflow::CompleteNotification",
+                            "to": ["approving"],
+                            "cc": []
+                        }
+                    ],
+                    "methods": [
+                        "CurationConcerns::Workflow::ActivateObject"
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/spec/factories/sipity_entities.rb
+++ b/spec/factories/sipity_entities.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :sipity_entity, class: Sipity::Entity do
+    proxy_for_global_id 'gid://internal/Mock/1'
+    workflow { workflow_state.workflow }
+    workflow_state
+  end
+end

--- a/spec/factories/workflow_states.rb
+++ b/spec/factories/workflow_states.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :workflow_state, class: Sipity::WorkflowState do
+    workflow
+    name 'initial'
+  end
+end

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :workflow, class: Sipity::Workflow do
+    name 'generic_work'
+  end
+end

--- a/spec/services/sufia/workflow/complete_notification_spec.rb
+++ b/spec/services/sufia/workflow/complete_notification_spec.rb
@@ -5,14 +5,8 @@ RSpec.describe Sufia::Workflow::CompleteNotification do
   let(:depositor) { create(:user) }
   let(:to_user) { create(:user) }
   let(:cc_user) { create(:user) }
-  let(:workflow) { Sipity::Workflow.create(name: 'foo') }
-  let(:workflow_state) { Sipity::WorkflowState.create(name: 'bar', workflow: workflow) }
   let(:work) { create(:generic_work, user: depositor) }
-  let(:entity) do
-    Sipity::Entity.create!(proxy_for_global_id: work.to_global_id.to_s,
-                           workflow: workflow,
-                           workflow_state: workflow_state)
-  end
+  let(:entity) { create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { to: [to_user], cc: [cc_user] } }
 

--- a/spec/services/sufia/workflow/complete_notification_spec.rb
+++ b/spec/services/sufia/workflow/complete_notification_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Sufia::Workflow::CompleteNotification do
+  let(:approver) { create(:user) }
+  let(:depositor) { create(:user) }
+  let(:to_user) { create(:user) }
+  let(:cc_user) { create(:user) }
+  let(:workflow) { Sipity::Workflow.create(name: 'foo') }
+  let(:workflow_state) { Sipity::WorkflowState.create(name: 'bar', workflow: workflow) }
+  let(:work) { create(:generic_work, user: depositor) }
+  let(:entity) do
+    Sipity::Entity.create!(proxy_for_global_id: work.to_global_id.to_s,
+                           workflow: workflow,
+                           workflow_state: workflow_state)
+  end
+  let(:comment) { double("comment", comment: 'A pleasant read') }
+  let(:recipients) { { to: [to_user], cc: [cc_user] } }
+
+  describe ".send_notification" do
+    it 'sends a message to all users' do
+      expect(approver).to receive(:send_message).once.and_call_original
+
+      expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
+        .to change { depositor.mailbox.inbox.count }.by(1)
+        .and change { to_user.mailbox.inbox.count }.by(1)
+        .and change { cc_user.mailbox.inbox.count }.by(1)
+    end
+  end
+end

--- a/spec/services/sufia/workflow/pending_review_notification_spec.rb
+++ b/spec/services/sufia/workflow/pending_review_notification_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe Sufia::Workflow::PendingReviewNotification do
+  let(:depositor) { create(:user) }
+  let(:to_user) { create(:user) }
+  let(:cc_user) { create(:user) }
+  let(:workflow) { Sipity::Workflow.create(name: 'foo') }
+  let(:workflow_state) { Sipity::WorkflowState.create(name: 'bar', workflow: workflow) }
+  let(:work) { create(:generic_work, user: depositor) }
+  let(:entity) do
+    Sipity::Entity.create!(proxy_for_global_id: work.to_global_id.to_s,
+                           workflow: workflow,
+                           workflow_state: workflow_state)
+  end
+  let(:comment) { double("comment", comment: 'A pleasant read') }
+  let(:recipients) { { to: [to_user], cc: [cc_user] } }
+
+  describe ".send_notification" do
+    it 'sends a message to all users except depositor' do
+      expect(depositor).to receive(:send_message).once.and_call_original
+
+      expect { described_class.send_notification(entity: entity, user: depositor, comment: comment, recipients: recipients) }
+        .to change { depositor.mailbox.inbox.count }.by(1)
+        .and change { to_user.mailbox.inbox.count }.by(1)
+        .and change { cc_user.mailbox.inbox.count }.by(1)
+    end
+  end
+end

--- a/spec/services/sufia/workflow/pending_review_notification_spec.rb
+++ b/spec/services/sufia/workflow/pending_review_notification_spec.rb
@@ -4,14 +4,8 @@ RSpec.describe Sufia::Workflow::PendingReviewNotification do
   let(:depositor) { create(:user) }
   let(:to_user) { create(:user) }
   let(:cc_user) { create(:user) }
-  let(:workflow) { Sipity::Workflow.create(name: 'foo') }
-  let(:workflow_state) { Sipity::WorkflowState.create(name: 'bar', workflow: workflow) }
   let(:work) { create(:generic_work, user: depositor) }
-  let(:entity) do
-    Sipity::Entity.create!(proxy_for_global_id: work.to_global_id.to_s,
-                           workflow: workflow,
-                           workflow_state: workflow_state)
-  end
+  let(:entity) { create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { to: [to_user], cc: [cc_user] } }
 


### PR DESCRIPTION
Can now see notifications sent to depositor and approver both on deposit and on approval. Fixes #2627, #2864.

# TODO 

- [x] Use FactoryGirl vs. real AR instances
- [x] Specs need to pass and need to be complete
- [x] Look for refactoring opportunities (DRY it out)
- [x] Comments not coming through in messages
- [x] `creating_user` role is not used (remove it from workflow json?)