### PR TITLE
Give a file its original filename instead of the interstitial one we use

### DIFF
--- a/lib/sufia/import/version_builder.rb
+++ b/lib/sufia/import/version_builder.rb
@@ -22,6 +22,10 @@ module Sufia::Import
 
         File.delete(filename_on_disk)
       end
+      # give the actual file its original file_name as opposed to the one we
+      # used for convenience in this script
+      file_set.original_file.file_name = file_set.label
+      file_set.original_file.save
     end
 
     private

--- a/spec/lib/sufia/import/version_builder_spec.rb
+++ b/spec/lib/sufia/import/version_builder_spec.rb
@@ -5,7 +5,7 @@ describe Sufia::Import::VersionBuilder do
   let(:sufia6_user) { "s6user" }
   let(:sufia6_password) { "s6password" }
   let(:builder) { described_class.new }
-  let(:file_set) { create(:file_set, user: user) }
+  let(:file_set) { create(:file_set, user: user, label: 'my label') }
   subject { file_set }
 
   let(:version1_uri) { "http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version1" }
@@ -54,11 +54,13 @@ describe Sufia::Import::VersionBuilder do
       version2.unlink
     end
     it "creates versions" do
-      expect(file_set.original_file.versions.all.count).to eq(2)
-      expect(file_set.original_file.versions.all.map(&:label)).to contain_exactly("version1", "version2")
-      expect(file_set.original_file.content).to eq("hello world! version2")
-      expect(file_set.original_file.date_created).to eq(["2016-09-29T15:58:00.639Z"])
-      expect(file_set.original_file.versions.all.map { |v| Hydra::PCDM::File.new(v.uri).date_created.first }).to contain_exactly("2016-09-28T20:00:14.658Z", "2016-09-29T15:58:00.639Z")
+      of = Hydra::PCDM::File.find file_set.original_file.id
+      expect(of.versions.all.count).to eq(2)
+      expect(of.versions.all.map(&:label)).to contain_exactly("version1", "version2")
+      expect(of.content).to eq("hello world! version2")
+      expect(of.date_created).to eq(["2016-09-29T15:58:00.639Z"])
+      expect(of.versions.all.map { |v| Hydra::PCDM::File.new(v.uri).date_created.first }).to contain_exactly("2016-09-28T20:00:14.658Z", "2016-09-29T15:58:00.639Z")
+      expect(of.file_name).to eq ["my label"]
     end
     context "when fileset has nil id" do
       it "raises runtime error" do


### PR DESCRIPTION
during import, fixes #2948

@projecthydra/sufia-code-reviewers
