### PR TITLE
Remove extra collapse/expand carets from facets

### DIFF
--- a/app/assets/stylesheets/sufia/_dashboard.scss
+++ b/app/assets/stylesheets/sufia/_dashboard.scss
@@ -123,7 +123,7 @@ ul.collapsing > li > a {
   padding-left: 40px;
 }
 
-.collapse-toggle {
+.admin-sidebar .collapse-toggle {
   margin-bottom: 0;
 
   &::after {

--- a/app/views/sufia/admin/_sidebar.html.erb
+++ b/app/views/sufia/admin/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<ul class="nav nav-pills nav-stacked">
+<ul class="admin-sidebar nav nav-pills nav-stacked">
   <li class="<%= 'active' if current_page? sufia.admin_stats_path %>">
     <%= link_to sufia.admin_stats_path do %>
       <span class="fa fa-bar-chart"></span> <%= t('sufia.admin.sidebar.statistics') %>


### PR DESCRIPTION
Fixes #3083 

A previous commit that added expand/collapse carets to the admin sidebar also unintentionally added the carets to the expandable catalog facets (which already had their own carets).  

So this fix just limits the carets to the admin sidebar where they were originally intended to be.