### PR TITLE
Backport changes to the workflow JSON template

### DIFF
--- a/app/services/sufia/workflow/complete_notification.rb
+++ b/app/services/sufia/workflow/complete_notification.rb
@@ -1,0 +1,7 @@
+module Sufia
+  module Workflow
+    class CompleteNotification < DepositedNotification
+      deprecation_deprecate initialize: "use DepositedNotification.initialize instead"
+    end
+  end
+end

--- a/app/services/sufia/workflow/deposited_notification.rb
+++ b/app/services/sufia/workflow/deposited_notification.rb
@@ -1,6 +1,6 @@
 module Sufia
   module Workflow
-    class CompleteNotification < AbstractNotification
+    class DepositedNotification < AbstractNotification
       protected
 
         def subject

--- a/lib/generators/sufia/templates/workflow.json.erb
+++ b/lib/generators/sufia/templates/workflow.json.erb
@@ -21,7 +21,7 @@
                     ]
                 }, {
                     "name": "request_changes",
-                    "from_states": [{"names": ["complete", "pending_review"], "roles": ["approving"]}],
+                    "from_states": [{"names": ["deposited", "pending_review"], "roles": ["approving"]}],
                     "transition_to": "changes_required",
                     "notifications": [
                         {
@@ -36,11 +36,11 @@
                 }, {
                     "name": "approve",
                     "from_states": [{"names": ["pending_review"], "roles": ["approving"]}],
-                    "transition_to": "complete",
+                    "transition_to": "deposited",
                     "notifications": [
                         {
                             "notification_type": "email",
-                            "name": "Sufia::Workflow::CompleteNotification",
+                            "name": "Sufia::Workflow::DepositedNotification",
                             "to": ["approving"]
                         }
                     ],
@@ -57,6 +57,12 @@
                             "name": "Sufia::Workflow::PendingReviewNotification",
                             "to": ["approving"]
                         }
+                    ]
+                }, {
+                    "name": "comment_only",
+                    "from_states": [
+                        { "names": ["pending_review", "deposited"], "roles": ["approving"] },
+                        { "names": ["changes_required"], "roles": ["depositing"] }
                     ]
                 }
             ]

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -4,5 +4,23 @@ namespace :sufia do
       require 'sufia/move_all_works_to_admin_set'
       MoveAllWorksToAdminSet.run(AdminSet.find(Sufia::DefaultAdminSetActor::DEFAULT_ID))
     end
+
+    desc "Migrate data from 7.2.x to 7.3.0"
+    task from_7_2_x_to_7_3_0_release: :environment do
+      logger = Logger.new(STDOUT)
+      logger.level = Logger::DEBUG
+      logger.info(%(Starting migration to Sufia 7.3.0 in preparation for Hyrax 1.0.0))
+      Sipity::Workflow.transaction do
+        logger.info(%(Migrating "complete" state to "deposited" state for all "one_step_mediated_deposit" workflows. See https://github.com/projecthydra/sufia/commit/711bb49892aa54fe190a45434f6b2d0364d69c7a for changes))
+        Sipity::Workflow.where(name: 'one_step_mediated_deposit').each do |workflow|
+          workflow.workflow_states.where(name: 'complete').each do |state|
+            logger.info(%(Updating name for #{state.class} ID=#{state.id} from 'complete' to 'deposited'))
+            state.update!(name: 'deposited')
+          end
+        end
+      end
+
+      logger.info(%(Completed migration to Sufia 7.3.0))
+    end
   end
 end

--- a/spec/services/sufia/workflow/complete_notification_spec.rb
+++ b/spec/services/sufia/workflow/complete_notification_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe Sufia::Workflow::CompleteNotification do
+  let(:entity) { double(:sipity_entity, proxy_for_global_id: '1234', proxy_for: double(title: 'title')) }
+  let(:comment) { nil }
+  it 'is deprecated' do
+    expect(Deprecation).to receive(:warn).with(described_class, /^initialize is deprecated/, kind_of(Array))
+    described_class.new(entity, nil, double, {})
+  end
+end

--- a/spec/services/sufia/workflow/deposited_notification_spec.rb
+++ b/spec/services/sufia/workflow/deposited_notification_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Sufia::Workflow::CompleteNotification do
+RSpec.describe Sufia::Workflow::DepositedNotification do
   let(:approver) { create(:user) }
   let(:depositor) { create(:user) }
   let(:to_user) { create(:user) }


### PR DESCRIPTION
So that folks can upgrade from Sufia 7.3.0 to Hyrax 1.0.0 without needing to migrate workflow data
