### PR TITLE
Add hidden batch_document_ids to the batch_edit form

### DIFF
--- a/app/forms/sufia/forms/batch_edit_form.rb
+++ b/app/forms/sufia/forms/batch_edit_form.rb
@@ -13,12 +13,15 @@ module Sufia
 
       # @param [ActiveFedora::Base] model the model backing the form
       # @param [Ability] current_ability the user authorization model
-      # @param [Array<String>] batch a list of document ids in the batch
-      def initialize(model, current_ability, batch)
+      # @param [Array<String>] batch_document_ids a list of document ids in the batch
+      def initialize(model, current_ability, batch_document_ids)
         super(model, current_ability)
         @names = []
-        initialize_combined_fields(batch)
+        @batch_document_ids = batch_document_ids
+        initialize_combined_fields
       end
+
+      attr_reader :batch_document_ids
 
       # Which parameters can we accept from the form
       def self.build_permitted_params
@@ -30,12 +33,11 @@ module Sufia
       private
 
         # override this method if you need to initialize more complex RDF assertions (b-nodes)
-        # @param [Array<String>] batch a list of document ids in the batch
-        def initialize_combined_fields(batch)
+        def initialize_combined_fields
           combined_attributes = {}
           permissions = []
           # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
-          batch.each do |doc_id|
+          batch_document_ids.each do |doc_id|
             work = model_class.find(doc_id)
             terms.each do |key|
               combined_attributes[key] ||= []

--- a/app/views/batch_edits/edit.html.erb
+++ b/app/views/batch_edits/edit.html.erb
@@ -34,8 +34,11 @@
                   <%= hidden_field_tag('key', term.to_s) %>
                   <%# TODO we don't need to show required %>
                   <%= render_edit_field_partial(term, f: f) %>
+                  <% @form.batch_document_ids.each do |batch_id| %>
+                    <%= hidden_field_tag "batch_document_ids[]", batch_id %>
+                  <% end %>
                   <div>
-                    <%= f.submit "Save changes", class: 'btn btn-primary field-save updates-batches' , id: "#{term.to_s}_save" %>
+                    <%= f.submit "Save changes", class: 'btn btn-primary field-save', id: "#{term.to_s}_save" %>
                     <a class="btn btn-default" data-toggle="collapse" data-parent="#row_<%= term.to_s %>" href="#collapse_<%= term.to_s %>">Cancel </a>
                     <div class="status fleft"></div>
                   </div>
@@ -56,9 +59,11 @@
         <%= hidden_field_tag('key', 'permissions') %>
         <%= render "curation_concerns/base/form_permission", f: f %>
         <%= render "curation_concerns/base/form_share", f: f %>
-        <%= hidden_field_tag "batch_document_ids[]", Array.wrap(params[:batch_document_ids]).join(",") %>
+        <% @form.batch_document_ids.each do |batch_id| %>
+          <%= hidden_field_tag "batch_document_ids[]", batch_id %>
+        <% end %>
         <div class="row">
-            <%= f.submit "Save changes", class: 'btn btn-primary updates-batches', id: 'permissions_save' %>
+            <%= f.submit "Save changes", class: 'btn btn-primary', id: 'permissions_save' %>
             <div id="status_permissions" class="status fleft"></div>
         </div>
       <% end %>


### PR DESCRIPTION
Stop using javascript to serialize the batch members onto the batch edit
form.

Fixes #2450 (again)