### PR TITLE
Increase timeouts for batch_edit feature spec

### DIFF
--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -120,7 +120,7 @@ describe 'Batch management of works', type: :feature do
 
   def fill_in_field_wait(id)
     within "#form_#{id}" do
-      expect(page).to have_content 'Changes Saved', wait: Capybara.default_max_wait_time * 4
+      expect(page).to have_content 'Changes Saved', wait: Capybara.default_max_wait_time * 5
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,7 @@ Capybara.default_max_wait_time = ENV['TRAVIS'] ? 30 : 15
 # Found in this thread: https://github.com/teampoltergeist/poltergeist/issues/375
 poltergeist_options = {
   js_errors: true,
-  timeout: 30,
+  timeout: 60,
   logger: nil,
   phantomjs_logger: StringIO.new,
   phantomjs_options: [


### PR DESCRIPTION
#2955 reduced the time our specs wait for Capybara actions to take effect, and since then we have seen intermittent failures. It is always the same spec that fails in the same way.
