### PR TITLE
create linked facets in index results

### DIFF
--- a/app/helpers/sufia/sufia_helper_behavior.rb
+++ b/app/helpers/sufia/sufia_helper_behavior.rb
@@ -123,6 +123,33 @@ module Sufia
       safe_join(links, ", ")
     end
 
+    # A Blacklight helper_method
+    #
+    # @example
+    #   link_to_each_facet_field({ value: "Imaging > Object Photography", config: { helper_facet: :document_types_sim }})
+    #   ```html
+    #   <a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Imaging\">Imaging</a> &gt; <a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Object+Photography\">Object Photography</a>
+    #   ```
+    #
+    # @param options [Hash] from blacklight invocation of helper_method
+    # @option options [Array<#strip>] :value
+    # @option options [Hash>] :config Example: { separator: '>', helper_facet: :document_types_sim, output_separator: '::' }
+    # @return the html_safe facet links separated by the given separator (default: ' > ') to indicate facet hierarchy
+    #
+    # @raise KeyError when the options are note properly configured
+    def link_to_each_facet_field(options)
+      config = options.fetch(:config)
+      separator = config.fetch(:separator, ' > ')
+      output_separator = config.fetch(:output_separator, separator)
+      facet_search = config.fetch(:helper_facet)
+      facet_fields = Array.wrap(options.fetch(:value)).first.split(separator).map(&:strip)
+
+      facet_links = facet_fields.map do |type|
+        link_to(type, main_app.search_catalog_path(f: { facet_search => [type] }))
+      end
+      safe_join(facet_links, output_separator)
+    end
+
     # Uses Rails auto_link to add links to fields
     #
     # @param field [String,Hash] string to format and escape, or a hash as per helper_method

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -68,6 +68,29 @@ describe SufiaHelper, type: :helper do
     end
   end
 
+  describe "#link_to_each_facet_field" do
+    subject { helper.link_to_each_facet_field(options) }
+    context "with helper_facet and default separator" do
+      let(:options) { { config: { helper_facet: Solrizer.solr_name("document_types", :facetable).to_sym }, value: ["Imaging > Object Photography"] } }
+      it { is_expected.to eq("<a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Imaging\">Imaging</a> &gt; <a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Object+Photography\">Object Photography</a>") }
+    end
+
+    context "with helper_facet and optional separator" do
+      let(:options) { { config: { helper_facet: Solrizer.solr_name("document_types", :facetable).to_sym, separator: " : " }, value: ["Imaging : Object Photography"] } }
+      it { is_expected.to eq("<a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Imaging\">Imaging</a> : <a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Object+Photography\">Object Photography</a>") }
+    end
+
+    context "with :output_separator" do
+      let(:options) { { config: { helper_facet: Solrizer.solr_name("document_types", :facetable).to_sym, output_separator: ' ~ ', separator: ":" }, value: ["Imaging : Object Photography"] } }
+      it { is_expected.to eq("<a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Imaging\">Imaging</a> ~ <a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Object+Photography\">Object Photography</a>") }
+    end
+
+    context "with :no_spaces_around_separator" do
+      let(:options) { { config: { helper_facet: Solrizer.solr_name("document_types", :facetable).to_sym, output_separator: '~', separator: ":" }, value: ["Imaging : Object Photography"] } }
+      it { is_expected.to eq("<a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Imaging\">Imaging</a>~<a href=\"/catalog?f%5Bdocument_types_sim%5D%5B%5D=Object+Photography\">Object Photography</a>") }
+    end
+  end
+
   describe "has_collection_search_parameters?" do
     subject { helper }
     context "when cq is set" do


### PR DESCRIPTION
A helper method to create links to facets in index results.

This is something I did for the Art Institute but wonder if it might be useful for Sufia. I looked at the available helper methods and none of them were quite what I needed so I essentially pulled all the bits I needed into this one. It lets me index and create links from the catalog_controller, putting the facet term into the options that BL passes, and using the > separator to show their hierarchy. 

```config.add_index_field solr_name("document_types", :stored_searchable),  label: AIC.documentType.label, helper_method: :link_to_each_facet_field, helper_facet: solr_name("document_types", :facetable).to_sym ```

<img width="591" alt="example" src="https://cloud.githubusercontent.com/assets/186452/20670902/cae9ea46-b540-11e6-97ad-7d094197aa9e.png">

I understand this might not be the best way to accomplish this, and would be happy to re-work it (and the tests) until it meets Sufia standards. But maybe it'll be useful and helpful to others.

Changes proposed in this pull request:
* Add a helper method to create linked facets in index results  
* Add unit helper test of method

@projecthydra/sufia-code-reviewers

