### PR TITLE
Add Release form to AdminSet

### DIFF
--- a/app/assets/javascripts/sufia.js
+++ b/app/assets/javascripts/sufia.js
@@ -54,6 +54,7 @@
 //= require almond
 //= require sufia/admin/admin_set_controls
 //= require sufia/admin/admin_set/participants
+//= require sufia/admin/admin_set/visibility
 //= require sufia/save_work
 //= require sufia/permissions
 //= require sufia/notifications

--- a/app/assets/javascripts/sufia/admin/admin_set/visibility.es6
+++ b/app/assets/javascripts/sufia/admin/admin_set/visibility.es6
@@ -1,0 +1,134 @@
+export default class {
+  constructor(element) {
+    this.element = element
+  }
+
+  setup() {
+    // Watch for changes to "release_period" radio inputs
+    let releasePeriodInput = this.element.find("input[type='radio'][name$='[release_period]']")
+    $(releasePeriodInput).on('change', () => { this.releasePeriodSelected() })
+    this.releasePeriodSelected()
+
+    // Watch for changes to "release_varies" radio inputs
+    let releaseVariesInput = this.element.find("input[type='radio'][name$='[release_varies]']")
+    $(releaseVariesInput).on('change', () => { this.releaseVariesSelected() })
+    this.releaseVariesSelected()
+  }
+
+  // Based on the "release_period" radio selected, enable/disable other options
+  releasePeriodSelected() {
+    let selected = this.element.find("input[type='radio'][name$='[release_period]']:checked")
+    
+    switch(selected.val()) {
+      // If "No Delay" (now) selected
+      case "now":
+        this.disableReleaseVariesOptions()
+        this.disableReleaseFixedDate()
+        this.enableVisibilityRestricted()
+        break;
+
+      // If "Varies" ("") selected
+      case "":
+        this.enableReleaseVariesRadio()
+        this.disableReleaseFixedDate()
+        this.disableVisibilityRestricted()
+        // Also check if a release "Varies" sub-option previously selected
+        this.releaseVariesSelected()
+        break;
+
+      // If "Fixed" selected
+      case "fixed":
+        this.disableReleaseVariesOptions()
+        this.enableReleaseFixedDate()
+        this.disableVisibilityRestricted()
+        break;
+
+      // Nothing selected
+      default:
+        this.disableReleaseVariesOptions()
+        this.disableReleaseFixedDate()
+        this.disableVisibilityRestricted()
+    }
+  }
+
+  // Based on the "release_varies" radio selected, enable/disable other options
+  releaseVariesSelected() {
+    let selected = this.element.find("input[type='radio'][name$='[release_varies]']:checked")
+
+    switch(selected.val()) {
+      // If before specific date selected
+      case "before":
+        this.enableReleaseVariesDate();
+        this.disableReleaseVariesSelect();
+        break;
+
+      // If embargo option selected
+      case "embargo":
+        this.disableReleaseVariesDate();
+        this.enableReleaseVariesSelect();
+        break;
+
+      // Nothing selected
+      default:
+        this.disableReleaseVariesDate();
+        this.disableReleaseVariesSelect();
+    }
+  }
+
+  // Disable ALL sub-options under "Varies"
+  disableReleaseVariesOptions() {
+    this.disableReleaseVariesRadio()
+    this.disableReleaseVariesSelect()
+    this.disableReleaseVariesDate()
+  }
+
+  // Disable all radio inputs under the release "Varies" option
+  disableReleaseVariesRadio() {
+    this.element.find("#release-varies input[type='radio'][name$='[release_varies]']").prop("disabled", true)
+  }
+
+  // Enable all radio inputs under the release "Varies" option
+  enableReleaseVariesRadio() {
+    this.element.find("#release-varies input[type='radio'][name$='[release_varies]']").prop("disabled", false)
+  }
+
+  // Disable selectbox next to release "Varies" embargo option
+  disableReleaseVariesSelect() {
+    this.element.find("#release-varies select[name$='[release_embargo]']").prop("disabled", true)
+  }
+
+  // Enable selectbox next to release "Varies" embargo option
+  enableReleaseVariesSelect() {
+    this.element.find("#release-varies select[name$='[release_embargo]']").prop("disabled", false)
+  }
+
+  // Disable date input field next to release "Varies" before option
+  disableReleaseVariesDate() {
+    this.element.find("#release-varies input[type='date'][name$='[release_date]']").prop("disabled", true)
+  }
+
+  // Enable date input field next to release "Varies" before option
+  enableReleaseVariesDate() {
+    this.element.find("#release-varies input[type='date'][name$='[release_date]']").prop("disabled", false)
+  }
+
+  // Disable date input field next to release "Fixed" option
+  disableReleaseFixedDate() {
+    this.element.find("#release-fixed input[type='date'][name$='[release_date]']").prop("disabled", true)
+  }
+
+  // Enable date input field next to release "Fixed" option
+  enableReleaseFixedDate() {
+    this.element.find("#release-fixed input[type='date'][name$='[release_date]']").prop("disabled", false)
+  }
+
+  // Disable visibility "Restricted" option (not valid for embargoes)
+  disableVisibilityRestricted() {
+    this.element.find("input[type='radio'][name$='[visibility]'][value='restricted']").prop("disabled", true)
+  }
+
+  // Enable visibility "Restricted" option
+  enableVisibilityRestricted() {
+    this.element.find("input[type='radio'][name$='[visibility]'][value='restricted']").prop("disabled", false)
+  }
+}

--- a/app/assets/javascripts/sufia/admin/admin_set_controls.es6
+++ b/app/assets/javascripts/sufia/admin/admin_set_controls.es6
@@ -3,5 +3,9 @@ export default class {
     let Participants = require('sufia/admin/admin_set/participants');
     let participants = new Participants(elem.find('#participants'))
     participants.setup();
+
+    let Visibility = require('sufia/admin/admin_set/visibility');
+    let visibilityTab = new Visibility(elem.find('#visibility'));
+    visibilityTab.setup();
   }
 }

--- a/app/controllers/sufia/admin/permission_templates_controller.rb
+++ b/app/controllers/sufia/admin/permission_templates_controller.rb
@@ -21,7 +21,8 @@ module Sufia
 
         def update_params
           params.require(:sufia_permission_template)
-                .permit(:visibility, access_grants_attributes: [:access, :agent_id, :agent_type, :id])
+                .permit(:release_date, :release_period, :release_varies, :release_embargo, :visibility,
+                        access_grants_attributes: [:access, :agent_id, :agent_type, :id])
         end
     end
   end

--- a/app/forms/sufia/forms/permission_template_form.rb
+++ b/app/forms/sufia/forms/permission_template_form.rb
@@ -4,7 +4,12 @@ module Sufia
       include HydraEditor::Form
       self.model_class = PermissionTemplate
       self.terms = []
-      delegate :access_grants, :access_grants_attributes=, :visibility, to: :model
+      delegate :access_grants, :access_grants_attributes=, :release_date, :release_period, :visibility, to: :model
+
+      # Stores which radio button under release "Varies" option is selected
+      attr_accessor :release_varies
+      # Selected release embargo timeframe (if any) under release "Varies" option
+      attr_accessor :release_embargo
 
       # Visibility options for permission templates
       def visibility_options
@@ -16,17 +21,29 @@ module Sufia
          [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, I18n.t('.restricted', scope: i18n_prefix)]]
       end
 
+      # Embargo / release period options
+      def embargo_options
+        i18n_prefix = "sufia.admin.admin_sets.form_visibility.release.varies.embargo"
+        [[Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_6_MONTHS, I18n.t('.6mos', scope: i18n_prefix)],
+         [Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR, I18n.t('.1yr', scope: i18n_prefix)],
+         [Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_2_YEARS, I18n.t('.2yrs', scope: i18n_prefix)],
+         [Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_3_YEARS, I18n.t('.3yrs', scope: i18n_prefix)]]
+      end
+
       def initialize(model)
         # This is a temporary way to make sure all new PermissionTemplates have
         # a workflow assigned to them. Ultimately we want to expose workflows in
         # the UI and have users choose a workflow for their PermissionTemplate.
         model.workflow_name = 'one_step_mediated_deposit'
         super(model)
+        # Ensure proper form options selected, based on model
+        select_release_varies_option(model)
       end
 
       def update(attributes)
         manage_grants = grants_as_collection(attributes).select { |x| x[:access] == 'manage' }
         grant_admin_set_access(manage_grants) if manage_grants.present?
+        update_release_attributes(attributes)
         model.update(attributes)
       end
 
@@ -53,6 +70,45 @@ module Sufia
           admin_set.edit_users = manage_grants.select { |x| x[:agent_type] == 'user' }.map { |x| x[:agent_id] }
           admin_set.edit_groups = manage_grants.select { |x| x[:agent_type] == 'group' }.map { |x| x[:agent_id] }
           admin_set.save!
+        end
+
+        # In form, select appropriate radio button under Release "Varies" option based on saved permission_template
+        def select_release_varies_option(permission_template)
+          # Ignore 'no_delay' or 'fixed' values, as they are separate options
+          return if permission_template.release_no_delay? || permission_template.release_fixed?
+
+          # If release_period BEFORE a specified date, then 'before' option under "varies" was selected
+          if permission_template.release_before_date?
+            @release_varies = Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
+          # If embargo specified, then 'embargo' option under "varies" was selected and embargo period selected
+          elsif permission_template.release_embargo?
+            # If release_period is some other value, it is specifying an embargo period (e.g. 6mos, 1yr, etc)
+            @release_varies = Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_EMBARGO
+            @release_embargo = permission_template.release_period
+          end
+        end
+
+        # Update attributes based on release options selected (if any).
+        def update_release_attributes(attributes)
+          # If 'varies' before date option selected, then set release_period='before' and save release_date as-is
+          if attributes[:release_varies] == Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
+            attributes[:release_period] = Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE
+          # Else if 'varies' + embargo selected, save embargo as the release_period
+          elsif attributes[:release_varies] == Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_EMBARGO && attributes[:release_embargo]
+            attributes[:release_period] = attributes[:release_embargo]
+            # In an embargo, the release_date should be unspecified as it is based on deposit date
+            attributes[:release_date] = nil
+          end
+
+          # If release is "no delay", a release_date should never be allowed/specified
+          if attributes[:release_period] == Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY
+            attributes[:release_date] = nil
+          end
+
+          # Remove release_varies and release_embargo from attributes
+          # These form fields are only used (above) to update release_period
+          attributes.delete(:release_varies)
+          attributes.delete(:release_embargo)
         end
     end
   end

--- a/app/models/sufia/permission_template.rb
+++ b/app/models/sufia/permission_template.rb
@@ -2,5 +2,43 @@ module Sufia
   class PermissionTemplate < ActiveRecord::Base
     has_many :access_grants, class_name: 'Sufia::PermissionTemplateAccess'
     accepts_nested_attributes_for :access_grants, reject_if: :all_blank
+
+    # Valid Release Period values
+    RELEASE_TEXT_VALUE_FIXED = 'fixed'.freeze
+    RELEASE_TEXT_VALUE_NO_DELAY = 'now'.freeze
+
+    # Valid Release Varies sub-options
+    RELEASE_TEXT_VALUE_BEFORE_DATE = 'before'.freeze
+    RELEASE_TEXT_VALUE_EMBARGO = 'embargo'.freeze
+    RELEASE_TEXT_VALUE_6_MONTHS = '6mos'.freeze
+    RELEASE_TEXT_VALUE_1_YEAR = '1yr'.freeze
+    RELEASE_TEXT_VALUE_2_YEARS = '2yrs'.freeze
+    RELEASE_TEXT_VALUE_3_YEARS = '3yrs'.freeze
+
+    # Does this permission template require a specific date of release for all works
+    # NOTE: date will be in release_date
+    def release_fixed?
+      release_period == RELEASE_TEXT_VALUE_FIXED
+    end
+
+    # Does this permission template require no release delays (i.e. no embargoes allowed)
+    def release_no_delay?
+      release_period == RELEASE_TEXT_VALUE_NO_DELAY
+    end
+
+    # Does this permission template require a date that all works are released before
+    # NOTE: date will be in release_date
+    def release_before_date?
+      release_period == RELEASE_TEXT_VALUE_BEFORE_DATE
+    end
+
+    # Is a specific embargo period required by this permission template
+    # NOTE: embargo period will be in release_period
+    def release_embargo?
+      release_period == RELEASE_TEXT_VALUE_6_MONTHS ||
+        release_period == RELEASE_TEXT_VALUE_1_YEAR ||
+        release_period == RELEASE_TEXT_VALUE_2_YEARS ||
+        release_period == RELEASE_TEXT_VALUE_3_YEARS
+    end
   end
 end

--- a/app/views/sufia/admin/admin_sets/_form_visibility.html.erb
+++ b/app/views/sufia/admin/admin_sets/_form_visibility.html.erb
@@ -4,10 +4,50 @@
                                   url: [sufia, :admin, @form, :permission_template] do |f| %>
                 <div class="panel-body">
                   <p><%= t('.page_description') %></p>
+                  <h3><%= t('.release.title') %></h3>
+                  <p><%= t('.release.description') %></p>
+                  <div id="release-no-delay" class="radio">
+                    <label>
+                      <%= f.radio_button :release_period, Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY %>
+                      <%= t('.release.no_delay') %>
+                    </label>
+                  </div>
+                  <div id="release-varies" class="radio">
+                    <label>
+                      <%= f.radio_button :release_period, '', checked: !f.object.release_varies.blank? %>
+                      <%= t('.release.varies.description') %>
+                    </label>
+                    <ul>
+                      <li class="radio form-inline">
+                        <label>
+                          <%= f.radio_button :release_varies, Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE %>
+                          <%= t('.release.varies.between') %>
+                        </label>
+                        <%= f.date_field :release_date, wrapper: :inline, class: 'datepicker form-control' %>
+                      </li>
+                      <li class="radio form-inline">
+                        <label>
+                          <%= f.radio_button :release_varies, Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_EMBARGO %>
+                          <%= t('.release.varies.between') %>
+                          <%= f.collection_select :release_embargo, f.object.embargo_options, :first, :last, prompt: t('.release.varies.embargo.select') %>
+                        </label>
+                      </li>
+                    </ul>
+                  </div>
+                  <div id="release-fixed" class="radio form-inline">
+                    <label>
+                      <%= f.radio_button :release_period, Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED %>
+                      <%= t('.release.fixed') %>
+                    </label>
+                    <%= f.date_field :release_date, wrapper: :inline, class: 'datepicker form-control' %>
+                  </div>
                   <h3><%= t('.visibility.title') %></h3>
                   <p><%= t('.visibility.description') %></p>
                   <%# List each option in a <div class='radio'> tag %>
-                  <%= f.collection_radio_buttons :visibility, f.object.visibility_options, :first, :last, item_wrapper_tag: :div, item_wrapper_class: 'radio' %>
+                  <%= f.collection_radio_buttons :visibility, f.object.visibility_options, :first, :last, item_wrapper_tag: :div, item_wrapper_class: 'radio' do |b| %>
+                    <%# NOTE: Bug in simple_form causes nested labels: https://github.com/plataformatec/simple_form/issues/1190 This block is a workaround. %>
+                    <% b.radio_button + b.text %>
+                  <% end %>
                 </div>
                 <div class="panel-footer">
                   <%= link_to t('.cancel'), sufia.admin_admin_sets_path, class: 'btn btn-default pull-right'%>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -353,6 +353,20 @@ en:
             remove:             "Remove"
         form_visibility:
           page_description:     "Release and visibility settings control when works added to this set are made available for discovery and download and who can discover and download them."
+          release:
+            title:              "Release"
+            description:        "You can impose a delay (embargo) before works in this administrative set are released for discovery and download."
+            no_delay:           "No delay -- release all works as soon as they are deposited"
+            varies:
+              description:      "Varies -- depositors can set the release date for an individual work:"
+              between:          "Between \"now\" and"
+              embargo:
+                select:         "Select embargo period.."
+                6mos:           "6 months after deposit"
+                1yr:            "1 year after deposit"
+                2yrs:           "2 years after deposit"
+                3yrs:           "3 years after deposit"
+            fixed:              "Fixed -- delay release of all works until"
           visibility:
             title:              "Visibility"
             description:        "After its release date, works in this set can be discovered and downloaded by:"

--- a/db/migrate/20161116222307_add_release_to_permission_templates.rb
+++ b/db/migrate/20161116222307_add_release_to_permission_templates.rb
@@ -1,0 +1,6 @@
+class AddReleaseToPermissionTemplates < ActiveRecord::Migration
+  def change
+    add_column :permission_templates, :release_date, :date
+    add_column :permission_templates, :release_period, :string
+  end
+end

--- a/spec/forms/sufia/forms/permission_template_form_spec.rb
+++ b/spec/forms/sufia/forms/permission_template_form_spec.rb
@@ -54,5 +54,140 @@ RSpec.describe Sufia::Forms::PermissionTemplateForm do
         expect { subject }.to change { permission_template.reload.visibility }.from(nil).to('open')
       end
     end
+
+    context "with release 'no delay'" do
+      let(:input_params) do
+        ActionController::Parameters.new(release_period: "now").permit!
+      end
+      it "sets release_period=now" do
+        expect { subject }.to change { permission_template.reload.release_period }.from(nil).to('now')
+        expect(permission_template.release_date).to be_nil
+      end
+    end
+
+    context "with release 'varies', date specified" do
+      let(:input_params) do
+        ActionController::Parameters.new(release_period: "", release_varies: "before", release_date: "2017-01-01").permit!
+      end
+      it "sets release_period=before and release_date" do
+        expect { subject }.to change { permission_template.reload.release_period }.from(nil).to('before')
+        expect(permission_template.release_date).to eq(Date.parse("2017-01-01"))
+      end
+    end
+
+    context "with release 'varies', embargo specified" do
+      let(:input_params) do
+        ActionController::Parameters.new(release_period: "", release_varies: "embargo", release_embargo: "2yrs").permit!
+      end
+      it "sets release_period to embargo period" do
+        expect { subject }.to change { permission_template.reload.release_period }.from(nil).to('2yrs')
+        expect(permission_template.release_date).to be_nil
+      end
+    end
+
+    context "with release 'fixed', date specified" do
+      let(:input_params) do
+        ActionController::Parameters.new(release_period: "fixed", release_date: "2017-01-01").permit!
+      end
+      it "sets release_period=fixed and release_date" do
+        expect { subject }.to change { permission_template.reload.release_period }.from(nil).to('fixed')
+        expect(permission_template.release_date).to eq(Date.parse("2017-01-01"))
+      end
+    end
+
+    context "with modifying release_period from 'fixed' to 'no_delay'" do
+      let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id, release_period: "fixed", release_date: "2017-01-01") }
+      let(:input_params) do
+        ActionController::Parameters.new(release_period: "now").permit!
+      end
+      it "sets release_period=now, release_date=nil" do
+        expect { subject }.to change { permission_template.reload.release_period }.from('fixed').to('now')
+        expect(permission_template.release_date).to be_nil
+      end
+    end
+
+    context "with modifying release 'varies' from date specified to embargo specified" do
+      let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id, release_period: "before", release_date: "2017-01-01") }
+      let(:input_params) do
+        ActionController::Parameters.new(release_period: "", release_varies: "embargo", release_embargo: "2yrs").permit!
+      end
+      it "sets release_period to embargo period, release_date=nil" do
+        expect { subject }.to change { permission_template.reload.release_period }.from('before').to('2yrs')
+        expect(permission_template.release_date).to be_nil
+      end
+    end
+  end
+
+  describe "#select_release_varies_option" do
+    let(:admin_set) { create(:admin_set) }
+    let(:form) { described_class.new(permission_template) }
+    subject { form.send(:select_release_varies_option, permission_template) }
+
+    context "with release before date specified" do
+      let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id, release_period: "before", release_date: "2017-01-01") }
+      it "selects release_varies='before'" do
+        expect(form.release_varies).to eq('before')
+        expect(form.release_embargo).to be_nil
+      end
+    end
+
+    context "with release embargo specified" do
+      let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id, release_period: "1yr") }
+      it "selects release_varies='embargo' and value in embargo selectbox" do
+        expect(form.release_varies).to eq('embargo')
+        expect(form.release_embargo).to eq('1yr')
+      end
+    end
+
+    context "with release no-delay (now) selected" do
+      let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id, release_period: "now") }
+      it "selects neither varies option, nor embargo" do
+        expect(form.release_varies).to be_nil
+        expect(form.release_embargo).to be_nil
+      end
+    end
+  end
+
+  describe "#update_release_attributes" do
+    let(:admin_set) { create(:admin_set) }
+    let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+    let(:form) { described_class.new(permission_template) }
+    subject { form.send(:update_release_attributes, input_params) }
+
+    context "with release varies by date selected" do
+      let(:input_params) do
+        ActionController::Parameters.new(release_period: "", release_varies: "before", release_date: "2017-01-01").permit!
+      end
+      it "updates params to release_period=before and keeps date" do
+        expect { subject }.to change { input_params[:release_period] }.from("").to("before")
+        expect(input_params[:release_date]).to eq("2017-01-01")
+        expect(input_params[:release_varies]).to be_nil
+        expect(input_params[:release_embargo]).to be_nil
+      end
+    end
+
+    context "with release varies by embargo selected" do
+      let(:input_params) do
+        ActionController::Parameters.new(release_period: "", release_varies: "embargo", release_embargo: "1yr").permit!
+      end
+      it "updates params to release_period=1yr" do
+        expect { subject }.to change { input_params[:release_period] }.from("").to("1yr")
+        expect(input_params[:release_date]).to be_nil
+        expect(input_params[:release_varies]).to be_nil
+        expect(input_params[:release_embargo]).to be_nil
+      end
+    end
+
+    context "with release no delay (now) selected, after filling out release_date" do
+      let(:input_params) do
+        ActionController::Parameters.new(release_period: "now", release_varies: "", release_embargo: "", release_date: "2017-01-01").permit!
+      end
+      it "updates params to release_period=1yr" do
+        expect { subject }.to change { input_params[:release_date] }.from("2017-01-01").to(nil)
+        expect(input_params[:release_period]).to eq("now")
+        expect(input_params[:release_varies]).to be_nil
+        expect(input_params[:release_embargo]).to be_nil
+      end
+    end
   end
 end

--- a/spec/models/sufia/permission_template_spec.rb
+++ b/spec/models/sufia/permission_template_spec.rb
@@ -1,0 +1,57 @@
+describe Sufia::PermissionTemplate do
+  let(:admin_set) { create(:admin_set) }
+  let(:permission_template) { described_class.new(attributes) }
+  let(:attibutes) { { admin_set_id: admin_set.id } }
+
+  describe "#release_fixed?" do
+    subject { permission_template.release_fixed? }
+    context "with release_period='fixed'" do
+      let(:attributes) { { admin_set_id: admin_set.id, release_period: Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
+      it { is_expected.to be true }
+    end
+    context "with other release_period" do
+      let(:attributes) { { admin_set_id: admin_set.id, release_period: Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#release_no_delay?" do
+    subject { permission_template.release_no_delay? }
+    context "with release_period='now'" do
+      let(:attributes) { { admin_set_id: admin_set.id, release_period: Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_NO_DELAY } }
+      it { is_expected.to be true }
+    end
+    context "with other release_period" do
+      let(:attributes) { { admin_set_id: admin_set.id, release_period: Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#release_before_date?" do
+    subject { permission_template.release_before_date? }
+    context "with release_period='before'" do
+      let(:attributes) { { admin_set_id: admin_set.id, release_period: Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_BEFORE_DATE } }
+      it { is_expected.to be true }
+    end
+    context "with other release_period" do
+      let(:attributes) { { admin_set_id: admin_set.id, release_period: Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#release_embargo?" do
+    subject { permission_template.release_embargo? }
+    context "with release_period='1yr'" do
+      let(:attributes) { { admin_set_id: admin_set.id, release_period: Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR } }
+      it { is_expected.to be true }
+    end
+    context "with release_period='2yrs'" do
+      let(:attributes) { { admin_set_id: admin_set.id, release_period: Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_2_YEARS } }
+      it { is_expected.to be true }
+    end
+    context "with other release_period" do
+      let(:attributes) { { admin_set_id: admin_set.id, release_period: Sufia::PermissionTemplate::RELEASE_TEXT_VALUE_FIXED } }
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/views/sufia/admin/admin_sets/_form_visibility.html.erb_spec.rb
+++ b/spec/views/sufia/admin/admin_sets/_form_visibility.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe 'sufia/admin/admin_sets/_form_visibility.html.erb', type: :view do
+  let(:admin_set) { create(:admin_set) }
+  let(:permission_template) { Sufia::PermissionTemplate.find_or_create_by(admin_set_id: admin_set.id) }
+  before do
+    @form = Sufia::Forms::AdminSetForm.new(admin_set, permission_template)
+    render
+  end
+  it "has the release form" do
+    expect(rendered).to have_selector('#visibility input[type=radio][name="sufia_permission_template[release_period]"][value=now]')
+    expect(rendered).to have_selector('#visibility input[type=radio][name="sufia_permission_template[release_period]"][value=fixed]')
+    expect(rendered).to have_selector('#visibility input[type=radio][name="sufia_permission_template[release_varies]"][value=before]')
+    expect(rendered).to have_selector('#visibility input[type=radio][name="sufia_permission_template[release_varies]"][value=embargo]')
+    expect(rendered).to have_selector('#visibility select[name="sufia_permission_template[release_embargo]"]')
+    expect(rendered).to have_selector('#visibility input[type=date][name="sufia_permission_template[release_date]"]')
+  end
+  it "has the visilibility form" do
+    expect(rendered).to have_selector('#visibility input[type=radio][name="sufia_permission_template[visibility]"][value=open]')
+    expect(rendered).to have_selector('#visibility input[type=radio][name="sufia_permission_template[visibility]"][value=authenticated]')
+    expect(rendered).to have_selector('#visibility input[type=radio][name="sufia_permission_template[visibility]"][value=restricted]')
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/projecthydra-labs/hyku/issues/418

Updates AdminSets to support Release templates. Adds the Release form on the "Release & Visibility" tab.  Also fixes an odd bug in the existing Visibility form where its input fields were surrounded by nested `<label>` tags.

Release templates are stored on the AdminSet's PermissionTemplate in two new attributes (database fields):
* `release_date` = If "Fixed" release, stores required release date.  If "Varies -> date", stores the date which all works must be released before. Otherwise, unspecified.
* `release_period` = If "Fixed" release, literal "fixed". If "No Delay" release, literal "now".  If "Varies -> date", literal "before".  If "Varies -> embargo", stores period of the embargo (e.g. 6mos, 1yr, 2yrs, etc)
(All literal values are specified as constants on PermissionTemplate)
* _UPDATE:_ All these various combos of `release_date` and `release_period` are now in Spec form, see `permission_template_form_spec.rb` updates in this PR.

![screenshot](https://cloud.githubusercontent.com/assets/483997/20448937/1f8ab892-adac-11e6-9377-e770c510eabc.png)

**NOTE: Several to-do's remain:**
- [x] Needs javascript to properly enable/disable subfields on the Release & Visibility form
- [x] Needs specs to prove out all functionality.

Early feedback on both the approach taken & existing code is welcome!

@projecthydra/sufia-code-reviewers
