### PR TITLE
Fix visibility form collapse/expand for batches

### DIFF
--- a/app/views/sufia/batch_uploads/_form.html.erb
+++ b/app/views/sufia/batch_uploads/_form.html.erb
@@ -1,4 +1,8 @@
-<%= simple_form_for [sufia, @form], html: { multipart: true } do |f| %>
+<%= simple_form_for [sufia, @form],
+                    html: {
+                      data: { behavior: 'work-form' },
+                      multipart: true
+                    } do |f| %>
   <% content_for :files_tab do %>
     <p class="switch-upload-type">To create a single work for all the files, go to <%= link_to "New Work", [:new, Sufia.primary_work_type.model_name.singular_route_key] %></p>
     <p class="instructions"><%= t("sufia.batch_uploads.files.instructions") %></p>

--- a/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
@@ -18,6 +18,7 @@ describe 'sufia/batch_uploads/_form.html.erb', type: :view do
 
   it "draws the page" do
     expect(page).to have_selector("form[action='/batch_uploads']")
+    expect(page).to have_selector("form[action='/batch_uploads'][data-behavior='work-form']")
     # No title, because it's captured per file (e.g. Display label)
     expect(page).not_to have_selector("input#generic_work_title")
     expect(view.content_for(:files_tab)).to have_link("New Work", href: "/concern/generic_works/new")


### PR DESCRIPTION
Fixes #3166 

This fixes a bug in the visibility pane on the new batch form. Clicking on the Embargo radio button will now expand and reveal the "Restricted to..." or "then open it up to.." options like it does on the single work form.

@projecthydra/sufia-code-reviewers
