### PR TITLE
Use strings instead of symbols for workflow notification recipients

### DIFF
--- a/app/services/sufia/workflow/abstract_notification.rb
+++ b/app/services/sufia/workflow/abstract_notification.rb
@@ -32,7 +32,7 @@ module Sufia
       private
 
         def users_to_notify
-          recipients[:to] + recipients[:cc]
+          recipients['to'] + recipients['cc']
         end
     end
   end

--- a/spec/services/sufia/workflow/complete_notification_spec.rb
+++ b/spec/services/sufia/workflow/complete_notification_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sufia::Workflow::CompleteNotification do
   let(:work) { create(:generic_work, user: depositor) }
   let(:entity) { create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
-  let(:recipients) { { to: [to_user], cc: [cc_user] } }
+  let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
 
   describe ".send_notification" do
     it 'sends a message to all users' do

--- a/spec/services/sufia/workflow/pending_review_notification_spec.rb
+++ b/spec/services/sufia/workflow/pending_review_notification_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Sufia::Workflow::PendingReviewNotification do
   let(:work) { create(:generic_work, user: depositor) }
   let(:entity) { create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
-  let(:recipients) { { to: [to_user], cc: [cc_user] } }
+  let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
 
   describe ".send_notification" do
     it 'sends a message to all users except depositor' do


### PR DESCRIPTION
Because the underlying implementation apparently expects strings.

Fixes #2943
Refs #2944

