### PR TITLE
Add a default admin set

### DIFF
--- a/app/actors/sufia/default_admin_set_actor.rb
+++ b/app/actors/sufia/default_admin_set_actor.rb
@@ -1,0 +1,42 @@
+module Sufia
+  # Ensures that the default AdminSet id is set if this form doesn't have
+  # an admin_set_id provided. This should come before the
+  # CurationConcerns::Actors::InitializeWorkflowActor, so that the correct
+  # workflow can be kicked off.
+  class DefaultAdminSetActor < CurationConcerns::Actors::AbstractActor
+    def create(attributes)
+      ensure_admin_set_attribute!(attributes)
+      next_actor.create(attributes)
+    end
+
+    def update(attributes)
+      ensure_admin_set_attribute!(attributes)
+      next_actor.update(attributes)
+    end
+
+    private
+
+      def ensure_admin_set_attribute!(attributes)
+        return if attributes[:admin_set_id].present?
+        attributes[:admin_set_id] = default_admin_set_id
+      end
+
+      DEFAULT_ID = 'admin_set/default'.freeze
+
+      def default_admin_set_id
+        create_default_admin_set unless default_exists?
+        DEFAULT_ID
+      end
+
+      def default_exists?
+        AdminSet.exists?(DEFAULT_ID)
+      end
+
+      # Creates the default AdminSet and an associated PermissionTemplate with workflow
+      def create_default_admin_set
+        AdminSet.create!(id: DEFAULT_ID, title: ['Default Admin Set']).tap do |_as|
+          PermissionTemplate.create!(admin_set_id: DEFAULT_ID, workflow_name: 'default')
+        end
+      end
+  end
+end

--- a/app/services/sufia/actor_factory.rb
+++ b/app/services/sufia/actor_factory.rb
@@ -9,6 +9,7 @@ module Sufia
        CurationConcerns::Actors::AttachFilesActor,
        CurationConcerns::Actors::ApplyOrderActor,
        CurationConcerns::Actors::InterpretVisibilityActor,
+       DefaultAdminSetActor,
        CurationConcerns::Actors::InitializeWorkflowActor,
        ApplyPermissionTemplateActor,
        model_actor(curation_concern)]

--- a/config/features.rb
+++ b/config/features.rb
@@ -4,6 +4,8 @@ Flipflop.configure do
   strategy :active_record, class: Sufia::Feature
   strategy :default
 
+  # Note, if this is deactivated, a default admin set will be created and all
+  # works will be assigned to it when they are created.
   feature :assign_admin_set,
           default: true,
           description: "Ability to assign uploaded items to an admin set"

--- a/spec/actors/sufia/default_admin_set_actor_spec.rb
+++ b/spec/actors/sufia/default_admin_set_actor_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe Sufia::DefaultAdminSetActor do
+  let(:next_actor) do
+    double('next actor', create: true,
+                         curation_concern: work,
+                         update: true,
+                         user: depositor)
+  end
+  let(:actor) do
+    CurationConcerns::Actors::ActorStack.new(work, depositor, [described_class])
+  end
+  let(:depositor) { create(:user) }
+  let(:work) { build(:generic_work) }
+  let(:admin_set) { create(:admin_set) }
+  let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+
+  describe "create" do
+    before do
+      allow(CurationConcerns::Actors::RootActor).to receive(:new).and_return(next_actor)
+    end
+
+    context "when admin_set_id is blank" do
+      let(:attributes) { { admin_set_id: '' } }
+      let(:default_id) { described_class::DEFAULT_ID }
+
+      it "creates the default AdminSet with a PermissionTemplate and calls the next actor with the default admin set id" do
+        expect(next_actor).to receive(:create).with(admin_set_id: default_id).and_return(true)
+        expect { actor.create(attributes) }.to change { AdminSet.count }.by(1)
+          .and change { Sufia::PermissionTemplate.count }.by(1)
+      end
+    end
+
+    context "when admin_set_id is provided" do
+      let(:attributes) { { admin_set_id: admin_set.id } }
+
+      it "uses the provided id and returns true" do
+        expect(next_actor).to receive(:create).with(attributes).and_return(true)
+        expect(actor.create(attributes)).to be true
+      end
+    end
+  end
+end

--- a/spec/services/sufia/actor_factory_spec.rb
+++ b/spec/services/sufia/actor_factory_spec.rb
@@ -13,6 +13,7 @@ describe Sufia::ActorFactory, :no_clean do
                          CurationConcerns::Actors::AttachFilesActor,
                          CurationConcerns::Actors::ApplyOrderActor,
                          CurationConcerns::Actors::InterpretVisibilityActor,
+                         Sufia::DefaultAdminSetActor,
                          CurationConcerns::Actors::InitializeWorkflowActor,
                          Sufia::ApplyPermissionTemplateActor,
                          CurationConcerns::Actors::GenericWorkActor]
@@ -30,6 +31,7 @@ describe Sufia::ActorFactory, :no_clean do
         CurationConcerns::Actors::AttachFilesActor,
         CurationConcerns::Actors::ApplyOrderActor,
         CurationConcerns::Actors::InterpretVisibilityActor,
+        Sufia::DefaultAdminSetActor,
         CurationConcerns::Actors::InitializeWorkflowActor,
         Sufia::ApplyPermissionTemplateActor,
         CurationConcerns::Actors::GenericWorkActor


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

This reduced conditionals, as now every newly created or updated work
will have an admin set.  This is required because the AdminSet
determines which workflow to use.  The Default admin set specifies the
default (direct deposit) workflow.

Ref projecthydra-labs/hyku#481 (needs port to Hyrax)