### PR TITLE
Autocomplete for child and parent relationships on work edit form.

### DIFF
--- a/app/assets/javascripts/sufia.js
+++ b/app/assets/javascripts/sufia.js
@@ -62,6 +62,7 @@
 //= require sufia/autocomplete/location
 //= require sufia/autocomplete/subject
 //= require sufia/autocomplete/language
+//= require sufia/autocomplete/work
 //= require sufia/relationships
 //= require curation_concerns/collections
 //= require hydra-editor/hydra-editor

--- a/app/assets/javascripts/sufia/autocomplete.es6
+++ b/app/assets/javascripts/sufia/autocomplete.es6
@@ -16,6 +16,11 @@ export class Autocomplete {
             case "based_near":
               this.autocompleteLocation(selector);
               break;
+            case "work":
+              var user = selector.data('user');
+              var id = selector.data('id');
+              this.autocompleteWork(selector, user, id);
+              break;
           }
       });
   }
@@ -47,5 +52,15 @@ export class Autocomplete {
   autocompleteLanguage(field) {
       var lang = require('sufia/autocomplete/language');
       new lang.Language(field, field.data('autocomplete-url'))
+  }
+
+  autocompleteWork(field, user, id) {
+    var work = require('sufia/autocomplete/work')
+    new work.Work(
+      field,
+      field.data('autocomplete-url'),
+      user,
+      id
+    )
   }
 }

--- a/app/assets/javascripts/sufia/autocomplete/work.es6
+++ b/app/assets/javascripts/sufia/autocomplete/work.es6
@@ -1,0 +1,29 @@
+export class Work {
+  // Autocomplete for finding possible related works (child and parent).
+  constructor(element, url, user, id) {
+    this.url = url;
+    this.user = user;
+    this.work_id = id;
+    element.autocomplete(this.options());
+  }
+
+  options() {
+    return {
+      minLength: 2,
+      source: ( request, response ) => {
+        $.getJSON(this.url, {
+          q: request.term,
+          id: this.work_id,
+          user: this.user
+        }, response );
+      },
+      focus: function() {
+        // prevent value inserted on focus
+        return false;
+      },
+      complete: function(event) {
+        $('.ui-autocomplete-loading').removeClass("ui-autocomplete-loading");
+      }
+    };
+  }
+}

--- a/app/authorities/qa/authorities/find_works.rb
+++ b/app/authorities/qa/authorities/find_works.rb
@@ -1,0 +1,15 @@
+module Qa::Authorities
+  class FindWorks < Qa::Authorities::Base
+    def search(_q, controller)
+      repo = CatalogController.new.repository
+      builder = Sufia::FindWorksSearchBuilder.new(controller)
+      response = repo.search(builder)
+      docs = response.documents
+      docs.map do |doc|
+        id = doc.id
+        title = doc.title
+        { id: id, label: title, value: id }
+      end
+    end
+  end
+end

--- a/app/forms/sufia/forms/work_form.rb
+++ b/app/forms/sufia/forms/work_form.rb
@@ -49,6 +49,12 @@ module Sufia::Forms
       model.ordered_members.to_a.select { |m| m.model_name.singular.to_sym != :file_set }
     end
 
+    # The in_work items
+    # @return [Array] All of the works that this work is a member of
+    def in_work_members
+      model.in_works.to_a
+    end
+
     def self.multiple?(term)
       return true if [:rights, :collection_ids].include? term
       super

--- a/app/search_builders/sufia/find_works_search_builder.rb
+++ b/app/search_builders/sufia/find_works_search_builder.rb
@@ -1,0 +1,44 @@
+# Search for possible works that user can edit and could be a work's child or parent.
+class Sufia::FindWorksSearchBuilder < Sufia::SearchBuilder
+  include Sufia::MySearchBuilderBehavior
+  include CurationConcerns::FilterByType
+
+  self.default_processor_chain += [:filter_on_title, :show_only_resources_deposited_by_current_user, :show_only_other_works, :show_only_works_not_child, :show_only_works_not_parent]
+
+  def initialize(context)
+    super(context)
+    @id = context.params[:id]
+    @q = context.params[:q]
+  end
+
+  def filter_on_title(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [ActiveFedora::SolrQueryBuilder.construct_query(title_tesim: @q)]
+  end
+
+  def show_only_other_works(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids([@id])
+    ]
+  end
+
+  def show_only_works_not_child(solr_parameters)
+    ids = ActiveFedora::SolrService.query("{!field f=id}#{@id}", fl: "member_ids_ssim", rows: 10_000).flat_map { |x| x.fetch("member_ids_ssim", []) }
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq]  += [
+      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)
+    ]
+  end
+
+  def show_only_works_not_parent(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq]  += [
+      "-" + ActiveFedora::SolrQueryBuilder.construct_query(member_ids_ssim: @id)
+    ]
+  end
+
+  def only_works?
+    true
+  end
+end

--- a/app/views/curation_concerns/base/_find_work_widget.html.erb
+++ b/app/views/curation_concerns/base/_find_work_widget.html.erb
@@ -1,0 +1,16 @@
+<%= f.input id_type,
+      label: false,
+      type: :text,
+      input_html:{
+        id: id_name,
+        name: f.object.model_name.param_key + '[' + id_type + '][]',
+        :'data-autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/find_works',
+        :'data-autocomplete' => 'work',
+        :'data-user' => current_user.email,
+        :'data-id' => id,
+        autocomplete: 'off',
+        :'aria-labelledby' => id_name + '_label',
+        :class => 'new-form-control string multi_value optional related_works_ids form-control multi-text-field ui-autocomplete-input',
+        value: ''
+      }
+ %>

--- a/app/views/curation_concerns/base/_form_child_work_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_child_work_relationships.html.erb
@@ -49,7 +49,7 @@ HTML Properties:
     <tr class="new-row">
       <td>
         <a href="" class="title hidden"></a>
-        <input class="new-form-control string multi_value optional related_works_ids work_child_members_ids form-control multi-text-field" value="" id="work_child_members_ids" aria-labelledby="work_child_members_ids_label" name="<%= f.object.model_name.param_key %>[ordered_member_ids][]" type="text">
+        <%= render "find_work_widget", f: f, id_name: 'work_child_members_ids', id_type: 'ordered_member_ids', user_email: current_user.email, id: f.object.model.id %>
         <div class="message has-warning hidden"></div>
       </td>
       <td>

--- a/app/views/curation_concerns/base/_form_parent_work_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_parent_work_relationships.html.erb
@@ -1,0 +1,43 @@
+<div class="form-group multi_value optional managed">
+
+  <table class="table table-striped related-files relationships-ajax-enabled"
+         data-query-url="<%= polymorphic_path([main_app, :curation_concerns, curation_concern.model_name.singular], id: '$id') %>">
+    <thead>
+    <tr>
+      <th>Parent Work</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+    <tbody>
+
+    <% f.object.in_work_members.each do |member| %>
+        <tr>
+          <td>
+            <%= link_to member.title.first, [main_app, member] %>
+            <input class="string multi_value optional form-control related_works_ids form-control multi-text-field hidden" value="<%= member.id %>" id="work_in_works_ids" aria-labelledby="work_in_works_ids_label" name="<%= f.object.model_name.param_key %>[in_works_ids][]" type="text">
+          </td>
+          <td>
+            <div class="child-actions">
+              <%= link_to "Edit", [main_app, :edit, member], target: "_blank", class: 'btn btn-default' %>
+              <a class="btn btn-danger btn-remove-row">Remove</a>
+            </div>
+          </td>
+        </tr>
+    <% end %>
+    <tr class="new-row">
+      <td>
+        <a href="" class="title hidden"></a>
+        <%= render "find_work_widget", f: f, id_name: 'work_parent_members_ids', id_type: 'in_works_ids', user_email: current_user.email, id: f.object.model.id %>
+        <div class="message has-warning hidden"></div>
+      </td>
+      <td>
+        <div class="child-actions">
+          <a href="" class="edit hidden btn btn-default" target="_blank">Edit</a>
+          <a class="btn btn-danger btn-remove-row hidden">Remove</a>
+          <a class="btn btn-primary btn-add-row">Add</a>
+        </div>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/curation_concerns/base/_form_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_relationships.html.erb
@@ -16,8 +16,8 @@
 
 <% if params[:id] %>
   <h3><%= t("sufia.works.#{action_name}.in_this_work") %></h3>
-  <%= render 'form_child_work_relationships', f: f %>
+   <%= render 'form_child_work_relationships', f: f, id_name: 'work_child_members_ids', id_type: 'ordered_member_ids' %>
 
   <h3><%= t("sufia.works.#{action_name}.in_other_works") %></h3>
-  <%= render_edit_field_partial(:in_works_ids, f: f) %>
+  <%= render 'form_parent_work_relationships', f: f, id_name: 'work_parent_members_ids', id_type: 'in_works_ids' %>
 <% end %>

--- a/spec/authorities/qa/authorities/find_works_spec.rb
+++ b/spec/authorities/qa/authorities/find_works_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Qa::Authorities::FindWorks do
+  let(:controller) { Qa::TermsController.new }
+  let(:user1) { create(:user) }
+  let(:user2) { create(:user) }
+  let(:ability) { instance_double(Ability, admin?: false, user_groups: [], current_user: user1) }
+  let(:q) { "foo" }
+  let(:params) { ActionController::Parameters.new(q: q, id: work1.id, user: user1.email, controller: "qa/terms", action: "search", vocab: "find_works") }
+  let(:service) { described_class.new }
+
+  before do
+    allow(controller).to receive(:params).and_return(params)
+    allow(controller).to receive(:current_user).and_return(user1)
+    allow(controller).to receive(:current_ability).and_return(ability)
+  end
+
+  let!(:work1) { create(:generic_work, :public, title: ['foo'], user: user1) }
+  let!(:work2) { create(:generic_work, :public, title: ['foo foo'], user: user1) }
+  let!(:work3) { create(:generic_work, :public, title: ['bar'], user: user1) }
+  let!(:work4) { create(:generic_work, :public, title: ['another foo'], user: user1) }
+  let!(:work5) { create(:generic_work, :public, title: ['foo foo foo'], user: user2) }
+
+  subject { service.search(q, controller) }
+
+  describe '#search' do
+    context "works by all users" do
+      it 'displays a list of other works deposited by current user' do
+        expect(subject.map { |result| result[:id] }).to match_array [work2.id, work4.id]
+      end
+    end
+
+    context "when work has child works" do
+      before do
+        work4.ordered_members << work1
+        work4.save!
+      end
+
+      it 'displays a list of other works deposited by current user, exluding the child work' do
+        expect(subject.map { |result| result[:id] }).to match_array [work2.id]
+      end
+    end
+
+    context "when work has parent works" do
+      before do
+        work1.ordered_members << work4
+        work1.save!
+      end
+
+      it 'displays a list of other works deposited by current user, excluding the parent work' do
+        expect(subject.map { |result| result[:id] }).to match_array [work2.id]
+      end
+    end
+  end
+end

--- a/spec/forms/sufia/forms/work_form_spec.rb
+++ b/spec/forms/sufia/forms/work_form_spec.rb
@@ -18,6 +18,13 @@ describe Sufia::Forms::WorkForm, :no_clean do
     end
   end
 
+  describe "#in_work_members" do
+    it "expects parent work members" do
+      allow(work).to receive(:in_works).and_return(works)
+      expect(form.in_work_members.size).to eq(3)
+    end
+  end
+
   describe ".build_permitted_params" do
     before do
       allow(described_class).to receive(:model_class).and_return(GenericWork)

--- a/spec/javascripts/autocomplete_spec.js.coffee
+++ b/spec/javascripts/autocomplete_spec.js.coffee
@@ -34,7 +34,7 @@ describe "auto complete", ->
         target.trigger(@typeEvent)
 
         # move time along so that events have a chance to happen
-        jasmine.clock().tick(800);
+        jasmine.clock().tick(800)
 
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()
@@ -50,7 +50,7 @@ describe "auto complete", ->
         target.trigger(@typeEvent)
 
         # move time along so that events have a chance to happen
-        jasmine.clock().tick(800);
+        jasmine.clock().tick(800)
 
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()
@@ -74,7 +74,7 @@ describe "auto complete", ->
         target.trigger(@typeEvent)
 
         # move time along so that events have a chance to happen
-        jasmine.clock().tick(800);
+        jasmine.clock().tick(800)
 
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()
@@ -90,7 +90,7 @@ describe "auto complete", ->
         target.trigger(@typeEvent)
 
         # move time along so that events have a chance to happen
-        jasmine.clock().tick(800);
+        jasmine.clock().tick(800)
 
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()
@@ -115,7 +115,7 @@ describe "auto complete", ->
         target.trigger(@typeEvent)
 
         # move time along so that events have a chance to happen
-        jasmine.clock().tick(800);
+        jasmine.clock().tick(800)
 
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()
@@ -131,7 +131,47 @@ describe "auto complete", ->
         target.trigger(@typeEvent)
 
         # move time along so that events have a chance to happen
-        jasmine.clock().tick(800);
+        jasmine.clock().tick(800)
+
+        # verify that the ajax call was made
+        expect(@spy_on_json).toHaveBeenCalled()
+
+  describe "works", ->
+    beforeEach ->
+      # setup two inputs for us to attach  auto complete to
+      setFixtures  '<input class="generic_work_work"  value="" id="generic_work_based_near" type="text" data-autocomplete="work" data-autocomplete-url="foo">
+                    <input class="generic_work_work"  value="" type="text" data-autocomplete="work" data-autocomplete-url="foo">'
+
+      # run all Blacklight.onload functions
+      Blacklight.activate()
+
+    describe "first input", ->
+
+      # field triggers auto complete
+      it "auto completes on typing", ->
+        # send a key stroke to the target input to activate the auto complete
+        target = $($("input.generic_work_work")[0])
+        target.val('fre')
+        target.trigger(@typeEvent)
+
+        # move time along so that events have a chance to happen
+        jasmine.clock().tick(800)
+
+        # verify that the ajax call was made
+        expect(@spy_on_json).toHaveBeenCalled()
+
+
+    describe "second input", ->
+
+      # field triggers auto complete
+      it "auto completes on typing", ->
+        # send a key stroke to the target input to activate the auto complete
+        target = $($("input.generic_work_work")[1])
+        target.val('fre')
+        target.trigger(@typeEvent)
+
+        # move time along so that events have a chance to happen
+        jasmine.clock().tick(800)
 
         # verify that the ajax call was made
         expect(@spy_on_json).toHaveBeenCalled()

--- a/spec/search_builder/sufia/find_works_search_builder_spec.rb
+++ b/spec/search_builder/sufia/find_works_search_builder_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe Sufia::FindWorksSearchBuilder do
+  let(:controller) { Qa::TermsController.new }
+  let(:user) { create(:user) }
+  let(:ability) { instance_double(Ability, admin?: false, user_groups: [], current_user: user) }
+  let(:q) { "foo" }
+  let(:params) { ActionController::Parameters.new(q: q, id: work.id, user: user.email, controller: "qa/terms", action: "search", vocab: "find_works") }
+
+  let(:context) do
+    double(current_ability: ability,
+           current_user: user,
+           params: params)
+  end
+  let!(:work) { create(:generic_work, :public, title: ['foo'], user: user) }
+
+  let(:builder) { described_class.new(context) }
+  let(:solr_params) { Blacklight::Solr::Request.new }
+
+  describe "#filter_on_title" do
+    subject { builder.filter_on_title(solr_params) }
+    it "is successful" do
+      subject
+      expect(solr_params[:fq]).to eq [ActiveFedora::SolrQueryBuilder.construct_query(title_tesim: q)]
+    end
+  end
+
+  describe "#show_only_other_works" do
+    subject { builder.show_only_other_works(solr_params) }
+    it "is successful" do
+      subject
+      expect(solr_params[:fq]).to eq ["-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids([work.id])]
+    end
+  end
+
+  describe "#show_only_works_not_child" do
+    subject { builder.show_only_works_not_child(solr_params) }
+    it "is successful" do
+      subject
+      ids = ActiveFedora::SolrService.query("{!field f=id}#{work.id}", fl: "member_ids_ssim").flat_map { |x| x.fetch("member_ids_ssim", []) }
+      expect(solr_params[:fq]).to eq ["-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids([ids])]
+    end
+  end
+
+  describe "#show_only_works_not_parent" do
+    subject { builder.show_only_works_not_parent(solr_params) }
+    it "is successful" do
+      subject
+      expect(solr_params[:fq]).to eq ["-" + ActiveFedora::SolrQueryBuilder.construct_query(member_ids_ssim: work.id)]
+    end
+  end
+
+  describe "#only_works?" do
+    subject { builder.only_works? }
+    it "is successful" do
+      subject
+      expect(subject). to eq true
+    end
+  end
+end

--- a/spec/views/curation_concerns/base/_form_parent_work_relationships.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form_parent_work_relationships.html.erb_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe "curation_concerns/base/_form_child_work_relationships.html.erb", type: :view do
+describe "curation_concerns/base/_form_parent_work_relationships.html.erb", type: :view do
   let(:work) do
     stub_model(GenericWork, id: '456', title: ["MyWork"])
   end
 
   let(:work_2) do
-    stub_model(GenericWork, id: '567', title: ["Child Work"])
+    stub_model(GenericWork, id: '567', title: ["Parent Work"])
   end
 
   let(:ability) { double }
@@ -34,11 +34,11 @@ describe "curation_concerns/base/_form_child_work_relationships.html.erb", type:
   end
 
   context "When editing a work" do
-    context "and no children works are present" do
+    context "and no parent works are present" do
       before do
-        allow(work).to receive(:ordered_members).and_return([])
+        allow(work).to receive(:in_works).and_return([])
       end
-      it "has 1 empty child work input" do
+      it "has 1 empty parent work input" do
         expect(page).to have_selector("input[value='']", count: 1)
       end
 
@@ -50,25 +50,25 @@ describe "curation_concerns/base/_form_child_work_relationships.html.erb", type:
         expect(page).to have_selector(".btn-add-row", visible: true, count: 1)
       end
     end
-    context "When 1 child work is present" do
+    context "When 1 parent work is present" do
       let(:work_2) do
-        stub_model(GenericWork, id: '567', title: ["Test Child Work"])
+        stub_model(GenericWork, id: '567', title: ["Test Parent Work"])
       end
 
       before do
-        allow(work).to receive(:ordered_members).and_return([work_2])
+        allow(work).to receive(:in_works).and_return([work_2])
       end
-      it "has 1 empty child work input with add button" do
+      it "has 1 empty parent work input with add button" do
         expect(page).to have_selector("input[value='']", count: 1)
         expect(page).to have_selector(".btn-add-row", visible: true, count: 1)
       end
 
-      it "has an input box that is filled in with the child id" do
+      it "has an input box that is filled in with the parent id" do
         expect(page).to have_selector("input[value='#{work_2.id}']", count: 1)
       end
 
-      it "generates a link for the childs first title" do
-        expect(page).to have_link("Test Child Work")
+      it "generates a link for the parents first title" do
+        expect(page).to have_link("Test Parent Work")
       end
 
       it "has an edit and remove button" do
@@ -78,29 +78,29 @@ describe "curation_concerns/base/_form_child_work_relationships.html.erb", type:
         end
       end
     end
-    context "When multiple child works are present" do
+    context "When multiple parent works are present" do
       let(:work_2) do
-        stub_model(GenericWork, id: '567', title: ["Test Child Work"])
+        stub_model(GenericWork, id: '567', title: ["Test Parent Work"])
       end
       let(:work_3) do
-        stub_model(GenericWork, id: '789', title: ["Test Child Work 2"])
+        stub_model(GenericWork, id: '789', title: ["Test Parent Work 2"])
       end
       before do
-        allow(work).to receive(:ordered_members).and_return([work_2, work_3])
+        allow(work).to receive(:in_works).and_return([work_2, work_3])
       end
-      it "has 1 empty child work input with add button" do
+      it "has 1 empty parent work input with add button" do
         expect(page).to have_selector("input[value='']", count: 1)
         expect(page).to have_selector(".btn-add-row", visible: true, count: 1)
       end
 
-      it "has an input box that is filled in with the child ids" do
+      it "has an input box that is filled in with the parent ids" do
         expect(page).to have_selector("input[value='#{work_2.id}']", count: 1)
         expect(page).to have_selector("input[value='#{work_3.id}']", count: 1)
       end
 
-      it "generates a link for the childs first title" do
-        expect(page).to have_link("Test Child Work")
-        expect(page).to have_link("Test Child Work 2")
+      it "generates a link for the parents first title" do
+        expect(page).to have_link("Test Parent Work")
+        expect(page).to have_link("Test Parent Work 2")
       end
 
       it "has an edit and remove button" do


### PR DESCRIPTION

Fixes #1563

Creates autocomplete fields for child and parent relationship fields on work edit form using Question Your Authority and a new search builder.

@projecthydra/sufia-code-reviewers
