### PR TITLE
Remove enable_mediated_deposit feature flipper.

### DIFF
--- a/app/actors/sufia/create_with_files_actor.rb
+++ b/app/actors/sufia/create_with_files_actor.rb
@@ -3,7 +3,7 @@ module Sufia
   class CreateWithFilesActor < CurationConcerns::Actors::AbstractActor
     def create(attributes)
       self.uploaded_file_ids = attributes.delete(:uploaded_files)
-      validate_files && mark_inactive && next_actor.create(attributes) && attach_files
+      validate_files && next_actor.create(attributes) && attach_files
     end
 
     def update(attributes)
@@ -41,15 +41,6 @@ module Sufia
       def uploaded_files
         return [] if uploaded_file_ids.empty?
         @uploaded_files ||= UploadedFile.find(uploaded_file_ids)
-      end
-
-      def mark_inactive
-        return true unless Flipflop.enable_mediated_deposit?
-        curation_concern.state = inactive_uri
-      end
-
-      def inactive_uri
-        ::RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive')
       end
   end
 end

--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -57,13 +57,5 @@ module Sufia::Forms
     def self.build_permitted_params
       super + [:on_behalf_of, { collection_ids: [] }]
     end
-
-    # If mediated deposit is indicated, don't allow edit access to be granted to other users.
-    def self.sanitize_params(form_params)
-      params = super
-      return params unless Flipflop.enable_mediated_deposit?
-      params.fetch(:permissions_attributes, []).reject! { |attributes| attributes['access'] == 'edit' }
-      params
-    end
   end
 end

--- a/app/search_builders/sufia/catalog_search_builder.rb
+++ b/app/search_builders/sufia/catalog_search_builder.rb
@@ -14,7 +14,6 @@ class Sufia::CatalogSearchBuilder < Sufia::SearchBuilder
 
   # show works that are in the active state.
   def show_only_active_records(solr_parameters)
-    return unless Flipflop.enable_mediated_deposit?
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] << '-suppressed_bsi:true'
   end

--- a/app/search_builders/sufia/my_shares_search_builder.rb
+++ b/app/search_builders/sufia/my_shares_search_builder.rb
@@ -10,6 +10,6 @@ class Sufia::MySharesSearchBuilder < Sufia::SearchBuilder
       "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: scope.current_user.user_key)
     ]
 
-    solr_parameters[:fq] += ['-suppressed_bsi:true'] if Flipflop.enable_mediated_deposit?
+    solr_parameters[:fq] += ['-suppressed_bsi:true']
   end
 end

--- a/app/services/sufia/workflow/workflow_by_admin_set_strategy.rb
+++ b/app/services/sufia/workflow/workflow_by_admin_set_strategy.rb
@@ -7,7 +7,7 @@ module Sufia
 
       # @return [String] The name of the workflow by admin_set to use
       def workflow_name
-        return 'default' unless @admin_set_id && Flipflop.enable_mediated_deposit?
+        return 'default' unless @admin_set_id
         Sufia::PermissionTemplate.find_by!(admin_set_id: @admin_set_id).workflow_name
       end
     end

--- a/app/views/curation_concerns/base/_form_share.html.erb
+++ b/app/views/curation_concerns/base/_form_share.html.erb
@@ -25,7 +25,7 @@
     <tr>
       <td>
 	<%= permission_fields.select :access, Sufia.config.permission_levels, {}, class: 'form-control select_perm' %>
-        
+
       </td>
       <td>
 	<%= permission_fields.label :agent_name, class: "control-label" do %>
@@ -37,8 +37,6 @@
   <% end %>
 </table>
 
-<% available_permissions = Sufia.config.permission_levels %>
-<% available_permissions.reject! { |_, v| v == 'edit'} if Flipflop.enable_mediated_deposit? %>
 <h2>Share work with other users</h2>
 <p class="sr-only">Use the add button to give access to one <%=t('sufia.account_label') %> at a time (it will be added to the list below).
   Select the user, by name or <%= t('sufia.account_label') %>. Then select the access level you wish to grant and click on Add this

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -5,9 +5,7 @@
       <%= render 'work_title', presenter: @presenter %>
     </header>
 
-    <% if Flipflop.enable_mediated_deposit? %>
-      <span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>
-    <% end %>
+    <span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>
   </div>
   <div class="col-sm-8">
     <%= render 'work_description', presenter: @presenter %>
@@ -26,13 +24,9 @@
 <div class="row">
   <div class="col-sm-12">
     <%= render 'items', presenter: @presenter %>
-    <% if Flipflop.enable_mediated_deposit? %>
-      <%= render 'workflow_actions_widget', presenter: @presenter %>
-    <% end %>
+    <%= render 'workflow_actions_widget', presenter: @presenter %>
     <%# TODO: we may consider adding these partials in the future %>
     <%#= render 'sharing_with', presenter: @presenter %>
     <%#= render 'user_activity', presenter: @presenter %>
   </div>
 </div>
-
-

--- a/config/features.rb
+++ b/config/features.rb
@@ -7,8 +7,4 @@ Flipflop.configure do
   feature :assign_admin_set,
           default: true,
           description: "Ability to assign uploaded items to an admin set"
-
-  feature :enable_mediated_deposit,
-          default: false,
-          description: "Turn on mediation for all deposits"
 end

--- a/spec/actors/sufia/create_with_files_actor_spec.rb
+++ b/spec/actors/sufia/create_with_files_actor_spec.rb
@@ -46,22 +46,4 @@ describe Sufia::CreateWithFilesActor do
       end
     end
   end
-
-  describe "mediated deposit" do
-    subject { actor.curation_concern.state }
-    let(:inactive_uri) { RDF::URI('http://fedora.info/definitions/1/0/access/ObjState#inactive') }
-    before do
-      allow(Flipflop).to receive(:enable_mediated_deposit?).and_return(mediation_enabled)
-      allow(AttachFilesToWorkJob).to receive(:perform_later).with(GenericWork, [uploaded_file1, uploaded_file2])
-      actor.create(attributes)
-    end
-    context "when enabled" do
-      let(:mediation_enabled) { true }
-      it { is_expected.to eq inactive_uri }
-    end
-    context "when disabled" do
-      let(:mediation_enabled) { false }
-      it { is_expected.to be nil }
-    end
-  end
 end

--- a/spec/forms/sufia/forms/work_form_spec.rb
+++ b/spec/forms/sufia/forms/work_form_spec.rb
@@ -34,26 +34,14 @@ describe Sufia::Forms::WorkForm, :no_clean do
     end
     subject { described_class.model_attributes(ActionController::Parameters.new(attributes)) }
 
-    context "without mediated deposit" do
-      context "and a user is granted edit access" do
-        let(:attributes) { { permissions_attributes: [{ type: 'person', name: 'justin', access: 'edit' }] } }
-        it { is_expected.to eq ActionController::Parameters.new(permissions_attributes: [ActionController::Parameters.new(type: 'person', name: 'justin', access: 'edit')]).permit! }
-      end
+    context "when a user is granted edit access" do
+      let(:attributes) { { permissions_attributes: [{ type: 'person', name: 'justin', access: 'edit' }] } }
+      it { is_expected.to eq ActionController::Parameters.new(permissions_attributes: [ActionController::Parameters.new(type: 'person', name: 'justin', access: 'edit')]).permit! }
     end
 
-    context "with mediated deposit" do
-      before do
-        allow(Flipflop).to receive(:enable_mediated_deposit?).and_return(true)
-      end
-      context "and a user is granted edit access" do
-        let(:attributes) { { permissions_attributes: [{ type: 'person', name: 'justin', access: 'edit' }] } }
-        it { is_expected.to eq ActionController::Parameters.new(permissions_attributes: []).permit! }
-      end
-
-      context "without permssions being set" do
-        let(:attributes) { {} }
-        it { is_expected.to eq ActionController::Parameters.new.permit! }
-      end
+    context "without permssions being set" do
+      let(:attributes) { {} }
+      it { is_expected.to eq ActionController::Parameters.new.permit! }
     end
   end
 end

--- a/spec/models/flipflop_spec.rb
+++ b/spec/models/flipflop_spec.rb
@@ -5,8 +5,4 @@ RSpec.describe Flipflop do
     subject { described_class.assign_admin_set? }
     it { is_expected.to be true }
   end
-  describe "enable_mediated_deposit?" do
-    subject { described_class.enable_mediated_deposit? }
-    it { is_expected.to be false }
-  end
 end

--- a/spec/search_builder/sufia/catalog_search_builder_spec.rb
+++ b/spec/search_builder/sufia/catalog_search_builder_spec.rb
@@ -39,28 +39,10 @@ describe Sufia::CatalogSearchBuilder do
   end
 
   describe "#show_only_active_records" do
-    before do
-      allow(Flipflop).to receive(:enable_mediated_deposit?).and_return(mediation_enabled)
-    end
-
     subject { builder.show_only_active_records(solr_params) }
-
-    context "with mediated deposit enabled" do
-      let(:user_query) { nil }
-      let(:mediation_enabled) { true }
-      it "includes suppressed switch" do
-        subject
-        expect(solr_params[:fq]).to eq ["-suppressed_bsi:true"]
-      end
-    end
-
-    context "with mediated deposit disabled" do
-      let(:user_query) { nil }
-      let(:mediation_enabled) { false }
-      it "does not include suppressed switch" do
-        subject
-        expect(solr_params[:fq]).to be_empty
-      end
+    it "includes suppressed switch" do
+      subject
+      expect(solr_params[:fq]).to eq ["-suppressed_bsi:true"]
     end
   end
 end

--- a/spec/search_builder/sufia/my_shares_search_builder_spec.rb
+++ b/spec/search_builder/sufia/my_shares_search_builder_spec.rb
@@ -17,34 +17,24 @@ describe Sufia::MySharesSearchBuilder do
     allow(ActiveFedora::SolrQueryBuilder).to receive(:construct_query_for_rel)
       .with(depositor: me.user_key)
       .and_return("depositor")
-    allow(Flipflop).to receive(:enable_mediated_deposit?).and_return(mediation_enabled)
   end
 
-  let(:mediation_enabled) { false }
   subject { builder.to_hash['fq'] }
 
   it "filters things we have access to in which we are not the depositor" do
     expect(subject).to eq ["access_filter1 OR access_filter2",
                            "{!terms f=has_model_ssim}GenericWork,Collection",
-                           "-depositor"]
+                           "-depositor",
+                           "-suppressed_bsi:true"]
   end
 
   describe "mediated deposit" do
     let(:user_query) { nil }
 
-    context "with mediated deposit enabled" do
-      let(:mediation_enabled) { true }
+    context "with suppressed items" do
       it "does includes suppressed switch" do
         builder.show_only_shared_files(solr_params)
         expect(solr_params[:fq]).to eq ["-depositor", "-suppressed_bsi:true"]
-      end
-    end
-
-    context "with mediated deposit disabled" do
-      let(:mediation_enabled) { false }
-      it "does not include suppressed switch" do
-        builder.show_only_shared_files(solr_params)
-        expect(solr_params[:fq]).to eq ["-depositor"]
       end
     end
   end

--- a/spec/services/sufia/workflow/workflow_by_admin_set_strategy_spec.rb
+++ b/spec/services/sufia/workflow/workflow_by_admin_set_strategy_spec.rb
@@ -1,7 +1,4 @@
 describe Sufia::Workflow::WorkflowByAdminSetStrategy, :no_clean do
-  before do
-    allow(Flipflop).to receive(:enable_mediated_deposit?) { true }
-  end
   context "when using default workflow strategy" do
     let(:workflow_strategy) { described_class.new(nil, {}) }
 
@@ -20,13 +17,6 @@ describe Sufia::Workflow::WorkflowByAdminSetStrategy, :no_clean do
     describe '#workflow_name' do
       subject { workflow_strategy.workflow_name }
       it { is_expected.to eq workflow_name }
-      context 'with mediated deposit disabled' do
-        before do
-          allow(Flipflop).to receive(:enable_mediated_deposit?) { false }
-        end
-        subject { workflow_strategy.workflow_name }
-        it { is_expected.to eq 'default' }
-      end
     end
   end
 end

--- a/spec/views/curation_concerns/base/show.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/show.html.erb_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 describe 'curation_concerns/base/show.html.erb', type: :view do
-  let(:solr_document) { SolrDocument.new(id: '999', date_modified_dtsi: '2011-04-01') }
+  let(:solr_document) do
+    SolrDocument.new(id: '999',
+                     date_modified_dtsi: '2011-04-01',
+                     has_model_ssim: ['GenericWork'])
+  end
   let(:ability) { double }
   let(:presenter) do
     Sufia::WorkShowPresenter.new(solr_document, ability)


### PR DESCRIPTION
This flipper is no longer needed now that Sufia ships with two usable workflows, and the ability to assign workflows to admin sets.

While doing so, remove or reduce (perhaps) unnecessary sleep statements in specs to prevent Travis hangs.

Fixes #2952