### PR TITLE
Prevent submitting work save form if uploads are in progress

### DIFF
--- a/app/assets/javascripts/sufia/save_work/save_work_control.es6
+++ b/app/assets/javascripts/sufia/save_work/save_work_control.es6
@@ -54,7 +54,19 @@ export class SaveWorkControl {
   }
 
   /**
-   * Is the form for a new object (vs edit an exisiting object)
+   * Keep the form from being submitted while uploads are running
+   *
+   */
+  preventSubmitIfUploading() {
+    this.form.on('submit', (evt) => {
+      if (this.uploads.inProgress) {
+        evt.preventDefault()
+      }
+    })
+  }
+
+  /**
+   * Is the form for a new object (vs edit an existing object)
    */
   get isNew() {
     return this.form.attr('id').startsWith('new')
@@ -80,6 +92,7 @@ export class SaveWorkControl {
     new VisibilityComponent(this.element.find('.visibility'))
     this.preventSubmitUnlessValid()
     this.preventSubmitIfAlreadyInProgress()
+    this.preventSubmitIfUploading()
     $('.multi_value.form-group', this.form).bind('managed_field:add', () => this.formChanged())
     $('.multi_value.form-group', this.form).bind('managed_field:remove', () => this.formChanged())
     this.formChanged()
@@ -136,4 +149,3 @@ export class SaveWorkControl {
     return this.depositAgreement.isAccepted
   }
 }
-

--- a/app/assets/javascripts/sufia/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/sufia/save_work/uploaded_files.es6
@@ -1,13 +1,18 @@
 export class UploadedFiles {
-  // Monitors the form and runs the callback if any files are added
+  // Monitors the form and runs the callback when files are added
   constructor(form, callback) {
     this.form = form
-    $('#fileupload').bind('fileuploadstop', callback)
+    this.element = $('#fileupload')
+    this.element.bind('fileuploadcompleted', callback)
   }
 
   get hasFileRequirement() {
     let fileRequirement = this.form.find('li#required-files')
     return fileRequirement.size() > 0
+  }
+
+  get inProgress() {
+    return this.element.fileupload('active') > 0
   }
 
   get hasFiles() {


### PR DESCRIPTION
Fixes #3048, #3068

Here you go, @hackmastera. Mind testing the two failure modes?

1. Should be able to submit form after adding one file.
2. Shouldn't be able to submit form while uploads are in progress
