### PR TITLE
Display edit button when checking boxes on shared works tab

### DIFF
--- a/app/assets/javascripts/sufia/dashboard_actions.js
+++ b/app/assets/javascripts/sufia/dashboard_actions.js
@@ -18,7 +18,7 @@ Blacklight.onLoad(function() {
     }
   }
 
-        // show/hide more information on the dashboard when clicking
+  // show/hide more information on the dashboard when clicking
   // plus/minus
   $('.glyphicon-chevron-right').on('click', function() {
     show_details(this);

--- a/app/views/my/_sort_and_per_page.html.erb
+++ b/app/views/my/_sort_and_per_page.html.erb
@@ -3,17 +3,17 @@
     <%= render 'collections/form_for_select_collection', user_collections: @user_collections %>
   </div>
 
-  <% if on_my_works? %>
-    <div class="batch-toggle">
-      <% session[:batch_edit_state] = "on" %>
-      <div class="button_to-inline">
-        <%= batch_edit_continue "Edit Selected" %>
-      </div>
+  <div class="batch-toggle">
+    <% session[:batch_edit_state] = "on" %>
+    <div class="button_to-inline">
+      <%= batch_edit_continue "Edit Selected" %>
+    </div>
+    <% if on_my_works? %>
       <%= batch_delete %>
       <%= button_tag "Add to Collection", class: 'btn btn-primary submits-batches submits-batches-add',
           data: { toggle: "modal", target: "#collection-list-container" } %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 
   <div class="sort-toggle">
     <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>

--- a/spec/views/my/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/my/_sort_and_per_page.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe 'my/_sort_and_per_page.html.erb', type: :view do
+  let(:mock_response) { double(response: { 'numFound' => 7 }) }
+  let(:sort_fields) { double(empty?: true) }
+
+  before do
+    @response = mock_response
+    allow(view).to receive(:sort_fields).and_return(sort_fields)
+  end
+
+  context "on my works page" do
+    before do
+      allow(view).to receive(:on_my_works?).and_return(true)
+      render
+    end
+    it "has buttons" do
+      expect(rendered).to have_selector('button', text: 'Add to Collection')
+      expect(rendered).to have_selector('input[value="Edit Selected"]')
+    end
+  end
+
+  context "not on my works page (i.e. Works shared with me)" do
+    before do
+      allow(view).to receive(:on_my_works?).and_return(false)
+      render
+    end
+    it "has buttons" do
+      expect(rendered).not_to have_selector('button', text: 'Add to Collection')
+      expect(rendered).to have_selector('input[value="Edit Selected"]')
+    end
+  end
+end


### PR DESCRIPTION
Patched in the code that Scholarsphere was using on its
sort_and_per_page partial
Fixes #2419
