### PR TITLE
Removes citation button for file sets.

### DIFF
--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -2,9 +2,6 @@
   <% if Sufia.config.analytics %>
     <%= link_to "Analytics", @presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
   <% end %>
-  <% if Sufia.config.citations %>
-    <%= link_to "Citations", sufia.citations_work_path(@presenter), id: 'citations', class: 'btn btn-default' %>
-  <% end %>
   <% if @presenter.editor? %>
       <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]),
                   class: 'btn btn-default' %>

--- a/spec/views/curation_concerns/file_sets/_show_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/_show_actions.html.erb_spec.rb
@@ -33,8 +33,8 @@ describe 'curation_concerns/file_sets/_show_actions.html.erb', type: :view do
     context 'when enabled' do
       let(:citations) { true }
 
-      it 'appears on page' do
-        expect(page).to have_selector('a#citations', count: 1)
+      it 'does not appear on page' do
+        expect(page).to have_no_selector('a#citations')
       end
     end
 


### PR DESCRIPTION
Fixes #3043 

Present tense short summary (50 characters or less)

Removes the citation button for file_sets.  The routing was not working and the PO does not need citations of file_sets.

Changes proposed in this pull request:
* Remove button from view partial
* Changes spec to account for different display condition.


@projecthydra/sufia-code-reviewers
