### PR TITLE
There's no sense in passing fl to a count query

### DIFF
--- a/app/presenters/sufia/admin_set_presenter.rb
+++ b/app/presenters/sufia/admin_set_presenter.rb
@@ -1,7 +1,7 @@
 module Sufia
   class AdminSetPresenter < CollectionPresenter
     def total_items
-      ActiveFedora::SolrService.count("{!field f=isPartOf_ssim}#{id}", fl: id)
+      ActiveFedora::SolrService.count("{!field f=isPartOf_ssim}#{id}")
     end
   end
 end


### PR DESCRIPTION
Fixes #2981 because when `fl` has a slash (e.g. 'admin_set/default'), Solr
is unable to parse the bad request

@projecthydra/sufia-code-reviewers
