### PR TITLE
Adding end of life notice for Sufia

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Docs: [![Documentation Status](https://inch-ci.org/github/samvera/sufia.svg?bran
 Jump in: [![Slack Status](http://slack.samvera.org/badge.svg)](http://slack.samvera.org/)
 [![Ready Tickets](https://badge.waffle.io/samvera/sufia.png?label=ready&title=Ready)](https://waffle.io/samvera/sufia)
 
+# End of Life Notice
+
+We envision the 7.x releases as the end-of-life for Sufia. During 2017, the [Samvera community](http://samvera.org/) consolidated Sufia and [CurationConcerns](https://github.com/samvera/curation_concerns) into [Hyrax](https://github.com/samvera/hyrax):
+
+* [planning notes on consolidation](https://wiki.duraspace.org/pages/viewpage.action?pageId=78161232))
+* [release notes on the bridge of Sufia to Hyrax](https://github.com/samvera/hyrax/releases/tag/v1.0.0.rc2)
+* [Samvera documentation for developers and managers](https://samvera.github.io)
+
+
+
 # Table of Contents
 
   * [What is Sufia?](#what-is-sufia)

--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ Jump in: [![Slack Status](http://slack.samvera.org/badge.svg)](http://slack.samv
 [![Ready Tickets](https://badge.waffle.io/samvera/sufia.png?label=ready&title=Ready)](https://waffle.io/samvera/sufia)
 
 
-# End of Life Notice
+# Shift in Community Focus
 
-We envision the 7.x releases as the end-of-life for Sufia. During 2017, the [Samvera community](http://samvera.org/) consolidated Sufia and [CurationConcerns](https://github.com/samvera/curation_concerns) into [Hyrax](https://github.com/samvera/hyrax):
+During 2017, the [Samvera community](http://samvera.org/) consolidated Sufia and [CurationConcerns](https://github.com/samvera/curation_concerns) into [Hyrax](https://github.com/samvera/hyrax):
 
 * [planning notes on consolidation](https://wiki.duraspace.org/pages/viewpage.action?pageId=78161232))
 * [release notes on the bridge of Sufia to Hyrax](https://github.com/samvera/hyrax/releases/tag/v1.0.0)
 * [release notes on the bridge of CurationConcerns to Hyrax](https://github.com/samvera/hyrax/releases/tag/v2.0.0)
 * [Samvera documentation for developers and managers](https://samvera.github.io)
+
+The Samvera Community effort has shifted its attention to developing out Hyrax.
 
 <hr>
 <br>

--- a/README.md
+++ b/README.md
@@ -15,15 +15,26 @@ Docs: [![Documentation Status](https://inch-ci.org/github/samvera/sufia.svg?bran
 Jump in: [![Slack Status](http://slack.samvera.org/badge.svg)](http://slack.samvera.org/)
 [![Ready Tickets](https://badge.waffle.io/samvera/sufia.png?label=ready&title=Ready)](https://waffle.io/samvera/sufia)
 
+
 # End of Life Notice
 
 We envision the 7.x releases as the end-of-life for Sufia. During 2017, the [Samvera community](http://samvera.org/) consolidated Sufia and [CurationConcerns](https://github.com/samvera/curation_concerns) into [Hyrax](https://github.com/samvera/hyrax):
 
 * [planning notes on consolidation](https://wiki.duraspace.org/pages/viewpage.action?pageId=78161232))
-* [release notes on the bridge of Sufia to Hyrax](https://github.com/samvera/hyrax/releases/tag/v1.0.0.rc2)
+* [release notes on the bridge of Sufia to Hyrax](https://github.com/samvera/hyrax/releases/tag/v1.0.0)
+* [release notes on the bridge of CurationConcerns to Hyrax](https://github.com/samvera/hyrax/releases/tag/v2.0.0)
 * [Samvera documentation for developers and managers](https://samvera.github.io)
 
-
+<hr>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
 
 # Table of Contents
 


### PR DESCRIPTION
Based on conversations on Slack and through email, the community has
agreed that Sufia is end-of-life, but that decision may not be as
obvious to those outside the community's communication channels.