### PR TITLE
Make select_work modal batch-aware

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,3 +100,6 @@ RSpec/NestedGroups:
 
 RSpec/LeadingSubject:
   Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: false

--- a/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
@@ -8,14 +8,19 @@ module Sufia
       self.work_form_service = BatchUploadFormService
       self.curation_concern_type = work_form_service.form_class.model_class # includes CanCan side-effects
       # We use BatchUploadItem as a null stand-in curation_concern_type.
-      # The actual permission is checked dynamically via `authorize!` during #create.
+      # The actual permission is checked dynamically during #create.
     end
 
     # The permissions to create a batch are not as important as the permissions for the concern being batched.
+    # @note we don't call `authorize!` directly, since `authorized_models` already checks `user.can? :create, ...`
     def create
       authenticate_user!
-      authorize! :create, params[:batch_upload_item][:payload_concern].constantize
-      create_update_job
+      unsafe_pc = params[:batch_upload_item][:payload_concern]
+      # Calling constantize on user params is disfavored (per brakeman), so we sanitize by matching it against an authorized model.
+      safe_pc = Sufia::SelectTypeListPresenter.new(current_user).authorized_models.map(&:to_s).find { |x| x == unsafe_pc }
+      raise CanCan::AccessDenied, "Cannot create an object of class '#{unsafe_pc}'" unless safe_pc
+      authorize! :create, safe_pc
+      create_update_job(safe_pc.constantize)
       flash[:notice] = t('sufia.works.new.after_create_html', application_name: view_context.application_name)
       redirect_after_update
     end
@@ -42,7 +47,8 @@ module Sufia
         end
       end
 
-      def create_update_job
+      # @param [Class] klass the Sufia Work Class being created by the batch
+      def create_update_job(klass)
         log = BatchCreateOperation.create!(user: current_user,
                                            operation_type: "Batch Create")
         # ActionController::Parameters are not serializable, so cast to a hash
@@ -50,7 +56,7 @@ module Sufia
                                      params[:title].permit!.to_h,
                                      params[:resource_type].permit!.to_h,
                                      params[:uploaded_files],
-                                     attributes_for_actor.to_h,
+                                     attributes_for_actor.to_h.merge!(model: klass),
                                      log)
       end
 

--- a/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
@@ -15,12 +15,12 @@ module Sufia
     # @note we don't call `authorize!` directly, since `authorized_models` already checks `user.can? :create, ...`
     def create
       authenticate_user!
-      unsafe_pc = params[:batch_upload_item][:payload_concern]
+      unsafe_pc = params.fetch(:batch_upload_item, {})[:payload_concern]
       # Calling constantize on user params is disfavored (per brakeman), so we sanitize by matching it against an authorized model.
       safe_pc = Sufia::SelectTypeListPresenter.new(current_user).authorized_models.map(&:to_s).find { |x| x == unsafe_pc }
       raise CanCan::AccessDenied, "Cannot create an object of class '#{unsafe_pc}'" unless safe_pc
-      authorize! :create, safe_pc
-      create_update_job(safe_pc.constantize)
+      # authorize! :create, safe_pc
+      create_update_job(safe_pc)
       flash[:notice] = t('sufia.works.new.after_create_html', application_name: view_context.application_name)
       redirect_after_update
     end
@@ -47,7 +47,8 @@ module Sufia
         end
       end
 
-      # @param [Class] klass the Sufia Work Class being created by the batch
+      # @param [String] klass the name of the Sufia Work Class being created by the batch
+      # @note Cannot use a proper Class here because it won't serialize
       def create_update_job(klass)
         log = BatchCreateOperation.create!(user: current_user,
                                            operation_type: "Batch Create")

--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -9,8 +9,8 @@ module Sufia
     end
 
     module ClassMethods
-      # We don't want the breadcrumb action to occur until after the concern has
-      # been loaded and authorized
+      # We don't want the actions to occur until after the concern has been loaded and authorized
+      # @note this is a terribly side-effecty kludge
       def curation_concern_type=(curation_concern_type)
         super
         before_action :build_breadcrumbs, only: [:edit, :show]

--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -62,13 +62,8 @@ module Sufia
       def after_update_response
         if permissions_changed? && curation_concern.file_sets.present?
           redirect_to sufia.confirm_access_curation_concerns_permission_path(curation_concern)
-        elsif curation_concern.visibility_changed? && curation_concern.file_sets.present?
-          redirect_to main_app.confirm_curation_concerns_permission_path(curation_concern)
         else
-          respond_to do |wants|
-            wants.html { redirect_to [main_app, curation_concern] }
-            wants.json { render :show, status: :ok, location: polymorphic_path([main_app, curation_concern]) }
-          end
+          super
         end
       end
 

--- a/app/forms/sufia/forms/batch_upload_form.rb
+++ b/app/forms/sufia/forms/batch_upload_form.rb
@@ -6,6 +6,8 @@ module Sufia
 
       self.terms -= [:title, :resource_type]
 
+      attr_accessor :payload_concern # a Class name: what is form creating a batch of?
+
       # The WorkForm delegates `#depositor` to `:model`, but `:model` in the
       # BatchUpload context is a blank work with a `nil` depositor
       # value. This causes the "Sharing With" widget to display the Depositor as
@@ -25,8 +27,7 @@ module Sufia
       #   super - [:title]
       # end
 
-      # Override of ActiveModel::Model name that allows us to use our
-      # custom name class
+      # Override of ActiveModel::Model name that allows us to use our custom name class
       def self.model_name
         @_model_name ||= begin
           namespace = parents.detect do |n|

--- a/app/jobs/batch_create_job.rb
+++ b/app/jobs/batch_create_job.rb
@@ -24,9 +24,9 @@ class BatchCreateJob < ActiveJob::Base
   private
 
     def create(user, titles, resource_types, uploaded_files, attributes, log)
+      model = attributes.delete(:model) || attributes.delete('model')
+      raise ArgumentError, 'attributes must include "model" => ClassName.to_s' unless model
       uploaded_files.each do |upload_id|
-        model = attributes.delete(:model) || attributes.delete('model')
-        raise ArgumentError, 'attributes must include "model" => ClassName.to_s' unless model
         title = [titles[upload_id]] if titles[upload_id]
         resource_type = [resource_types[upload_id]] if resource_types[upload_id]
         attributes = attributes.merge(uploaded_files: [upload_id],

--- a/app/models/batch_upload_item.rb
+++ b/app/models/batch_upload_item.rb
@@ -6,6 +6,8 @@ class BatchUploadItem < ActiveFedora::Base
   include ::CurationConcerns::BasicMetadata
   include Sufia::WorkBehavior
 
+  attr_accessor :payload_concern # a Class name: what is this a batch of?
+
   # This mocks out the behavior of Hydra::PCDM::PcdmBehavior
   def in_collection_ids
     []

--- a/app/models/concerns/sufia/ability.rb
+++ b/app/models/concerns/sufia/ability.rb
@@ -18,6 +18,9 @@ module Sufia
       return unless registered_user?
       can :create, [UploadedFile, BatchUploadItem]
       can :destroy, UploadedFile, user: current_user
+      # BatchUploadItem permissions depend on the kind of objects being made by the batch,
+      # but it must be authorized directly in the controller, not here.
+      # Note: cannot call `authorized_models` without going recursive.
     end
 
     def proxy_deposit_abilities

--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -40,7 +40,6 @@
                 ) %>
           <% end %>
           </li>
-          <li><%= link_to t("sufia.toolbar.works.batch"), sufia.new_batch_upload_path %></li>
         </ul>
       </li>
     <% end %>

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -17,15 +17,19 @@
                 <p><%= row_presenter.description %></p>
               </td>
               <td class="select-work-actions">
+                <% dclass = dom_class(row_presenter.concern, 'new').gsub('_', '-') %>
                 <%= link_to(new_polymorphic_path([main_app, row_presenter.concern]),
-                            class: "btn btn-info #{dom_class(row_presenter.concern, 'new').gsub('_', '-')} select-work-single",
+                            class: "btn btn-info #{dclass} select-work-single",
                             role: 'button'
-                    ) do %>
+                    ) do -%>
                     <h4><%= t('sufia.dashboard.create_work') %></h4>
-                <% end %>
-                <%= link_to(sufia.new_batch_upload_path(payload_concern: row_presenter.concern), class: 'btn btn-info select-work-batch', role: 'button') do %>
+                <%- end -%>
+                <%= link_to(sufia.new_batch_upload_path(payload_concern: row_presenter.concern),
+                            class: "btn btn-info #{dclass} select-work-batch",
+                            role: 'button'
+                    ) do -%>
                     <h4><%= t('sufia.toolbar.works.batch') %></h4>
-                <% end %>
+                <%- end %>
               </td>
             </tr>
           <% end %>

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('sufia.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
         <h4 class="modal-title" id="select-worktype-label"><%= t('sufia.dashboard.heading_actions.select_type_of_work') %></h4>
       </div>
       <div class="modal-body">
@@ -26,13 +26,17 @@
                     <p><%= row_presenter.description %></p>
                 <% end %>
               </td>
+              <td class="select-work-batch">
+                <%= link_to(sufia.new_batch_upload_path(concern: row_presenter.concern), class: 'btn btn-info', role: 'button') do %>
+                    <h4><%= t('sufia.toolbar.works.batch') %></h4>
+                <% end %>
+              </td>
             </tr>
           <% end %>
         </table>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('sufia.dashboard.heading_actions.close') %></button>
-        <button type="button" class="btn btn-primary"><%= t('sufia.dashboard.heading_actions.create_work') %></button>
       </div>
     </div>
   </div>

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -10,24 +10,20 @@
           <% create_work_presenter.each do |row_presenter| %>
             <tr>
               <td class="select-work-icon">
-                <%= link_to(new_polymorphic_path([main_app, row_presenter.concern]),
-                            class: "item-option contextual-quick-classify #{dom_class(row_presenter.concern, 'new').gsub('_', '-')}",
-                            role: 'menuitem'
-                    ) do %>
-                    <span class="<%= row_presenter.icon_class %>"></span>
-                <% end %>
+                <span class="<%= row_presenter.icon_class %>"></span>
               </td>
               <td class="select-work-description">
-                <%= link_to(new_polymorphic_path([main_app, row_presenter.concern]),
-                            class: "item-option contextual-quick-classify #{dom_class(row_presenter.concern, 'new').gsub('_', '-')}",
-                            role: 'menuitem'
-                    ) do %>
-                    <h3><%= row_presenter.name %></h3>
-                    <p><%= row_presenter.description %></p>
-                <% end %>
+                <h3><%= row_presenter.name %></h3>
+                <p><%= row_presenter.description %></p>
               </td>
-              <td class="select-work-batch">
-                <%= link_to(sufia.new_batch_upload_path(concern: row_presenter.concern), class: 'btn btn-info', role: 'button') do %>
+              <td class="select-work-actions">
+                <%= link_to(new_polymorphic_path([main_app, row_presenter.concern]),
+                            class: "btn btn-info #{dom_class(row_presenter.concern, 'new').gsub('_', '-')} select-work-single",
+                            role: 'button'
+                    ) do %>
+                    <h4><%= t('sufia.dashboard.create_work') %></h4>
+                <% end %>
+                <%= link_to(sufia.new_batch_upload_path(payload_concern: row_presenter.concern), class: 'btn btn-info select-work-batch', role: 'button') do %>
                     <h4><%= t('sufia.toolbar.works.batch') %></h4>
                 <% end %>
               </td>

--- a/app/views/sufia/batch_uploads/_form.html.erb
+++ b/app/views/sufia/batch_uploads/_form.html.erb
@@ -1,10 +1,11 @@
 <%= simple_form_for [sufia, @form], html: { multipart: true } do |f| %>
   <% content_for :files_tab do %>
     <p class="switch-upload-type">To create a single work for all the files, go to <%= link_to "New Work", [:new, Sufia.primary_work_type.model_name.singular_route_key] %></p>
-        <p class="instructions"><%= t("sufia.batch_uploads.files.instructions") %></p>
+    <p class="instructions"><%= t("sufia.batch_uploads.files.instructions") %></p>
   <% end %>
   <%= render 'curation_concerns/base/guts4form', f: f, tabs: %w[files metadata relationships share] do %>
   <% end %>
+  <%= f.hidden_field :payload_concern, value: @form.payload_concern %>
 <% end %>
 
 <script type="text/javascript">

--- a/spec/controllers/sufia/batch_uploads_controller_spec.rb
+++ b/spec/controllers/sufia/batch_uploads_controller_spec.rb
@@ -1,6 +1,29 @@
 describe Sufia::BatchUploadsController do
   let(:user) { create(:user) }
+  let(:expected_types) do
+    { '1' => 'Article' }
+  end
+  let(:expected_individual_params) do
+    { '1' => 'foo' }
+  end
+  let(:expected_shared_params) do
+    { 'keyword' => [], 'visibility' => 'open', 'model' => 'GenericWork' }
+  end
+  let(:batch_upload_item) do
+    { keyword: [""], visibility: 'open', payload_concern: 'GenericWork' }
+  end
+  let(:post_params) do
+    {
+      title: expected_individual_params,
+      resource_type: expected_types,
+      uploaded_files: ['1'],
+      batch_upload_item: batch_upload_item
+    }
+  end
+
   before do
+    # allow(user).to receive(:can?).with(:create, GenericWork).and_return(true)
+    # allow(user).to receive(:can?).with(:create, Atlas).and_return(true)
     sign_in user
   end
 
@@ -13,16 +36,6 @@ describe Sufia::BatchUploadsController do
   end
 
   describe "#create" do
-    let(:expected_types) do
-      { '1' => 'Article' }
-    end
-    let(:expected_individual_params) do
-      { '1' => 'foo' }
-    end
-    let(:expected_shared_params) do
-      { 'keyword' => [], 'visibility' => 'open' }
-    end
-
     context "enquing a update job" do
       it "is successful" do
         expect(BatchCreateJob).to receive(:perform_later)
@@ -32,31 +45,25 @@ describe Sufia::BatchUploadsController do
                 ['1'],
                 expected_shared_params,
                 CurationConcerns::Operation)
-        post :create, params: {
-          title: expected_individual_params,
-          resource_type: expected_types,
-          uploaded_files: ['1'],
-          batch_upload_item: { keyword: [""], visibility: 'open' }
-        }
+        post :create, params: post_params
         expect(response).to redirect_to Sufia::Engine.routes.url_helpers.dashboard_works_path
         expect(flash[:notice]).to include("Your files are being processed")
       end
     end
 
     describe "when submiting works on behalf of another user" do
+      let(:batch_upload_item) do
+        {
+          payload_concern: Atlas,
+          permissions_attributes: [
+            { type: "group", name: "public", access: "read" }
+          ],
+          on_behalf_of: 'elrayle'
+        }
+      end
       it "redirects to my shares page" do
         allow(BatchCreateJob).to receive(:perform_later)
-        post :create, params: {
-          title: expected_individual_params,
-          resource_type: expected_types,
-          uploaded_files: ['1'],
-          batch_upload_item: {
-            permissions_attributes: [
-              { type: "group", name: "public", access: "read" }
-            ],
-            on_behalf_of: 'elrayle'
-          }
-        }
+        post :create, params: post_params
         expect(response).to redirect_to Sufia::Engine.routes.url_helpers.dashboard_shares_path
       end
     end
@@ -65,9 +72,7 @@ describe Sufia::BatchUploadsController do
   describe "attributes_for_actor" do
     subject { controller.send(:attributes_for_actor) }
     before do
-      controller.params = { title: { '1' => 'foo' },
-                            uploaded_files: ['1'],
-                            batch_upload_item: { keyword: [""], visibility: 'open' } }
+      controller.params = post_params
     end
     let(:expected_shared_params) do
       if Rails.version < '5.0.0'
@@ -77,6 +82,7 @@ describe Sufia::BatchUploadsController do
       end
     end
     it "excludes uploaded_files and title" do
+      expect(subject).not_to include('title', :title, 'uploaded_files', :uploaded_files)
       expect(subject).to eq expected_shared_params
     end
   end

--- a/spec/controllers/sufia/batch_uploads_controller_spec.rb
+++ b/spec/controllers/sufia/batch_uploads_controller_spec.rb
@@ -7,7 +7,7 @@ describe Sufia::BatchUploadsController do
     { '1' => 'foo' }
   end
   let(:expected_shared_params) do
-    { 'keyword' => [], 'visibility' => 'open', 'model' => 'GenericWork' }
+    { 'keyword' => [], 'visibility' => 'open', :model => 'GenericWork' }
   end
   let(:batch_upload_item) do
     { keyword: [""], visibility: 'open', payload_concern: 'GenericWork' }
@@ -44,7 +44,7 @@ describe Sufia::BatchUploadsController do
                 expected_types,
                 ['1'],
                 expected_shared_params,
-                a_kind_of(CurationConcerns::Operation))
+                a_kind_of(Sufia::BatchCreateOperation))
         post :create, params: post_params
         expect(response).to redirect_to Sufia::Engine.routes.url_helpers.dashboard_works_path
         expect(flash[:notice]).to include("Your files are being processed")

--- a/spec/controllers/sufia/batch_uploads_controller_spec.rb
+++ b/spec/controllers/sufia/batch_uploads_controller_spec.rb
@@ -13,17 +13,17 @@ describe Sufia::BatchUploadsController do
   end
 
   describe "#create" do
-    context "enquing a update job" do
-      let(:expected_types) do
-        { '1' => 'Article' }
-      end
-      let(:expected_individual_params) do
-        { '1' => 'foo' }
-      end
-      let(:expected_shared_params) do
-        { 'keyword' => [], 'visibility' => 'open' }
-      end
+    let(:expected_types) do
+      { '1' => 'Article' }
+    end
+    let(:expected_individual_params) do
+      { '1' => 'foo' }
+    end
+    let(:expected_shared_params) do
+      { 'keyword' => [], 'visibility' => 'open' }
+    end
 
+    context "enquing a update job" do
       it "is successful" do
         expect(BatchCreateJob).to receive(:perform_later)
           .with(user,
@@ -33,8 +33,8 @@ describe Sufia::BatchUploadsController do
                 expected_shared_params,
                 CurationConcerns::Operation)
         post :create, params: {
-          title: { '1' => 'foo' },
-          resource_type: { '1' => 'Article' },
+          title: expected_individual_params,
+          resource_type: expected_types,
           uploaded_files: ['1'],
           batch_upload_item: { keyword: [""], visibility: 'open' }
         }
@@ -47,15 +47,15 @@ describe Sufia::BatchUploadsController do
       it "redirects to my shares page" do
         allow(BatchCreateJob).to receive(:perform_later)
         post :create, params: {
+          title: expected_individual_params,
+          resource_type: expected_types,
+          uploaded_files: ['1'],
           batch_upload_item: {
             permissions_attributes: [
               { type: "group", name: "public", access: "read" }
             ],
             on_behalf_of: 'elrayle'
-          },
-          title: { '1' => 'foo' },
-          resource_type: { '1' => 'Article' },
-          uploaded_files: ['1']
+          }
         }
         expect(response).to redirect_to Sufia::Engine.routes.url_helpers.dashboard_shares_path
       end

--- a/spec/controllers/sufia/batch_uploads_controller_spec.rb
+++ b/spec/controllers/sufia/batch_uploads_controller_spec.rb
@@ -44,7 +44,7 @@ describe Sufia::BatchUploadsController do
                 expected_types,
                 ['1'],
                 expected_shared_params,
-                CurationConcerns::Operation)
+                a_kind_of(CurationConcerns::Operation))
         post :create, params: post_params
         expect(response).to redirect_to Sufia::Engine.routes.url_helpers.dashboard_works_path
         expect(flash[:notice]).to include("Your files are being processed")

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -11,6 +11,7 @@ feature 'Editing a work', type: :feature do
 
   context 'when the user changes permissions' do
     it 'confirms copying permissions to files using Sufia layout' do
+      # e.g. /concern/generic_works/jq085k20z/edit
       visit edit_curation_concerns_generic_work_path(work)
       choose('generic_work_visibility_open')
       check('agreement')

--- a/spec/jobs/batch_create_job_spec.rb
+++ b/spec/jobs/batch_create_job_spec.rb
@@ -1,6 +1,6 @@
 describe BatchCreateJob do
   let(:user) { create(:user) }
-  let(:log) { create(:batch_create_operation, user: user) }
+  let(:log)  { create(:batch_create_operation, user: user) }
 
   before do
     allow(CharacterizeJob).to receive(:perform_later)
@@ -18,13 +18,13 @@ describe BatchCreateJob do
     let(:file2) { File.open(fixture_path + '/image.jp2') }
     let(:upload1) { Sufia::UploadedFile.create(user: user, file: file1) }
     let(:upload2) { Sufia::UploadedFile.create(user: user, file: file2) }
-    let(:title) { { upload1.id.to_s => 'File One', upload2.id.to_s => 'File Two' } }
-    let(:resource_types) { { upload1.id.to_s => 'Article', upload2.id.to_s => 'Image' } }
-    let(:metadata) { { keyword: [] } }
+    let(:title)          { { upload1.id.to_s => 'File One', upload2.id.to_s => 'File Two' } }
+    let(:resource_types) { { upload1.id.to_s => 'Article',  upload2.id.to_s => 'Image'    } }
+    let(:metadata)       { { keyword: [], model: 'GenericWork' } }
     let(:uploaded_files) { [upload1.id.to_s, upload2.id.to_s] }
     let(:errors) { double(full_messages: "It's broke!") }
-    let(:work) { double(errors: errors) }
-    let(:actor) { double(curation_concern: work) }
+    let(:work)   { double(errors: errors) }
+    let(:actor)  { double(curation_concern: work) }
 
     subject do
       described_class.perform_later(user,

--- a/spec/views/shared/select_work_type_modal.html.erb_spec.rb
+++ b/spec/views/shared/select_work_type_modal.html.erb_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'shared/_select_work_type_modal.html.erb', type: :view do
   let(:presenter) { instance_double Sufia::SelectTypeListPresenter }
   let(:row1) do
@@ -12,25 +10,25 @@ RSpec.describe 'shared/_select_work_type_modal.html.erb', type: :view do
   let(:row2) do
     instance_double(Sufia::SelectTypePresenter,
                     icon_class: 'icon',
-                    name: 'Book',
-                    description: 'Book of things',
-                    concern: other_model)
+                    name: 'Atlas',
+                    description: 'Atlas of places',
+                    concern: Atlas)
   end
-  let(:other_model) do
-    double(persisted?: false,
-           model_name: double(singular_route_key: 'foo', param_key: 'foo'))
-  end
+  let(:results) { [GenericWork, Atlas] }
+
   before do
     allow(presenter).to receive(:each).and_yield(row1).and_yield(row2)
-    allow(view).to receive(:new_polymorphic_path).and_return('/foos/new')
     allow(view).to receive(:create_work_presenter).and_return(presenter)
     render
   end
-  let(:results) { [GenericWork, other_model] }
 
-  it "draws the modal" do
-    expect(rendered).to have_selector "#worktypes-to-create.modal"
-    expect(rendered).to have_link "Book", href: '/foos/new'
-    expect(rendered).to have_link "Generic Work"
+  it 'draws the modal' do
+    expect(rendered).to have_selector '#worktypes-to-create.modal'
+    expect(rendered).to have_content 'Generic Work'
+    expect(rendered).to have_content 'Atlas'
+    expect(rendered).to have_link 'Create Work', class: ['new-generic-work', 'select-work-single'], href: '/concern/generic_works/new'
+    expect(rendered).to have_link 'Batch Create', class: ['new-generic-work', 'select-work-batch'], href: '/batch_uploads/new?payload_concern=GenericWork'
+    expect(rendered).to have_link 'Create Work', class: ['new-atlas', 'select-work-single'], href: '/concern/atlas/new'
+    expect(rendered).to have_link 'Batch Create', class: ['new-atlas', 'select-work-batch'], href: '/batch_uploads/new?payload_concern=Atlas'
   end
 end


### PR DESCRIPTION
Advances, but does not resolve #2913 

Several tweaks to the modal:
- Translate the aria-label ("Close").
- Remove the useless button at the bottom.
- Add "Batch Create" buttons per type.

It also removes separate Batch Create dropdown in the toolbar, since now
the same flow (via modal) is used for single or batch uploads, when more than one object model is present.