### PR TITLE
Removing an exclusion for a non-existent file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,6 @@ Metrics/LineLength:
 Metrics/AbcSize:
   Max: 30
   Exclude:
-    - 'app/controllers/concerns/sufia/admin/depositor_stats.rb'
     - 'app/controllers/concerns/sufia/my_controller_behavior.rb'
     - 'app/services/sufia/user_stat_importer.rb'
     - 'lib/sufia/arkivo/metadata_munger.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,8 +22,6 @@ Metrics/ModuleLength:
 
 Metrics/MethodLength:
   Exclude:
-    - 'lib/generators/sufia/templates/migrations/create_local_authorities.rb'
-    - 'app/helpers/sufia/citations_behaviors/formatters/endnote_formatter.rb'
     - 'app/models/concerns/sufia/solr_document/export.rb'
     - 'app/controllers/concerns/sufia/my_controller_behavior.rb'
     - 'lib/generators/sufia/install_generator.rb'
@@ -42,11 +40,6 @@ Rails/Output:
   Exclude:
     - 'lib/generators/**/*'
 
-Rails/HasAndBelongsToMany:
-  Exclude:
-    - 'app/models/domain_term.rb'
-    - 'app/models/local_authority.rb'
-
 RSpec/NamedSubject:
   Enabled: false
 
@@ -54,7 +47,6 @@ RSpec/ExampleLength:
   Max: 7
   Exclude:
     - 'spec/controllers/api/items_controller_spec.rb'
-    - 'spec/controllers/authorities_controller_spec.rb'
     - 'spec/controllers/collections_controller_spec.rb'
     - 'spec/controllers/curation_concerns/file_sets_controller_spec.rb'
     - 'spec/controllers/my/highlights_controller_spec.rb'


### PR DESCRIPTION
Using the following script, found several files that were not
referenced.

```ruby
require 'psych'
['.rubocop.yml', '.rubocop_todo.yml'].each do |filename|
yaml = Psych.load_file(filename)

def read(node)
  if node.is_a?(Hash)
    node.each_pair do |key, value|
      read(value)
    end
  elsif node.is_a?(Array)
    node.each do |value|
      read(value)
    end
  elsif node.is_a?(String)
    return unless node =~ /.rb\Z/
    return if node =~ /\*/
    return if File.exist?(node)
    puts node
  end
end
read(yaml)
```

@projecthydra/sufia-code-reviewers
