### PR TITLE
Allow long file names to wrap on upload screen

### DIFF
--- a/app/assets/stylesheets/sufia/_file_upload.scss
+++ b/app/assets/stylesheets/sufia/_file_upload.scss
@@ -18,3 +18,5 @@
     transition: background-color 0.1s ease-out;
   }
 }
+
+.files .name span { word-break: break-all; }


### PR DESCRIPTION
Fixes #3112 

Simple CSS change that allows very long file names on the upload screen to wrap so the Delete button doesn't get hidden behind the Save Work pane.

Before:

![long-file-name](https://cloud.githubusercontent.com/assets/5639859/23313976/de5e198e-fa8d-11e6-90a6-fb0b23a4d7d1.png)

After:

![long-file-name2](https://cloud.githubusercontent.com/assets/5639859/23313981/e44fd8b4-fa8d-11e6-9a13-e4b51f2b5641.png)

@projecthydra/sufia-code-reviewers
