### PR TITLE
Don't use action_name in i18n routes

### DIFF
--- a/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
@@ -21,7 +21,7 @@ module Sufia
       raise CanCan::AccessDenied, "Cannot create an object of class '#{unsafe_pc}'" unless safe_pc
       # authorize! :create, safe_pc
       create_update_job(safe_pc)
-      flash[:notice] = t('sufia.works.new.after_create_html', application_name: view_context.application_name)
+      flash[:notice] = t('sufia.works.create.after_create_html', application_name: view_context.application_name)
       redirect_after_update
     end
 

--- a/app/controllers/concerns/sufia/works_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/works_controller_behavior.rb
@@ -52,7 +52,7 @@ module Sufia
       def after_create_response
         respond_to do |wants|
           wants.html do
-            flash[:notice] = t('sufia.works.new.after_create_html', application_name: view_context.application_name)
+            flash[:notice] = t('sufia.works.create.after_create_html', application_name: view_context.application_name)
             redirect_to [main_app, curation_concern]
           end
           wants.json { render :show, status: :created, location: polymorphic_path([main_app, curation_concern]) }

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -1,12 +1,12 @@
 <%= simple_form_for @form, html: { class: 'editor' } do |f| %>
   <div id="descriptions_display">
-    <h2 class="non lower"><%= t('sufia.collection.edit.description') %></h2>
+    <h2 class="non lower"><%= t('sufia.collection.form.description') %></h2>
     <div id="base-terms">
       <% f.object.primary_terms.each do |term| %>
         <%= render_edit_field_partial(term, f: f) %>
       <% end %>
     </div>
-    <%= link_to t('sufia.collection.edit.additional_fields'),
+    <%= link_to t('sufia.collection.form.additional_fields'),
             '#extended-terms',
             class: 'btn btn-default additional-fields',
             data: { toggle: 'collapse' },

--- a/app/views/curation_concerns/base/_form_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_metadata.html.erb
@@ -7,7 +7,7 @@
             <%= render_edit_field_partial(term, f: f) %>
           <% end %>
         </div>
-        <%= link_to t('sufia.works.edit.additional_fields'),
+        <%= link_to t('sufia.works.form.additional_fields'),
                     '#extended-terms',
                     class: 'btn btn-default additional-fields',
                     data: { toggle: 'collapse' },

--- a/app/views/curation_concerns/base/_form_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_relationships.html.erb
@@ -7,7 +7,7 @@
 
 <%= render 'form_in_works', f: f %>
 
-<h2><%= t("sufia.works.#{action_name}.in_collections") %></h2>
+<h2><%= t("sufia.works.form.in_collections") %></h2>
 <div id="collection-widget">
   <%= f.input :collection_ids, as: :select,
               collection: available_collections(nil),
@@ -15,9 +15,9 @@
 </div>
 
 <% if params[:id] %>
-  <h3><%= t("sufia.works.#{action_name}.in_this_work") %></h3>
+  <h3><%= t("sufia.works.form.in_this_work") %></h3>
    <%= render 'form_child_work_relationships', f: f, id_name: 'work_child_members_ids', id_type: 'ordered_member_ids' %>
 
-  <h3><%= t("sufia.works.#{action_name}.in_other_works") %></h3>
+  <h3><%= t("sufia.works.form.in_other_works") %></h3>
   <%= render 'form_parent_work_relationships', f: f, id_name: 'work_parent_members_ids', id_type: 'in_works_ids' %>
 <% end %>

--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -12,7 +12,7 @@
           <li role="presentation">
         <% end %>
             <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
-              <i class="fa icon-<%= tab %>"></i> <%= t("sufia.works.edit.tab.#{tab}") %>
+              <i class="fa icon-<%= tab %>"></i> <%= t("sufia.works.form.tab.#{tab}") %>
             </a>
           </li>
       <% end %>

--- a/app/views/curation_concerns/base/edit.html.erb
+++ b/app/views/curation_concerns/base/edit.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, curation_concern_page_title(curation_concern) %>
 <% provide :page_header do %>
-  <h1><%= t("sufia.works.#{action_name}.header") %></h1>
+  <h1><%= t("sufia.works.update.header") %></h1>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/curation_concerns/base/new.html.erb
+++ b/app/views/curation_concerns/base/new.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, curation_concern_page_title(curation_concern) %>
 <% provide :page_header do %>
-  <h1><%= t("sufia.works.#{action_name}.header", type: curation_concern.human_readable_type) %></h1>
+  <h1><%= t("sufia.works.create.header", type: curation_concern.human_readable_type) %></h1>
 <% end %>
 
 <%= render 'form' %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -238,15 +238,12 @@ en:
         title: "Filename will be the default title. Please provide a more meaningful title, and filenames will still be preserved by the system."
         resource_type: "You may select multiple types to apply to all files"
     works:
-      new:
+      create:
         header: "Add New %{type}"
-        in_collections: This Work in Collections
-        in_this_work: Other Works in this Work
-        in_other_works: This Work in Other Works
         after_create_html: "Your files are being processed by %{application_name} in the background. The metadata and access controls you specified are being applied. Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh this page to see these updates."
       edit:
-        header: Edit Work
         breadcrumb: 'Edit'
+      form:
         in_collections: This Work in Collections
         in_this_work: Other Works in this Work
         in_other_works: This Work in Other Works
@@ -256,6 +253,8 @@ en:
           files:         "Files"
           relationships: "Relationships"
           share:         "Share"
+      update:
+        header: Edit Work
       progress:
         header: "Save Work"
       show:
@@ -285,13 +284,14 @@ en:
           label: "Delete"
           desc: "Delete this collection"
           confirmation: "Delete this collection?"
-      edit:
-        manage_items: "Manage Items in this Collection"
-        description: "Descriptions"
-        additional_fields: "Additional fields"
       document_list:
         edit: "Edit"
         no_visible_works: "The collection is either empty or does not contain items to which you have access."
+      edit:
+        manage_items: "Manage Items in this Collection"
+      form:
+        description: "Descriptions"
+        additional_fields: "Additional fields"
       select_form:
         title: "Add to collection"
         no_collections: "You do not have access to any existing collections. You may create a new collection."


### PR DESCRIPTION
The common pattern for a form that fails validation is to have the
create or update method re-render that form.  By doing that you have to
have duplicate i18n keys (e.g. edit & update) for a single form.  This change ensures you
only have one for new/create and one for edit/update.  This change ensures we only need a single i18n value for each.
Fixes #3058
