### PR TITLE
Ensuring that a permission template exists

### DIFF
--- a/app/actors/sufia/default_admin_set_actor.rb
+++ b/app/actors/sufia/default_admin_set_actor.rb
@@ -17,8 +17,15 @@ module Sufia
     private
 
       def ensure_admin_set_attribute!(attributes)
-        return if attributes[:admin_set_id].present?
-        attributes[:admin_set_id] = default_admin_set_id
+        if attributes[:admin_set_id].present?
+          ensure_permission_template!(admin_set_id: attributes[:admin_set_id])
+        else
+          attributes[:admin_set_id] = default_admin_set_id
+        end
+      end
+
+      def ensure_permission_template!(admin_set_id:)
+        Sufia::PermissionTemplate.find_or_create_by!(admin_set_id: admin_set_id)
       end
 
       DEFAULT_ID = 'admin_set/default'.freeze

--- a/spec/actors/sufia/default_admin_set_actor_spec.rb
+++ b/spec/actors/sufia/default_admin_set_actor_spec.rb
@@ -34,9 +34,11 @@ RSpec.describe Sufia::DefaultAdminSetActor do
     context "when admin_set_id is provided" do
       let(:attributes) { { admin_set_id: admin_set.id } }
 
-      it "uses the provided id and returns true" do
+      it "uses the provided id, ensures a permission template, and returns true" do
         expect(next_actor).to receive(:create).with(attributes).and_return(true)
-        expect(actor.create(attributes)).to be true
+        expect do
+          expect(actor.create(attributes)).to be true
+        end.to change { Sufia::PermissionTemplate.count }.by(1)
       end
     end
   end


### PR DESCRIPTION
This is a quick and dirty solution to ensure that we have a permission
template.

Related to projecthydra-labs/hyrax#477
Closes #3098

@projecthydra/sufia-code-reviewers
