### PR TITLE
Bump hydra-head to 10.4.0 to fix caching bug

### DIFF
--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache2'
 
   spec.add_dependency 'curation_concerns', '~> 1.7.2'
-  # This is not required, but helps bundler resolve a bundle faster:
-  spec.add_dependency 'hydra-head', '>= 10.1'
+  spec.add_dependency 'hydra-head', '>= 10.4.0'
   spec.add_dependency 'hydra-batch-edit', '~> 2.0'
   spec.add_dependency 'browse-everything', '>= 0.10.3'
   spec.add_dependency 'blacklight', '~> 6.6'


### PR DESCRIPTION
Previously `WorksControllerBehavior#permissions_changed?` would return
false if the access level of a user had been changed, or a user was
removed from the form.

Fixes #2820 