### PR TITLE
Pinning rake to get rid of last_comment error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,10 @@
-require: rubocop-rspec
-
 AllCops:
   TargetRubyVersion: 2.2
   DisplayCopNames: true
   Include:
     - '**/Rakefile'
     - '**/config.ru'
+    - rubocop-rspec
   Exclude:
     - 'db/**/*'
     - 'script/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem "simplecov", require: false
   gem 'byebug' unless ENV['CI']
   gem 'coveralls', require: false
-  gem 'rubocop', '~> 0.37.2', require: false
+  gem 'rubocop', '~> 0.38.0', require: false
   gem 'rubocop-rspec', require: false
 end
 

--- a/sufia-models/sufia-models.gemspec
+++ b/sufia-models/sufia-models.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mailboxer', '~> 0.12'
   spec.add_dependency 'acts_as_follower', '>= 0.1.1', '< 0.3'
   spec.add_dependency 'carrierwave', '~> 0.9'
-  spec.add_dependency 'oauth2', '~> 0.9'
+  spec.add_dependency 'oauth2', '~> 1.2'
   spec.add_dependency 'google-api-client', '~> 0.7.1'
   spec.add_dependency 'legato', '~> 0.3'
   spec.add_dependency 'activerecord-import', '~> 0.5'


### PR DESCRIPTION
Pins rake to remove the error `NoMethodError: undefined method 'last_comment' for #<Rake::Application:0x00000002997a30>`


@projecthydra/sufia-code-reviewers
