### PR TITLE
Move admin_set metadata rendering to its own partial

### DIFF
--- a/app/views/sufia/admin/admin_sets/_form.html.erb
+++ b/app/views/sufia/admin/admin_sets/_form.html.erb
@@ -17,8 +17,7 @@
       <div class="panel panel-default labels">
         <%= simple_form_for @form, url: [sufia, :admin, @form] do |f| %>
           <div class="panel-body">
-            <%= f.input :title %>
-            <%= f.input :description, as: :text %>
+            <%= render 'form_metadata', f: f %>
 
             <% if f.object.persisted? && f.object.member_ids.present? %>
               <%= f.input :thumbnail_id, collection: @form.select_files %>

--- a/app/views/sufia/admin/admin_sets/_form_metadata.html.erb
+++ b/app/views/sufia/admin/admin_sets/_form_metadata.html.erb
@@ -1,0 +1,2 @@
+<%= f.input :title %>
+<%= f.input :description, as: :text %>

--- a/spec/views/sufia/admin/admin_sets/_form_metadata.html.erb_spec.rb
+++ b/spec/views/sufia/admin/admin_sets/_form_metadata.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe 'sufia/admin/admin_sets/_form_metadata.html.erb', type: :view do
+  let(:admin_set) { create(:admin_set) }
+  let(:permission_template) { Sufia::PermissionTemplate.find_or_create_by(admin_set_id: admin_set.id) }
+  before do
+    @form = Sufia::Forms::AdminSetForm.new(admin_set, permission_template)
+    render 'form'
+  end
+  it "has the metadata fields" do
+    expect(rendered).to have_selector('input[type=text][name="admin_set[title]"]')
+    expect(rendered).to have_selector('textarea[name="admin_set[description]"]')
+  end
+end


### PR DESCRIPTION
Fixes #2995

Moves metadata rendering (e.g. title, description) from _form partial to _form_metadata partial.  This makes it easier for apps to make additions to the set of fields on the create/edit form for admin sets.

@projecthydra/sufia-code-reviewers
