### PR TITLE
Logs an error when the Id already exists

### DIFF
--- a/lib/sufia/import/translator.rb
+++ b/lib/sufia/import/translator.rb
@@ -30,6 +30,7 @@ module Sufia
           Rails.logger.debug "Importing #{File.basename(filename)}"
           file_str = File.read(filename)
           json = JSON.parse(file_str)
+          raise "Id exists in Fedora before import: #{json['id']}" if ActiveFedora::Base.exists?(json["id"])
           build_from_json(json)
         end
 


### PR DESCRIPTION
Fixes #2925

Make a check to be certain we are not reprocessing files and log an error if that happens.

@hackmastera 

