### PR TITLE
Basic ability to delete an admin set

### DIFF
--- a/app/controllers/sufia/admin/admin_sets_controller.rb
+++ b/app/controllers/sufia/admin/admin_sets_controller.rb
@@ -63,6 +63,11 @@ module Sufia
       end
     end
 
+    def destroy
+      @admin_set.destroy
+      redirect_to sufia.admin_admin_sets_path, notice: t(:'sufia.admin.admin_sets.delete.notification')
+    end
+
     # for the AdminSetService
     def repository
       repository_class.new(blacklight_config)

--- a/app/views/sufia/admin/admin_sets/show.html.erb
+++ b/app/views/sufia/admin/admin_sets/show.html.erb
@@ -11,6 +11,9 @@
           <%= link_to sufia.edit_admin_admin_set_path(@presenter), class: 'btn btn-primary' do %>
             <span class="fa fa-edit"></span> <%= t(:'helpers.action.edit') %>
           <% end %>
+          <%= link_to sufia.admin_admin_set_path(@presenter), class: 'btn btn-danger', data: { confirm: t('.confirm_delete'), method: :delete } do %>
+            <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+          <% end %>
         </div>
       </div>
 

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -319,6 +319,8 @@ en:
           header:         "Edit Administrative Set"
         new:
           header:         "Create New Administrative Set"
+        delete:
+          notification:   "Administrative set successfully deleted"
         form:
           tabs:
             description:        "Description"
@@ -378,6 +380,7 @@ en:
         show:
           header:           "Administrative Set"
           item_list_header: "Works in This Set"
+          confirm_delete:   "Are you sure you wish to delete this Administrative Set? This action cannot be undone."
       collections:
         collection:         "Collection"
         subtitle:           "Recent collection activity"
@@ -511,6 +514,7 @@ en:
       admin_set:
         new: "Create new administrative set"
       cancel: "Cancel"
+      delete: "Delete"
       edit: "Edit"
     submit:
       admin_set:

--- a/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
@@ -121,5 +121,31 @@ describe Sufia::Admin::AdminSetsController do
         expect(permission_template.workflow_name).to eq 'one_step_mediated_deposit'
       end
     end
+
+    describe "#destroy" do
+      let(:admin_set) { create(:admin_set, edit_users: [user]) }
+      context "with empty admin set" do
+        it "deletes the admin set" do
+          delete :destroy, params: { id: admin_set }
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(Sufia::Engine.routes.url_helpers.admin_admin_sets_path)
+          expect(flash[:notice]).to eq "Administrative set successfully deleted"
+        end
+      end
+      context "with a non-empty admin set" do
+        let(:work) { create(:generic_work, user: user) }
+        before do
+          admin_set.members << work
+          admin_set.reload
+        end
+        it "detaches the works and deletes the admin set" do
+          delete :destroy, params: { id: admin_set }
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(Sufia::Engine.routes.url_helpers.admin_admin_sets_path)
+          expect(flash[:notice]).to eq "Administrative set successfully deleted"
+          expect(GenericWork.exists?(work.id)).to be true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Implements a basic AdminSet delete button for Sufia.  

This functionality is *similar to* projecthydra-labs/hyrax#217, however it does NOT require the AdminSet is empty prior to deletion.

Instead, this simple implementation inherits the [admin set deletion logic from CC](https://github.com/projecthydra/curation_concerns/blob/master/spec/models/admin_set_spec.rb#L68), which simply detaches any works from the AdminSet prior to deletion.

@mjgiarlo and @projecthydra/sufia-code-reviewers , I'll leave it up to you whether this basic implementation is worth merging into Sufia 7.3.0. Currently, as it stands, no delete button is provided in the Sufia Admin UI. So, my opinion is this PR is likely better than nothing.

The full implementation of projecthydra-labs/hyrax#217 will be implemented in a separate PR to Hyrax (per notes below) and will be based on the code in this PR