### PR TITLE
Assign workflow name to PermissionTemplate for AdminSet

### DIFF
--- a/app/controllers/sufia/admin/admin_sets_controller.rb
+++ b/app/controllers/sufia/admin/admin_sets_controller.rb
@@ -43,6 +43,7 @@ module Sufia
 
     def update
       if @admin_set.update(admin_set_params)
+        permission_template.update(permission_template_params)
         redirect_to sufia.admin_admin_sets_path
       else
         setup_form
@@ -52,6 +53,9 @@ module Sufia
 
     def create
       if create_admin_set
+        permission_template_holder = permission_template
+        permission_template_holder.attributes = permission_template_params
+        permission_template_holder.save! # to create permission template on create
         redirect_to sufia.admin_admin_sets_path
       else
         setup_form
@@ -96,7 +100,7 @@ module Sufia
 
       # Find or create the permission_template object for this admin set
       def permission_template
-        PermissionTemplate.find_or_create_by(admin_set_id: @admin_set.id)
+        PermissionTemplate.find_or_initialize_by(admin_set_id: @admin_set.id)
       end
 
       def action_breadcrumb
@@ -114,6 +118,10 @@ module Sufia
 
       def repository_class
         blacklight_config.repository_class
+      end
+
+      def permission_template_params
+        { "workflow_name" => params[:admin_set][:workflow_name] }
       end
   end
 end

--- a/app/forms/sufia/forms/admin_set_form.rb
+++ b/app/forms/sufia/forms/admin_set_form.rb
@@ -21,6 +21,14 @@ module Sufia
         PermissionTemplateForm.new(@permission_template)
       end
 
+      def workflow_name
+        @permission_template.workflow_name
+      end
+
+      def workflows
+        Sipity::Workflow.all.map { |workflow| [workflow.label, workflow.name] }
+      end
+
       class << self
         # This determines whether the allowed parameters are single or multiple.
         # By default it delegates to the model.

--- a/app/views/sufia/admin/admin_sets/_form.html.erb
+++ b/app/views/sufia/admin/admin_sets/_form.html.erb
@@ -24,6 +24,8 @@
                   <%= f.input :thumbnail_id, collection: @form.select_files %>
                 <% end %>
 
+                <%= f.input :workflow_name, as: :select, collection: f.object.workflows %>
+
               </div>
               <div class="panel-footer">
                 <%= link_to 'Cancel', sufia.admin_admin_sets_path, class: 'btn btn-default pull-right'%>

--- a/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
@@ -114,9 +114,7 @@ describe Sufia::Admin::AdminSetsController do
         # Prevent a save which causes Fedora to complain it doesn't know the referenced node.
         expect_any_instance_of(AdminSet).to receive(:save).and_return(true)
         patch :update, params: { id: admin_set,
-                                 admin_set: { title: "Improved title",
-                                              thumbnail_id: "mw22v559x" ,
-                                              workflow_name: "one_step_mediated_deposit" } }
+                                 admin_set: { title: "Improved title", thumbnail_id: "mw22v559x", workflow_name: "one_step_mediated_deposit" } }
         expect(response).to be_redirect
         expect(assigns[:admin_set].title).to eq ['Improved title']
         expect(assigns[:admin_set].thumbnail_id).to eq 'mw22v559x'

--- a/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
@@ -66,7 +66,8 @@ describe Sufia::Admin::AdminSetsController do
         it 'creates file sets' do
           expect(service).to receive(:create).and_return(true)
           post :create, params: { admin_set: { title: 'Test title',
-                                               description: 'test description' } }
+                                               description: 'test description',
+                                               workflow_name: 'default' } }
           expect(response).to be_redirect
         end
       end
@@ -108,15 +109,18 @@ describe Sufia::Admin::AdminSetsController do
 
     describe "#update" do
       let(:admin_set) { create(:admin_set, edit_users: [user]) }
+      let(:permission_template) { Sufia::PermissionTemplate.find_or_create_by(admin_set_id: admin_set.id) }
       it 'updates a record' do
         # Prevent a save which causes Fedora to complain it doesn't know the referenced node.
         expect_any_instance_of(AdminSet).to receive(:save).and_return(true)
         patch :update, params: { id: admin_set,
                                  admin_set: { title: "Improved title",
-                                              thumbnail_id: "mw22v559x" } }
+                                              thumbnail_id: "mw22v559x" ,
+                                              workflow_name: "one_step_mediated_deposit" } }
         expect(response).to be_redirect
         expect(assigns[:admin_set].title).to eq ['Improved title']
         expect(assigns[:admin_set].thumbnail_id).to eq 'mw22v559x'
+        expect(permission_template.workflow_name).to eq 'one_step_mediated_deposit'
       end
     end
   end

--- a/spec/views/sufia/admin/admin_sets/_form.html.erb_spec.rb
+++ b/spec/views/sufia/admin/admin_sets/_form.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe 'sufia/admin/admin_sets/_form.html.erb', type: :view do
+  let(:admin_set) { create(:admin_set) }
+  let!(:workflow) { Sipity::Workflow.create!(name: "default", label: "default") }
+  let!(:permission_template) { Sufia::PermissionTemplate.find_or_create_by(admin_set_id: admin_set.id, workflow_name: 'default') }
+  before do
+    @form = Sufia::Forms::AdminSetForm.new(admin_set, permission_template)
+    render
+  end
+  it "has the edit form" do
+    expect(rendered).to have_select('admin_set[workflow_name]', selected: 'default')
+  end
+end
+  

--- a/spec/views/sufia/admin/admin_sets/_form.html.erb_spec.rb
+++ b/spec/views/sufia/admin/admin_sets/_form.html.erb_spec.rb
@@ -12,4 +12,3 @@ RSpec.describe 'sufia/admin/admin_sets/_form.html.erb', type: :view do
     expect(rendered).to have_select('admin_set[workflow_name]', selected: 'default')
   end
 end
-  


### PR DESCRIPTION
Refs #2844, #2877

Fixes #2902

The WorkflowName is now set in the PermissionTemplate for an AdminSet when saved from the "Edit" tab of an AdminSet.

# TODO (possibly in a follow-up PR)

- [ ] Need to check if there are any loaded workflows before displaying the select list.

@projecthydra/sufia-code-reviewers
