### PR TITLE
Correction to Tumblr share link

### DIFF
--- a/app/views/curation_concerns/base/_social_media.html.erb
+++ b/app/views/curation_concerns/base/_social_media.html.erb
@@ -39,7 +39,7 @@
   <% end %>
 
   <!-- Sharingbutton Tumblr -->
-  <%= link_to "https://www.tumblr.com/widgets/share/tool?#{{posttype: 'link', content: share_url, shareSource: 'tumblr_share_button'}.to_param}", class: 'resp-sharing-button__link', target: '_blank', rel: 'noopener noreferrer', title: t('curation_concerns.base.social_media.tumblr') do %>
+  <%= link_to "https://www.tumblr.com/widgets/share/tool?#{{posttype: 'link', canonicalUrl: share_url, shareSource: 'tumblr_share_button'}.to_param}", class: 'resp-sharing-button__link', target: '_blank', rel: 'noopener noreferrer', title: t('curation_concerns.base.social_media.tumblr') do %>
     <div class="resp-sharing-button resp-sharing-button--tumblr resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
       <svg version="1.1" x="0px" y="0px" width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
           <g>

--- a/spec/views/curation_concerns/base/_social_media.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_social_media.html.erb_spec.rb
@@ -13,6 +13,6 @@ describe 'curation_concerns/base/_social_media.html.erb', type: :view do
     expect(page).to have_link '', href: 'https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Fexample.com%2F'
     expect(page).to have_link '', href: 'https://twitter.com/intent/tweet/?text=Example&url=http%3A%2F%2Fexample.com%2F'
     expect(page).to have_link '', href: 'https://plus.google.com/share?url=http%3A%2F%2Fexample.com%2F'
-    expect(page).to have_link '', href: 'https://www.tumblr.com/widgets/share/tool?content=http%3A%2F%2Fexample.com%2F&posttype=link&shareSource=tumblr_share_button'
+    expect(page).to have_link '', href: 'https://www.tumblr.com/widgets/share/tool?canonicalUrl=http%3A%2F%2Fexample.com%2F&posttype=link&shareSource=tumblr_share_button'
   end
 end


### PR DESCRIPTION
The present link results in a "Not found" error. The correctly routes to the Tumblr login page.

@projecthydra/sufia-code-reviewers

