### PR TITLE
Pass selected workflow from AS controller to ASCreateService

### DIFF
--- a/app/controllers/sufia/admin/admin_sets_controller.rb
+++ b/app/controllers/sufia/admin/admin_sets_controller.rb
@@ -95,7 +95,7 @@ module Sufia
       end
 
       def create_admin_set
-        AdminSetCreateService.new(@admin_set, current_user).create
+        AdminSetCreateService.new(@admin_set, current_user, params[:admin_set][:workflow_name]).create
       end
 
       def setup_form

--- a/app/services/sufia/admin_set_create_service.rb
+++ b/app/services/sufia/admin_set_create_service.rb
@@ -19,7 +19,7 @@ module Sufia
     def initialize(admin_set, creating_user, workflow_name)
       @admin_set = admin_set
       @creating_user = creating_user
-      @workflow_name = workflow_name
+      @workflow_name = workflow_name || AdminSet::DEFAULT_WORKFLOW_NAME
     end
 
     attr_reader :creating_user, :admin_set, :workflow_name

--- a/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/sufia/admin/admin_sets_controller_spec.rb
@@ -58,7 +58,7 @@ describe Sufia::Admin::AdminSetsController do
       let(:service) { instance_double(Sufia::AdminSetCreateService) }
       before do
         allow(Sufia::AdminSetCreateService).to receive(:new)
-          .with(AdminSet, user)
+          .with(an_instance_of(AdminSet), user, anything)
           .and_return(service)
       end
 

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -6,7 +6,10 @@ describe "Rake tasks" do
     let!(:user2) { FactoryGirl.create(:user) }
 
     before do
-      load_rake_environment [File.expand_path("../../../tasks/sufia_user.rake", __FILE__)]
+      load_rake_environment [
+        File.expand_path("../../../tasks/sufia_user.rake", __FILE__),
+        File.expand_path("../../../lib/tasks/default_admin_set.rake", __FILE__)
+      ]
     end
 
     it "creates a file" do
@@ -22,6 +25,16 @@ describe "Rake tasks" do
       expect(File.exist?("abc123.txt")).to be_truthy
       expect(IO.read("abc123.txt")).to include(user1.email, user2.email)
       File.delete("abc123.txt")
+    end
+
+    describe 'sufia:default_admin_set:create' do
+      before do
+        AdminSet.find(AdminSet::DEFAULT_ID).eradicate if AdminSet.exists?(AdminSet::DEFAULT_ID)
+      end
+
+      it 'creates the default AdminSet' do
+        expect { run_task 'sufia:default_admin_set:create' }.to change { AdminSet.count }.by(1)
+      end
     end
   end
 end


### PR DESCRIPTION
 * Allow AS controller to pass workflow_name param to service (thanks, @hortongn!)
 * Default ASCreateService to the default workflow if `nil` is passed
 * Add a test for the rake task

Fixes #3161