### PR TITLE
Clarifying Prerequisites section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Sufia 7.x requires the following software to work:
 1. [FITS](#characterization) version 0.8.x (0.8.5 is known to be good)
 1. [LibreOffice](#derivatives)
 
-**NOTE: If you do not already have Solr and Fedora instances you can use in your development environment, you may use hydra-jetty (instructions are provided below to get you up and running quickly and with minimal hassle).**
+**NOTE: The [Sufia Development Guide](https://github.com/projecthydra/sufia/wiki/Sufia-Development-Guide) has instructions for installing Solr and Fedora in a development environment.**
 
 ### Characterization
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ After installing the Prerequisites:
 
 Sufia 7.x requires the following software to work:
 
-1. [Solr](http://lucene.apache.org/solr/) version >= 5.x (tested up to 6.2.0)
-1. [Fedora Commons](http://www.fedora-commons.org/) digital repository version >= 4.5.1 (tested up to 4.6.0)
+1. [Solr](http://lucene.apache.org/solr/) version >= 5.x (tested up to 6.3.0)
+1. [Fedora Commons](http://www.fedora-commons.org/) digital repository version >= 4.5.1 (tested up to 4.7.0)
 1. A SQL RDBMS (MySQL, PostgreSQL), though **note** that SQLite will be used by default if you're looking to get up and running quickly
 1. [Redis](http://redis.io/), a key-value store
 1. [ImageMagick](http://www.imagemagick.org/) with JPEG-2000 support

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ After installing the Prerequisites:
 
 Sufia 7.x requires the following software to work:
 
-1. Solr version >= 5.x (tested up to 6.2.0)
+1. [Solr](http://lucene.apache.org/solr/) version >= 5.x (tested up to 6.2.0)
 1. [Fedora Commons](http://www.fedora-commons.org/) digital repository version >= 4.5.1 (tested up to 4.6.0)
 1. A SQL RDBMS (MySQL, PostgreSQL), though **note** that SQLite will be used by default if you're looking to get up and running quickly
 1. [Redis](http://redis.io/), a key-value store


### PR DESCRIPTION
The note about hydra_jetty in the Prerequisites portion of the README is no longer correct.

Changes proposed in this pull request:
* @227aa57566484c89aef298c47a15b04c656c9920 Add link to Solr (all the other prequisits have links). 
* @4b22197aa16fdd5bf1a093217e356b38c6de6e00 The instructions for installing Fedora Commons and Solr have moved; hydra-jetty is no longer maintained.
* @2cde826496956cb09c90aa7565db187e1358277d Bumping tested versions based on feedback from @mjgiarlo

@projecthydra/sufia-code-reviewers
