### PR TITLE
add notion of 'depositor review' to one step mediated deposit workflow

### DIFF
--- a/app/services/sufia/workflow/changes_required_notification.rb
+++ b/app/services/sufia/workflow/changes_required_notification.rb
@@ -1,0 +1,22 @@
+module Sufia
+  module Workflow
+    class ChangesRequiredNotification < AbstractNotification
+      protected
+
+        def subject
+          'Your deposit requires changes'
+        end
+
+        def message
+          "#{title} (#{work_id}) requires additional changes before approval.\n\n '#{comment}'"
+        end
+
+      private
+
+        def users_to_notify
+          user_key = ActiveFedora::Base.find(work_id).depositor
+          super << ::User.find_by(email: user_key)
+        end
+    end
+  end
+end

--- a/lib/generators/sufia/templates/workflow.json.erb
+++ b/lib/generators/sufia/templates/workflow.json.erb
@@ -3,7 +3,7 @@
         {
             "name": "one_step_mediated_deposit",
             "label": "One-step mediated deposit workflow",
-            "description": "A single-step workflow for mediated deposit",
+            "description": "A single-step workflow for mediated deposit in which all deposits must be approved by a reviewer. Reviewer may also send deposits back to the depositor.",
             "actions": [
                 {
                     "name": "deposit",
@@ -15,9 +15,25 @@
                             "name": "Sufia::Workflow::PendingReviewNotification",
                             "to": ["approving"]
                         }
+                    ],
+                    "methods": [
+                        "CurationConcerns::Workflow::DeactivateObject"
                     ]
-                },
-                {
+                }, {
+                    "name": "request_changes",
+                    "from_states": [{"names": ["complete", "pending_review"], "roles": ["approving"]}],
+                    "transition_to": "changes_required",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Sufia::Workflow::ChangesRequiredNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "CurationConcerns::Workflow::DeactivateObject"
+                    ]
+                }, {
                     "name": "approve",
                     "from_states": [{"names": ["pending_review"], "roles": ["approving"]}],
                     "transition_to": "complete",
@@ -30,6 +46,17 @@
                     ],
                     "methods": [
                         "CurationConcerns::Workflow::ActivateObject"
+                    ]
+                }, {
+                    "name": "request_review",
+                    "from_states": [{"names": ["changes_required"], "roles": ["depositing"]}],
+                    "transition_to": "pending_review",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Sufia::Workflow::PendingReviewNotification",
+                            "to": ["approving"]
+                        }
                     ]
                 }
             ]

--- a/spec/services/sufia/workflow/changes_required_notification_spec.rb
+++ b/spec/services/sufia/workflow/changes_required_notification_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe Sufia::Workflow::ChangesRequiredNotification do
+  let(:approver) { create(:user) }
+  let(:depositor) { create(:user) }
+  let(:to_user) { create(:user) }
+  let(:cc_user) { create(:user) }
+  let(:work) { create(:generic_work, user: depositor) }
+  let(:entity) { create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
+  let(:comment) { double("comment", comment: 'A pleasant read') }
+  let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
+
+  describe ".send_notification" do
+    it 'sends a message to all users' do
+      expect(approver).to receive(:send_message).once.and_call_original
+
+      expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
+        .to change { depositor.mailbox.inbox.count }.by(1)
+        .and change { to_user.mailbox.inbox.count }.by(1)
+        .and change { cc_user.mailbox.inbox.count }.by(1)
+    end
+    context 'without carbon-copied users' do
+      let(:recipients) { { 'to' => [to_user] } }
+      it 'sends a message to the to user(s)' do
+        expect(approver).to receive(:send_message).once.and_call_original
+        expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
+          .to change { depositor.mailbox.inbox.count }.by(1)
+          .and change { to_user.mailbox.inbox.count }.by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes #2880 
fixes #2879 

The approach here would allow for a notion of an admin/reviewer type person to move a work back to `depositor_review` at any point in time (during `pending_review` or `complete`). The work is set as inactive and is hidden from search. After the depositor submits the updated work to `pending_review`, the admin/reviewer can direct the work back to `depositor_review` for even more review or to be `complete` and the work activated (visible in search).

