### PR TITLE
InterpretVisibilityActor#update should call update on the next actor.

### DIFF
--- a/app/actors/sufia/interpret_visibility_actor.rb
+++ b/app/actors/sufia/interpret_visibility_actor.rb
@@ -9,8 +9,9 @@ module Sufia
 
     # Override CC to ensure our custom 'validate' method is used
     def update(attributes)
-      # Perform same validation/actions as create()
-      create(attributes)
+      @intention = Intention.new(attributes)
+      attributes = @intention.sanitize_params
+      validate(attributes) && apply_visibility(attributes) && next_actor.update(attributes)
     end
 
     private


### PR DESCRIPTION
Reverts part of #2966
Backports fixes from
https://github.com/projecthydra-labs/hyrax/pull/258/commits/a9acc0922d56657f45d87ae1d0e8ab0f4897b246
