### PR TITLE
Changing to  StandardError

### DIFF
--- a/lib/sufia/import/translator.rb
+++ b/lib/sufia/import/translator.rb
@@ -18,7 +18,7 @@ module Sufia
         files.each do |file|
           begin
             import_file(file)
-          rescue RuntimeError => e
+          rescue StandardError => e
             Sufia::Import::ErrorLog.error("\"#{file}\",\"#{e.message}\"\n")
           end
         end


### PR DESCRIPTION
 Use standard error instead of RuntimeError becuase ActiveFedora throws StandardErrors while running instead on RuntimeErrors and RuntimeError is a StandardError.

@hackmastera 