### PR TITLE
Backporting AdminSet deletion and validation per hyrax#217

### DIFF
--- a/app/actors/sufia/default_admin_set_actor.rb
+++ b/app/actors/sufia/default_admin_set_actor.rb
@@ -28,21 +28,19 @@ module Sufia
         Sufia::PermissionTemplate.find_or_create_by!(admin_set_id: admin_set_id)
       end
 
-      DEFAULT_ID = 'admin_set/default'.freeze
-
       def default_admin_set_id
         create_default_admin_set unless default_exists?
-        DEFAULT_ID
+        AdminSet::DEFAULT_ID
       end
 
       def default_exists?
-        AdminSet.exists?(DEFAULT_ID)
+        AdminSet.exists?(AdminSet::DEFAULT_ID)
       end
 
       # Creates the default AdminSet and an associated PermissionTemplate with workflow
       def create_default_admin_set
-        AdminSet.create!(id: DEFAULT_ID, title: ['Default Admin Set']).tap do |_as|
-          PermissionTemplate.create!(admin_set_id: DEFAULT_ID, workflow_name: 'default')
+        AdminSet.create!(id: AdminSet::DEFAULT_ID, title: ['Default Admin Set']).tap do |_as|
+          PermissionTemplate.create!(admin_set_id: AdminSet::DEFAULT_ID, workflow_name: 'default')
         end
       end
   end

--- a/app/controllers/sufia/admin/admin_sets_controller.rb
+++ b/app/controllers/sufia/admin/admin_sets_controller.rb
@@ -64,8 +64,11 @@ module Sufia
     end
 
     def destroy
-      @admin_set.destroy
-      redirect_to sufia.admin_admin_sets_path, notice: t(:'sufia.admin.admin_sets.delete.notification')
+      if @admin_set.destroy
+        redirect_to sufia.admin_admin_sets_path, notice: t(:'sufia.admin.admin_sets.delete.notification')
+      else
+        redirect_to sufia.admin_admin_set_path(@admin_set), alert: @admin_set.errors.full_messages.to_sentence
+      end
     end
 
     # for the AdminSetService

--- a/app/models/concerns/sufia/admin_set_behavior.rb
+++ b/app/models/concerns/sufia/admin_set_behavior.rb
@@ -1,0 +1,37 @@
+module Sufia
+  module AdminSetBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      DEFAULT_ID = 'admin_set/default'.freeze
+
+      def self.default_set?(id)
+        id == DEFAULT_ID
+      end
+
+      before_destroy :check_if_not_default_set, :check_if_empty
+    end
+
+    private
+
+      def check_if_empty
+        return true if members.empty?
+        errors[:base] << I18n.t('sufia.admin.admin_sets.delete.error_not_empty')
+        if Rails.version < '5.0.0'
+          false
+        else
+          throw :abort
+        end
+      end
+
+      def check_if_not_default_set
+        return true unless AdminSet.default_set?(id)
+        errors[:base] << I18n.t('sufia.admin.admin_sets.delete.error_default_set')
+        if Rails.version < '5.0.0'
+          false
+        else
+          throw :abort
+        end
+      end
+  end
+end

--- a/app/presenters/sufia/admin_set_presenter.rb
+++ b/app/presenters/sufia/admin_set_presenter.rb
@@ -3,5 +3,16 @@ module Sufia
     def total_items
       ActiveFedora::SolrService.count("{!field f=isPartOf_ssim}#{id}")
     end
+
+    # AdminSet cannot be deleted if default set or non-empty
+    def disable_delete?
+      AdminSet.default_set?(id) || total_items > 0
+    end
+
+    # Message to display if deletion is disabled
+    def disabled_message
+      return I18n.t('sufia.admin.admin_sets.delete.error_default_set') if AdminSet.default_set?(id)
+      return I18n.t('sufia.admin.admin_sets.delete.error_not_empty') if total_items > 0
+    end
   end
 end

--- a/app/views/sufia/admin/admin_sets/show.html.erb
+++ b/app/views/sufia/admin/admin_sets/show.html.erb
@@ -11,8 +11,16 @@
           <%= link_to sufia.edit_admin_admin_set_path(@presenter), class: 'btn btn-primary' do %>
             <span class="fa fa-edit"></span> <%= t(:'helpers.action.edit') %>
           <% end %>
-          <%= link_to sufia.admin_admin_set_path(@presenter), class: 'btn btn-danger', data: { confirm: t('.confirm_delete'), method: :delete } do %>
-            <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+          <% if @presenter.disable_delete? %>
+            <span title="<%= @presenter.disabled_message %>">
+              <%= link_to sufia.admin_admin_set_path(@presenter), class: 'btn btn-danger disabled' do %>
+                <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+              <% end %>
+            </span>
+          <% else %>
+            <%= link_to sufia.admin_admin_set_path(@presenter), class: 'btn btn-danger', data: { confirm: t('.confirm_delete'), method: :delete } do %>
+              <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/config/initializers/monkey_patch_admin_set.rb
+++ b/config/initializers/monkey_patch_admin_set.rb
@@ -1,0 +1,2 @@
+# Override CC's AdminSet to load Sufia's updated AdminSetBehavior
+AdminSet.include(Sufia::AdminSetBehavior)

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -321,6 +321,8 @@ en:
         new:
           header:         "Create New Administrative Set"
         delete:
+          error_default_set: "Administrative set cannot be deleted as it is the default set"
+          error_not_empty:   "Administrative set cannot be deleted as it is not empty"
           notification:   "Administrative set successfully deleted"
         form:
           tabs:

--- a/spec/actors/sufia/default_admin_set_actor_spec.rb
+++ b/spec/actors/sufia/default_admin_set_actor_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Sufia::DefaultAdminSetActor do
 
     context "when admin_set_id is blank" do
       let(:attributes) { { admin_set_id: '' } }
-      let(:default_id) { described_class::DEFAULT_ID }
+      let(:default_id) { AdminSet::DEFAULT_ID }
 
       it "creates the default AdminSet with a PermissionTemplate and calls the next actor with the default admin set id" do
         expect(next_actor).to receive(:create).with(admin_set_id: default_id).and_return(true)

--- a/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
@@ -124,12 +124,14 @@ describe Sufia::Admin::AdminSetsController do
 
     describe "#destroy" do
       let(:admin_set) { create(:admin_set, edit_users: [user]) }
+
       context "with empty admin set" do
         it "deletes the admin set" do
           delete :destroy, params: { id: admin_set }
           expect(response).to have_http_status(:found)
           expect(response).to redirect_to(Sufia::Engine.routes.url_helpers.admin_admin_sets_path)
           expect(flash[:notice]).to eq "Administrative set successfully deleted"
+          expect(AdminSet.exists?(admin_set.id)).to be false
         end
       end
       context "with a non-empty admin set" do
@@ -138,12 +140,24 @@ describe Sufia::Admin::AdminSetsController do
           admin_set.members << work
           admin_set.reload
         end
-        it "detaches the works and deletes the admin set" do
+        it "doesn't delete the admin set (or work)" do
           delete :destroy, params: { id: admin_set }
           expect(response).to have_http_status(:found)
-          expect(response).to redirect_to(Sufia::Engine.routes.url_helpers.admin_admin_sets_path)
-          expect(flash[:notice]).to eq "Administrative set successfully deleted"
+          expect(response).to redirect_to(Sufia::Engine.routes.url_helpers.admin_admin_set_path(admin_set))
+          expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is not empty"
+          expect(AdminSet.exists?(admin_set.id)).to be true
           expect(GenericWork.exists?(work.id)).to be true
+        end
+      end
+
+      context "with the default admin set" do
+        let(:admin_set) { create(:admin_set, edit_users: [user], id: AdminSet::DEFAULT_ID) }
+        it "doesn't delete the admin set" do
+          delete :destroy, params: { id: admin_set }
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(Sufia::Engine.routes.url_helpers.admin_admin_set_path(admin_set))
+          expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is the default set"
+          expect(AdminSet.exists?(admin_set.id)).to be true
         end
       end
     end

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe AdminSet, type: :model do
+  let(:gf1) { create(:generic_work, user: user) }
+  let(:gf2) { create(:generic_work, user: user) }
+
+  let(:user) { create(:user) }
+
+  before do
+    subject.title = ['Some title']
+  end
+
+  describe "#default_set?" do
+    context "with default AdminSet ID" do
+      it "returns true" do
+        expect(AdminSet.default_set?(described_class::DEFAULT_ID)).to be true
+      end
+    end
+
+    context "with a non-default  ID" do
+      it "returns false" do
+        expect(AdminSet.default_set?('different-id')).to be false
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "with member works" do
+      before do
+        subject.members = [gf1, gf2]
+        subject.save!
+        subject.destroy
+      end
+
+      it "does not delete adminset or member works" do
+        expect(subject.errors.full_messages).to eq ["Administrative set cannot be deleted as it is not empty"]
+        expect(AdminSet.exists?(subject.id)).to be true
+        expect(GenericWork.exists?(gf1.id)).to be true
+        expect(GenericWork.exists?(gf2.id)).to be true
+      end
+    end
+
+    context "with no member works" do
+      before do
+        subject.members = []
+        subject.save!
+        subject.destroy
+      end
+
+      it "deletes the adminset" do
+        expect(AdminSet.exists?(subject.id)).to be false
+      end
+    end
+
+    context "is default adminset" do
+      before do
+        subject.members = []
+        subject.id = described_class::DEFAULT_ID
+        subject.save!
+        subject.destroy
+      end
+
+      it "does not delete the adminset" do
+        expect(subject.errors.full_messages).to eq ["Administrative set cannot be deleted as it is the default set"]
+        expect(AdminSet.exists?(described_class::DEFAULT_ID)).to be true
+      end
+    end
+  end
+end

--- a/spec/presenters/sufia/admin_set_presenter_spec.rb
+++ b/spec/presenters/sufia/admin_set_presenter_spec.rb
@@ -7,22 +7,51 @@ describe Sufia::AdminSetPresenter do
           description: ['An example admin set.'],
           title: ['Example Admin Set Title'])
   end
-  let(:work) { build(:work, title: ['Example Work Title'], admin_set_id: '123') }
+  let(:work) { build(:work, title: ['Example Work Title']) }
   let(:solr_document) { SolrDocument.new(admin_set.to_solr) }
   let(:ability) { double }
   let(:presenter) { described_class.new(solr_document, ability) }
 
   describe "total_items" do
     subject { presenter.total_items }
+
     context "empty admin set" do
       it { is_expected.to eq 0 }
     end
+
     context "admin set with work" do
       before do
+        admin_set.members = [work]
         admin_set.save!
-        work.save!
       end
       it { is_expected.to eq 1 }
+    end
+  end
+
+  describe "disable_delete?" do
+    subject { presenter.disable_delete? }
+
+    context "empty admin set" do
+      before do
+        admin_set.members = []
+        admin_set.save!
+      end
+      it { is_expected.to be false }
+    end
+
+    context "non-empty admin set" do
+      before do
+        admin_set.members = [work]
+        admin_set.save!
+      end
+      it { is_expected.to be true }
+    end
+
+    context "default admin set" do
+      let(:admin_set) do
+        build(:admin_set, id: AdminSet::DEFAULT_ID)
+      end
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/views/sufia/admin/admin_sets/show.html.erb_spec.rb
+++ b/spec/views/sufia/admin/admin_sets/show.html.erb_spec.rb
@@ -1,0 +1,59 @@
+describe "sufia/admin/admin_sets/show.html.erb", type: :view do
+  let(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+  let(:ability) { double }
+  let(:presenter) { Sufia::AdminSetPresenter.new(solr_document, ability) }
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:blacklight_configuration_context) do
+    Blacklight::Configuration::Context.new(controller)
+  end
+  before do
+    allow(view).to receive(:blacklight_config).and_return(blacklight_config)
+    allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+
+    # Stub route because view specs don't handle engine routes
+    allow(view).to receive(:edit_admin_admin_set_path).and_return("/admin/admin_sets/123/edit")
+    allow(view).to receive(:admin_admin_set_path).and_return("/admin/admin_sets/123")
+
+    stub_template '_collection_description.html.erb' => ''
+    stub_template '_show_descriptions.erb' => ''
+    stub_template '_sort_and_per_page.html.erb' => 'sort and per page'
+    stub_template '_document_list.html.erb' => 'document list'
+    stub_template '_paginate.html.erb' => 'paginate'
+
+    assign(:presenter, presenter)
+  end
+
+  context "with non-empty admin set" do
+    let(:admin_set) { build(:admin_set, id: '123') }
+    let(:work) { build(:work, title: ['Example Work Title']) }
+    before do
+      admin_set.members = [work]
+      admin_set.save!
+      render
+    end
+    it "displays a disabled delete button" do
+      expect(rendered).to have_selector(:css, "a.btn-danger.disabled")
+    end
+  end
+
+  context "with empty admin set" do
+    let(:admin_set) { build(:admin_set, id: '345') }
+    before do
+      render
+    end
+    it "displays an enabled delete button" do
+      expect(rendered).to have_selector(:css, "a.btn-danger")
+      expect(rendered).not_to have_selector(:css, "a.btn-danger.disabled")
+    end
+  end
+
+  context "with default admin set" do
+    let(:admin_set) { build(:admin_set, id: AdminSet::DEFAULT_ID) }
+    before do
+      render
+    end
+    it "displays a disabled delete button" do
+      expect(rendered).to have_selector(:css, "a.btn-danger.disabled")
+    end
+  end
+end

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hydra-head', '>= 10.4.0'
   spec.add_dependency 'hydra-batch-edit', '~> 2.0'
   spec.add_dependency 'browse-everything', '>= 0.10.3'
-  spec.add_dependency 'blacklight', '~> 6.6'
+  # Workaround for https://github.com/projecthydra-labs/hyrax/issues/546
+  spec.add_dependency 'blacklight', '~> 6.6', '< 6.8.0'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
   spec.add_dependency 'tinymce-rails-imageupload', '~> 4.0.16.beta'


### PR DESCRIPTION
Fixes #3128 ; refs projecthydra-labs/hyrax#217 and projecthydra-labs/hyrax#363

This is a backport of projecthydra-labs/hyrax#363 to Sufia. It updates Admin Set deletion logic to only allow deletion if an Admin Set has no member Works and is not the Default Admin Set.

@projecthydra/sufia-code-reviewers