### PR TITLE
Fix spec for CC change to default thumbnails for files

### DIFF
--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -54,6 +54,7 @@ describe DownloadsController, type: :controller do
     end
 
     describe "when not logged in as reader" do
+      let(:default_image) { ActionController::Base.helpers.image_path 'default.png' }
       before do
         sign_in create(:user)
       end
@@ -61,8 +62,7 @@ describe DownloadsController, type: :controller do
       describe "show" do
         it "denies access" do
           get :show, params: { id: file }
-          expect(response).to redirect_to root_path
-          expect(flash[:alert]).to eq 'You are not authorized to access this page.'
+          expect(response).to redirect_to default_image
         end
       end
     end


### PR DESCRIPTION
New behavior in curation_concerns 1.7.3 breaks one test in Sufia.  So this test needs tweaked to handle how default thumbnails are now displayed for files when a user doesn't have access to the file(s).  See https://github.com/projecthydra/curation_concerns/commit/c9094e669bf3ede719585959db804985e0571d85