### PR TITLE
Avoid JS error when there are no admin sets on the page.

### DIFF
--- a/app/assets/javascripts/sufia/editor.es6
+++ b/app/assets/javascripts/sufia/editor.es6
@@ -16,16 +16,14 @@ export default class {
 
   // Display the sharing tab if they select an admin set that permits sharing
   sharingTab() {
-    if(this.adminSetWidget) {
-      console.log("admin set selected")
+    if(this.adminSetWidget && !this.adminSetWidget.isEmpty()) {
       this.adminSetWidget.on('change', (data) => this.sharingTabVisiblity(data))
-      this.sharingTabVisiblity(this.adminSetWidget.data())
+      this.sharingTabVisiblity(this.adminSetWidget.isSharing())
     }
   }
 
-  sharingTabVisiblity(data) {
-      console.log("Data " + data["sharing"])
-      if (data["sharing"])
+  sharingTabVisiblity(visible) {
+      if (visible)
          this.sharingTabElement.removeClass('hidden')
       else
          this.sharingTabElement.addClass('hidden')

--- a/app/assets/javascripts/sufia/editor/admin_set_widget.es6
+++ b/app/assets/javascripts/sufia/editor/admin_set_widget.es6
@@ -13,16 +13,27 @@ export default class {
         return this.element.find(":selected").data()
     }
 
+    isEmpty() {
+        return this.element.children().length === 0
+    }
+
+    /**
+     * returns undefined or true
+     */
+    isSharing() {
+        return this.data()["sharing"]
+    }
+
     on(eventName, handler) {
         switch (eventName) {
             case "change":
-                return this.changeHandlers.push(handler);
+                return this.changeHandlers.push(handler)
         }
     }
 
     change(data) {
         for (let fn of this.changeHandlers) {
-          setTimeout(function() { fn(data) }, 0);
+          setTimeout(function() { fn(data) }, 0)
         }
     }
 }

--- a/app/assets/javascripts/sufia/save_work/visibility_component.es6
+++ b/app/assets/javascripts/sufia/save_work/visibility_component.es6
@@ -43,6 +43,10 @@ export default class VisibilityComponent {
   limitByAdminSet() {
     if(this.adminSetWidget) {
       this.adminSetWidget.on('change', (data) => this.restrictToVisibility(data))
+      if (this.adminSetWidget.isEmpty()) {
+          console.error("No data was passed from the admin set. Perhaps there are no selectable options?")
+          return
+      }
       this.restrictToVisibility(this.adminSetWidget.data())
     }
   }


### PR DESCRIPTION
Prevents a null pointer error. Fixes #3153 