### PR TITLE
Adding error logger and rescue to log errors instead of ending import

### DIFF
--- a/lib/sufia/import.rb
+++ b/lib/sufia/import.rb
@@ -7,6 +7,7 @@ require 'sufia/import/work_builder'
 require 'sufia/import/collection_builder'
 require 'sufia/import/generic_file_translator'
 require 'sufia/import/collection_translator'
+require 'sufia/import/log'
 
 module Sufia
   module Permissions

--- a/lib/sufia/import/collection_builder.rb
+++ b/lib/sufia/import/collection_builder.rb
@@ -34,12 +34,20 @@ module Sufia::Import
 
     def get_members(data)
       members = []
-      data.each do |i|
-        members << Sufia.primary_work_type.find(i)
+      missing_files = []
+      data.each do |id|
+        begin
+          members << Sufia.primary_work_type.find(id)
+        rescue ActiveFedora::ObjectNotFoundError
+          missing_files << id
+        end
+      end
+      if missing_files.count > 0
+        message = "Error getting members #{missing_files.join(', ')}."
+        message += "  #{Sufia.primary_work_type} must be imported before Collections" if missing_files.count == data.count
+        raise message
       end
       members
-    rescue ActiveFedora::ObjectNotFoundError
-      raise "GenericFiles must be imported before Collections"
     end
   end
 end

--- a/lib/sufia/import/log.rb
+++ b/lib/sufia/import/log.rb
@@ -1,0 +1,28 @@
+module Sufia
+  module Import
+    class Log
+      class << self
+        def error(message)
+          file.write(message)
+          file.flush
+        end
+
+        def file
+          @file ||= open_file
+          @file = validate(@file)
+        end
+
+        private
+
+        def validate(file)
+          return open_file unless File.exist?(file.path)
+          file
+        end
+
+        def open_file
+          File.open("import_log.out", (File::WRONLY | File::APPEND | File::CREAT))
+        end
+      end
+    end
+  end
+end

--- a/lib/sufia/import/translator.rb
+++ b/lib/sufia/import/translator.rb
@@ -15,7 +15,13 @@ module Sufia
         raise "No such directory: '#{@import_dir}'" unless Dir.exist?(@import_dir)
         # get filenames
         files = Dir.glob(File.join(@import_dir, '*')).select { |f| exported_json?(f, @filename_prefix) }
-        files.each { |f| import_file(f) }
+        files.each do |file|
+          begin
+            import_file(file)
+          rescue RuntimeError => e
+            Sufia::Import::Log.error("\"#{file}\",\"#{e.message}\"\n")
+          end
+        end
       end
 
       protected

--- a/spec/lib/sufia/import/collection_translator_spec.rb
+++ b/spec/lib/sufia/import/collection_translator_spec.rb
@@ -5,8 +5,9 @@ describe Sufia::Import::CollectionTranslator do
   let(:sufia6_password) { "s6password" }
   let(:translator) { described_class.new(import_dir:  import_directory) }
 
+  let(:collection_file) { File.join(import_directory, "collection_#{collection_id}.json") }
   let(:import_directory) { File.join(fixture_path, 'import') }
-  let(:col_metadata) { JSON.parse(File.read(File.join(import_directory, "collection_#{collection_id}.json")), symbolize_names: true) }
+  let(:col_metadata) { JSON.parse(File.read(collection_file), symbolize_names: true) }
   let(:collection) { Collection.find(collection_id) }
   # used to retrieve the fixture and then test that the object was created with the same id
   let(:collection_id) { '2v23vt57t' }
@@ -35,7 +36,8 @@ describe Sufia::Import::CollectionTranslator do
     end
 
     it 'Errors when it tries to add a nonexistent work' do
-      expect { translator.import }.to raise_error RuntimeError
+      translator.import
+      expect(File.new(Sufia::Import::Log.file.path, 'rb').read).to include("\"#{collection_file}\",\"Error getting members qr46r0963.  GenericWork must be imported before Collections\"")
     end
   end
 end

--- a/spec/lib/sufia/import/log_spec.rb
+++ b/spec/lib/sufia/import/log_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'support/export_json_helper'
+
+describe Sufia::Import::Log do
+  let(:log_name) { described_class.file.path }
+  let(:message) { "My Error\n" }
+  subject { File.new(log_name, 'rb').read }
+
+  before do
+    File.delete(log_name) if File.exist?(log_name)
+    described_class.error(message)
+  end
+  after do
+    File.delete(log_name)
+  end
+
+  it { is_expected.to eq(message) }
+
+  context "when I log multiple times" do
+    let(:second_message) { "Second message\n" }
+    before do
+      described_class.error(second_message)
+    end
+    it { is_expected.to eq(message + second_message) }
+  end
+end


### PR DESCRIPTION
Fixes #2926

Creates a logger that can be tested and reused.  Not using system log since we may want to process the migration log in some fashion separate from any other information.

The log is then used to rescue and note any error that occurs with each file being imported.

Additionally added a more detailed error message when processing collection members since an error on import on a Work or the Collections being process before the works could result in the error.

@projecthydra/sufia-code-reviewers

