### PR TITLE
Update jQuery fileupload callback to fire when all current uploads have finished

### DIFF
--- a/app/assets/javascripts/sufia/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/sufia/save_work/uploaded_files.es6
@@ -2,7 +2,7 @@ export class UploadedFiles {
   // Monitors the form and runs the callback if any files are added
   constructor(form, callback) {
     this.form = form
-    $('#fileupload').bind('fileuploadcompleted', callback)
+    $('#fileupload').bind('fileuploadstop', callback)
   }
 
   get hasFileRequirement() {


### PR DESCRIPTION
Fixes #3048

Can you take this (very simple, small) fix for a test drive, @hackmastera? It seemed to the do the trick for me when I tossed a bunch of files at it.

@projecthydra/sufia-code-reviewers
