### PR TITLE
updating to match browse-everything

### DIFF
--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_follower', '>= 0.1.1', '< 0.3'
   spec.add_dependency 'carrierwave', '~> 0.9'
   spec.add_dependency 'oauth2', '~> 0.9'
-  spec.add_dependency 'google-api-client', '~> 0.7.1'
+  spec.add_dependency 'google-api-client', '~> 0.8.6'
   spec.add_dependency 'legato', '~> 0.3'
   spec.add_dependency 'activerecord-import', '~> 0.5'
   if RUBY_VERSION < '2.1.0'


### PR DESCRIPTION
The last update created a conflict between Browse everything and sufia on the version of the google-api.  This copies the same syntax as browse-everything to resolve that conflict